### PR TITLE
[Hotfix] Use nullopt for mask in histogram benchmark

### DIFF
--- a/benchmarks/src/bench_histogram.cpp
+++ b/benchmarks/src/bench_histogram.cpp
@@ -24,6 +24,7 @@
 #include <core/image_format.hpp>
 #include <core/tensor.hpp>
 #include <op_histogram.hpp>
+#include <optional>
 #include <roccvbench/registry.hpp>
 #include <roccvbench/utils.hpp>
 


### PR DESCRIPTION
## Motivation

Changes to roccv::Histogram parameters caused compilation issues on the benchmark suite.

## Technical Details

* `nullptr` replaced with `nullopt` for the mask argument of the Histogram op call.

## Test Plan

Check if it compiles successfully with `-DBENCHMARKS=1`.

## Test Result

After changes, everything is compiling successfully.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
