### PR TITLE
Fixed build errors with swizzling test on ROCm 7.0 and below.

### DIFF
--- a/include/core/detail/swizzling.hpp
+++ b/include/core/detail/swizzling.hpp
@@ -47,7 +47,7 @@ template <> struct SwizzleIndexMap<eSwizzle::ZYXW, 4> { using Seq = std::integer
 
 template <typename T, size_t... Indices>
 __host__ __device__ constexpr T SwizzleIndicesImpl(const T &v) {
-    return T{v.data[Indices]...};
+    return T{v[Indices]...};
 }
 
 template <typename T, size_t... I>

--- a/tests/roccv/cpp/test_swizzling.cpp
+++ b/tests/roccv/cpp/test_swizzling.cpp
@@ -41,7 +41,7 @@ template <typename T, eSwizzle SwizzlePattern>
 void TestCorrectness(T input, T expected) {
     T output = detail::Swizzle<SwizzlePattern>(input);
     for (int i = 0; i < detail::NumElements<T>; i++) {
-        EXPECT_EQ(output.data[i], expected.data[i]);
+        EXPECT_EQ(output[i], expected[i]);
     }
 }
 }  // namespace


### PR DESCRIPTION
## Motivation

This PR fixes the build errors due to ROCm 7.1 changes in amd_hip_vector_types.h.
- Note with this PR, rocCV build will fail on ROCm 7.0 and below.
- Authors: Zach, Pavel, Essam and Jeff.

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
