### PR TITLE
[Hotfix] Destroy HIP streams after creation in Thresholding/CvtColor/BilateralFilter/Histogram tests

### DIFF
--- a/tests/roccv/cpp/test_op_bilateral_filter.cpp
+++ b/tests/roccv/cpp/test_op_bilateral_filter.cpp
@@ -56,6 +56,8 @@ eTestStatusType testCorrectness(const std::string &inputFile, uint8_t *expectedD
                                               stream));
 
         HIP_VALIDATE_NO_ERRORS(hipStreamSynchronize(stream));
+        HIP_VALIDATE_NO_ERRORS(hipStreamDestroy(stream));
+
         for (int i = 0; i < output.shape().size(); i++) {
             float err = std::abs(resultData[i] - expectedData[i]);
 

--- a/tests/roccv/cpp/test_op_cvt_color.cpp
+++ b/tests/roccv/cpp/test_op_cvt_color.cpp
@@ -66,6 +66,7 @@ eTestStatusType testCorrectness(const std::string &inputFile, uint8_t *expectedD
             std::vector<uint8_t> resultData(output_image_size);
             HIP_VALIDATE_NO_ERRORS(hipMemcpyAsync(resultData.data(), outputTensorData.basePtr(), output_image_size,
                                                   hipMemcpyDeviceToHost, stream));
+            HIP_VALIDATE_NO_ERRORS(hipStreamSynchronize(stream));
             for (int i = 0; i < output_image_size; i++) {
                 float err = std::abs(resultData[i] - expectedData[i]);
                 if (err > 1) {
@@ -81,6 +82,7 @@ eTestStatusType testCorrectness(const std::string &inputFile, uint8_t *expectedD
             std::vector<uint8_t> resultData(output_image_size);
             HIP_VALIDATE_NO_ERRORS(hipMemcpyAsync(resultData.data(), outputTensorData.basePtr(), output_image_size,
                                                   hipMemcpyDeviceToHost, stream));
+            HIP_VALIDATE_NO_ERRORS(hipStreamSynchronize(stream));
             for (int i = 0; i < output_image_size; i++) {
                 float err = std::abs(resultData[i] - expectedData[i]);
                 if (err > 1) {
@@ -90,7 +92,7 @@ eTestStatusType testCorrectness(const std::string &inputFile, uint8_t *expectedD
                 }
             }
         }
-        HIP_VALIDATE_NO_ERRORS(hipStreamSynchronize(stream));
+        HIP_VALIDATE_NO_ERRORS(hipStreamDestroy(stream));
     } else if (device == eDeviceType::CPU) {
         size_t image_size = input.shape().size() * input.dtype().size();
         auto inputData = input.exportData<TensorDataStrided>();

--- a/tests/roccv/cpp/test_op_histogram.cpp
+++ b/tests/roccv/cpp/test_op_histogram.cpp
@@ -69,6 +69,7 @@ eTestStatusType testCorrectness(const std::string &inputFile, int32_t *expectedD
                                          output.shape().size() * output.dtype().size(), hipMemcpyDeviceToHost));
 
         HIP_VALIDATE_NO_ERRORS(hipStreamSynchronize(stream));
+        HIP_VALIDATE_NO_ERRORS(hipStreamDestroy(stream));
 
         for (int i = 0; i < output.shape().size(); i++) {
             float err = std::abs(static_cast<int32_t>(resultData[i] - expectedData[i]));

--- a/tests/roccv/cpp/test_op_thresholding.cpp
+++ b/tests/roccv/cpp/test_op_thresholding.cpp
@@ -76,6 +76,7 @@ eTestStatusType testCorrectness(const std::string &inputFile, uint8_t *expectedD
             hipMemcpyAsync(d_output.data(), outputTensorData.basePtr(), image_size, hipMemcpyDeviceToHost, stream));
 
         HIP_VALIDATE_NO_ERRORS(hipStreamSynchronize(stream));
+        HIP_VALIDATE_NO_ERRORS(hipStreamDestroy(stream));
 
         for (int i = 0; i < output.shape().size(); i++) {
             float err = std::abs(d_output.data()[i] - expectedData[i]);


### PR DESCRIPTION
## Changes Made
* HIP streams are now destroyed after synchronization in the tests listed above.
* In CvtColor, synchronized with the stream before host-side data was being compared. This is another issue that wasn't caught.