### PR TITLE
[Refactor] BndBox refactor

### DIFF
--- a/include/kernels/device/bnd_box_device.hpp
+++ b/include/kernels/device/bnd_box_device.hpp
@@ -23,7 +23,9 @@ THE SOFTWARE.
 #pragma once
 
 #include <hip/hip_runtime.h>
+
 #include <core/detail/type_traits.hpp>
+
 #include "kernels/kernel_helpers.hpp"
 #include "operator_types.h"
 
@@ -32,9 +34,8 @@ using namespace roccv;
 namespace Kernels {
 namespace Device {
 template <bool has_alpha, typename T, typename SrcWrapper, typename DstWrapper, typename BT = detail::BaseType<T>>
-__global__ void bndbox_kernel(SrcWrapper input, DstWrapper output, Rect_t *rects,
-                              size_t n_rects, int64_t batch, int64_t height,
-                              int64_t width) {
+__global__ void bndbox_kernel(SrcWrapper input, DstWrapper output, const Rect_t *rects, size_t n_rects, int64_t batch,
+                              int64_t height, int64_t width) {
     // Working type for internal pixel format, which has 4 channels.
     using WorkType = detail::MakeType<BT, 4>;
 
@@ -50,18 +51,15 @@ __global__ void bndbox_kernel(SrcWrapper input, DstWrapper output, Rect_t *rects
 
     for (size_t i = 0; i < n_rects; i++) {
         Rect_t curr_rect = rects[i];
-        if (curr_rect.batch <= b_idx)
-            shade_rectangle<WorkType>(curr_rect, x_idx, y_idx, &shaded_pixel);
+        if (curr_rect.batch <= b_idx) shade_rectangle<WorkType>(curr_rect, x_idx, y_idx, &shaded_pixel);
     }
 
-    WorkType out_color =
-        MathVector::fill(input.at(b_idx, y_idx, x_idx, 0));
+    WorkType out_color = MathVector::fill(input.at(b_idx, y_idx, x_idx, 0));
     out_color.w = has_alpha ? out_color.w : (std::numeric_limits<BT>::max());
 
     if (shaded_pixel.w != 0) blend_single_color<WorkType>(out_color, shaded_pixel);
 
-    MathVector::trunc(out_color,
-                      &output.at(b_idx, y_idx, x_idx, 0));
+    MathVector::trunc(out_color, &output.at(b_idx, y_idx, x_idx, 0));
 }
 };  // namespace Device
 };  // namespace Kernels

--- a/include/kernels/device/custom_crop_device.hpp
+++ b/include/kernels/device/custom_crop_device.hpp
@@ -29,7 +29,7 @@ THE SOFTWARE.
 namespace Kernels {
 namespace Device {
 template <typename SrcWrapper, typename DstWrapper>
-__global__ void custom_crop(SrcWrapper input, DstWrapper output, Box_t cropRect) {
+__global__ void custom_crop(SrcWrapper input, DstWrapper output, roccv::Box_t cropRect) {
     const int x = blockIdx.x * blockDim.x + threadIdx.x;
     const int y = blockIdx.y * blockDim.y + threadIdx.y;
     const int b = blockIdx.z;

--- a/include/kernels/host/bnd_box_host.hpp
+++ b/include/kernels/host/bnd_box_host.hpp
@@ -23,7 +23,9 @@ THE SOFTWARE.
 #pragma once
 
 #include <hip/hip_runtime.h>
+
 #include <core/detail/type_traits.hpp>
+
 #include "kernels/kernel_helpers.hpp"
 #include "operator_types.h"
 
@@ -32,9 +34,8 @@ using namespace roccv;
 namespace Kernels {
 namespace Host {
 template <bool has_alpha, typename T, typename SrcWrapper, typename DstWrapper, typename BT = detail::BaseType<T>>
-void bndbox_kernel(SrcWrapper input, DstWrapper output, Rect_t *rects,
-                   size_t n_rects, int64_t batch, int64_t height,
-                   int64_t width) {
+void bndbox_kernel(SrcWrapper input, DstWrapper output, const Rect_t *rects, size_t n_rects, int64_t batch,
+                   int64_t height, int64_t width) {
     // Working type for internal pixel format, which has 4 channels.
     using WorkType = detail::MakeType<BT, 4>;
 
@@ -45,15 +46,13 @@ void bndbox_kernel(SrcWrapper input, DstWrapper output, Rect_t *rects,
 
                 for (size_t i = 0; i < n_rects; i++) {
                     Rect_t curr_rect = rects[i];
-                    if (curr_rect.batch <= b_idx)
-                        shade_rectangle<WorkType>(curr_rect, x_idx, y_idx, &shaded_pixel);
+                    if (curr_rect.batch <= b_idx) shade_rectangle<WorkType>(curr_rect, x_idx, y_idx, &shaded_pixel);
                 }
 
                 WorkType out_color = MathVector::fill(input.at(b_idx, y_idx, x_idx, 0));
                 out_color.w = has_alpha ? out_color.w : (std::numeric_limits<BT>::max());
 
-                if (shaded_pixel.w != 0)
-                    blend_single_color<WorkType>(out_color, shaded_pixel);
+                if (shaded_pixel.w != 0) blend_single_color<WorkType>(out_color, shaded_pixel);
 
                 MathVector::trunc(out_color, &output.at(b_idx, y_idx, x_idx, 0));
             }

--- a/include/kernels/host/custom_crop_host.hpp
+++ b/include/kernels/host/custom_crop_host.hpp
@@ -29,13 +29,13 @@ THE SOFTWARE.
 namespace Kernels {
 namespace Host {
 template <typename SrcWrapper, typename DstWrapper>
-void custom_crop(SrcWrapper input, DstWrapper output, Box_t cropRect) {
+void custom_crop(SrcWrapper input, DstWrapper output, roccv::Box_t cropRect) {
     for (int b = 0; b < output.batches(); b++) {
         for (int i = 0; i < cropRect.width; i++) {
             for (int j = 0; j < cropRect.height; j++) {
-                    int sourceX = i + cropRect.x;
-                    int sourceY = j + cropRect.y;
-                    output.at(b, j, i, 0) = input.at(b, sourceY, sourceX, 0);
+                int sourceX = i + cropRect.x;
+                int sourceY = j + cropRect.y;
+                output.at(b, j, i, 0) = input.at(b, sourceY, sourceX, 0);
             }
         }
     }

--- a/include/op_bnd_box.hpp
+++ b/include/op_bnd_box.hpp
@@ -85,8 +85,8 @@ class BndBox final : public IOperator {
      *
      */
     void operator()(hipStream_t stream, const roccv::Tensor& input, const roccv::Tensor& output,
-                    const BndBoxes_t bnd_boxes, eDeviceType device = eDeviceType::GPU);
+                    const BndBoxes& bndboxes, eDeviceType device = eDeviceType::GPU);
 
-    void generateRects(std::vector<Rect_t>& rects, const BndBoxes_t& bnd_boxes, int64_t height, int64_t width);
+    void generateRects(std::vector<Rect_t>& rects, const BndBoxes& bnd_boxes, int64_t height, int64_t width);
 };
 }  // namespace roccv

--- a/include/operator_types.h
+++ b/include/operator_types.h
@@ -41,7 +41,7 @@ typedef enum eBorderType {
 } eBorderType;
 
 typedef enum eRemapType {
-    REMAP_ABSOLUTE = 0,             
+    REMAP_ABSOLUTE = 0,
     REMAP_ABSOLUTE_NORMALIZED = 1,
     REMAP_RELATIVE_NORMALIZED = 2,
 } eRemapType;
@@ -120,7 +120,6 @@ typedef struct {
     bool bordered;
 } Rect_t;
 
-
 namespace roccv {
 
 /**
@@ -130,4 +129,81 @@ namespace roccv {
 struct Size2D {
     int w, h;
 };
+
+/**
+ * @brief Describes an 8-bit RGBA color value.
+ *
+ */
+struct ColorRGBA {
+    uint8_t r;
+    uint8_t g;
+    uint8_t b;
+    uint8_t a;
+};
+
+/**
+ * @brief Describes a single box.
+ *
+ */
+struct BoxT {
+    int32_t x;       // top-left corner x coordinate
+    int32_t y;       // top-left corner y coordinate
+    int32_t width;   // width of the box
+    int32_t height;  // height of the box
+};
+
+/**
+ * @brief Describes a single bounding box with a border thickness, border color, and fill color.
+ *
+ */
+struct BndBoxT {
+    BoxT box;               // bounding box
+    int32_t thickness;      // thickness of the box border
+    ColorRGBA borderColor;  // color of the box border
+    ColorRGBA fillColor;    // fill color of the bounding box
+};
+
+/**
+ * @brief Describes a list of bounding boxes to be used alongside the BndBox operator.
+ *
+ */
+class BndBoxes {
+   public:
+    /**
+     * @brief Construct a new BndBoxes object.
+     *
+     * @param[in] bndboxesVec A list of lists of bounding boxes corresponding to each image in the batch.
+     */
+    BndBoxes(const std::vector<std::vector<BndBoxT>> &bndboxesVec);
+    BndBoxes(const BndBoxes &) = delete;
+    BndBoxes &operator=(const BndBoxes &) = delete;
+
+    /**
+     * @brief Retrieves the batch size of this bounding box definition.
+     *
+     * @return The batch size of this bounding box definition.
+     */
+    int32_t batch() const;
+
+    /**
+     * @brief Returns the number of bounding boxes at a specific batch index.
+     *
+     * @param b
+     * @return int32_t
+     */
+    int32_t numBoxesAt(int32_t b) const;
+
+    /**
+     * @brief Returns the bounding box at the specified batch and bounding box index.
+     *
+     * @param b The batch index.
+     * @param i The index of the box within the specified batch.
+     * @return A bounding box.
+     */
+    BndBoxT boxAt(int32_t b, int32_t i) const;
+
+   private:
+    std::vector<std::vector<BndBoxT>> m_bndboxesVec;
+};
+
 }  // namespace roccv

--- a/include/operator_types.h
+++ b/include/operator_types.h
@@ -80,35 +80,6 @@ typedef enum eThresholdType {
 // Column Major
 typedef float PerspectiveTransform[9];
 
-typedef struct {
-    uint8_t c0;
-    uint8_t c1;
-    uint8_t c2;
-    uint8_t c3;
-} Color4_t;
-
-typedef struct {
-    int64_t x;       ///@brief x coordinate of the top-left corner.
-    int64_t y;       ///@brief y coordinate of the top-left corner.
-    int32_t width;   ///@brief width of the box.
-    int32_t height;  ///@brief height of the box.
-} Box_t;
-
-typedef struct {
-    Box_t box;             ///@brief Bounding box definition.
-    int32_t thickness;     ///@brief Border thickness of bounding box.
-    Color4_t borderColor;  ///@brief Border color of bounding box.
-    Color4_t fillColor;    ///@brief Fill color of bounding box.
-} BndBox_t;
-
-typedef struct {
-    int64_t batch;                  ///@brief Batch size.
-    std::vector<int32_t> numBoxes;  ///@brief Vector of number of boxes in each image, must have
-                                    /// atleast \ref batch elements.
-    std::vector<BndBox_t> boxes;    ///@brief Vector of bounding boxes to draw, must have enough
-                                    /// elements to match \ref numBoxes.
-} BndBoxes_t;
-
 /**
  * The Rect_t struct is used for the bounding box rectangles for the Bounding Box operator
  */
@@ -134,7 +105,7 @@ struct Size2D {
  * @brief Describes an 8-bit RGBA color value.
  *
  */
-struct ColorRGBA {
+struct ColorRGBA_t {
     uint8_t r;
     uint8_t g;
     uint8_t b;
@@ -145,7 +116,7 @@ struct ColorRGBA {
  * @brief Describes a single box.
  *
  */
-struct BoxT {
+struct Box_t {
     int32_t x;       // top-left corner x coordinate
     int32_t y;       // top-left corner y coordinate
     int32_t width;   // width of the box
@@ -156,11 +127,11 @@ struct BoxT {
  * @brief Describes a single bounding box with a border thickness, border color, and fill color.
  *
  */
-struct BndBoxT {
-    BoxT box;               // bounding box
-    int32_t thickness;      // thickness of the box border
-    ColorRGBA borderColor;  // color of the box border
-    ColorRGBA fillColor;    // fill color of the bounding box
+struct BndBox_t {
+    Box_t box;                // bounding box
+    int32_t thickness;        // thickness of the box border
+    ColorRGBA_t borderColor;  // color of the box border
+    ColorRGBA_t fillColor;    // fill color of the bounding box
 };
 
 /**
@@ -174,7 +145,7 @@ class BndBoxes {
      *
      * @param[in] bndboxesVec A list of lists of bounding boxes corresponding to each image in the batch.
      */
-    BndBoxes(const std::vector<std::vector<BndBoxT>> &bndboxesVec);
+    BndBoxes(const std::vector<std::vector<BndBox_t>> &bndboxesVec);
     BndBoxes(const BndBoxes &) = delete;
     BndBoxes &operator=(const BndBoxes &) = delete;
 
@@ -200,10 +171,10 @@ class BndBoxes {
      * @param i The index of the box within the specified batch.
      * @return A bounding box.
      */
-    BndBoxT boxAt(int32_t b, int32_t i) const;
+    BndBox_t boxAt(int32_t b, int32_t i) const;
 
    private:
-    std::vector<std::vector<BndBoxT>> m_bndboxesVec;
+    std::vector<std::vector<BndBox_t>> m_bndboxesVec;
 };
 
 }  // namespace roccv

--- a/python/include/operators/py_op_bnd_box.hpp
+++ b/python/include/operators/py_op_bnd_box.hpp
@@ -26,16 +26,16 @@ THE SOFTWARE.
 #include <pybind11/pybind11.h>
 
 #include "py_stream.hpp"
-#include "py_tensor.hpp"
 #include "py_structs.hpp"
+#include "py_tensor.hpp"
 
 namespace py = pybind11;
 
 class PyOpBndBox {
    public:
     static void Export(py::module& m);
-    static PyTensor Execute(PyTensor& input, BndBoxes_t bnd_boxes,
+    static PyTensor Execute(PyTensor& input, const roccv::BndBoxes& bnd_boxes,
                             std::optional<std::reference_wrapper<PyStream>> stream, eDeviceType device);
-    static void ExecuteInto(PyTensor& output, PyTensor& input, BndBoxes_t bnd_boxes,
+    static void ExecuteInto(PyTensor& output, PyTensor& input, const roccv::BndBoxes& bnd_boxes,
                             std::optional<std::reference_wrapper<PyStream>> stream, eDeviceType device);
 };

--- a/python/include/operators/py_op_custom_crop.hpp
+++ b/python/include/operators/py_op_custom_crop.hpp
@@ -32,9 +32,9 @@ namespace py = pybind11;
 
 class PyOpCustomCrop {
    public:
-    static void ExecuteInto(PyTensor& output, PyTensor& input, Box_t cropRect,
+    static void ExecuteInto(PyTensor& output, PyTensor& input, roccv::Box_t cropRect,
                             std::optional<std::reference_wrapper<PyStream>> stream, eDeviceType device);
-    static PyTensor Execute(PyTensor& input, Box_t cropRect, std::optional<std::reference_wrapper<PyStream>> stream,
-                            eDeviceType device);
+    static PyTensor Execute(PyTensor& input, roccv::Box_t cropRect,
+                            std::optional<std::reference_wrapper<PyStream>> stream, eDeviceType device);
     static void Export(py::module& m);
 };

--- a/python/src/operators/py_op_bnd_box.cpp
+++ b/python/src/operators/py_op_bnd_box.cpp
@@ -24,9 +24,8 @@ THE SOFTWARE.
 
 #include <op_bnd_box.hpp>
 
-PyTensor PyOpBndBox::Execute(PyTensor& input, BndBoxes_t bnd_boxes,
-                            std::optional<std::reference_wrapper<PyStream>> stream, eDeviceType device) {
-    
+PyTensor PyOpBndBox::Execute(PyTensor& input, const roccv::BndBoxes& bnd_boxes,
+                             std::optional<std::reference_wrapper<PyStream>> stream, eDeviceType device) {
     hipStream_t hipStream = stream.has_value() ? stream.value().get().getStream() : nullptr;
 
     auto inputTensor = input.getTensor();
@@ -37,9 +36,8 @@ PyTensor PyOpBndBox::Execute(PyTensor& input, BndBoxes_t bnd_boxes,
     return PyTensor(outputTensor);
 }
 
-void PyOpBndBox::ExecuteInto(PyTensor& output, PyTensor& input, BndBoxes_t bnd_boxes,
-                            std::optional<std::reference_wrapper<PyStream>> stream, eDeviceType device) {
-    
+void PyOpBndBox::ExecuteInto(PyTensor& output, PyTensor& input, const roccv::BndBoxes& bnd_boxes,
+                             std::optional<std::reference_wrapper<PyStream>> stream, eDeviceType device) {
     hipStream_t hipStream = stream.has_value() ? stream.value().get().getStream() : nullptr;
 
     roccv::BndBox op;
@@ -48,8 +46,8 @@ void PyOpBndBox::ExecuteInto(PyTensor& output, PyTensor& input, BndBoxes_t bnd_b
 
 void PyOpBndBox::Export(py::module& m) {
     using namespace py::literals;
-    m.def("bndbox", &PyOpBndBox::Execute, "src"_a, "bnd_boxes"_a, 
-                    "stream"_a = nullptr, "device"_a = eDeviceType::GPU, R"pbdoc(
+    m.def("bndbox", &PyOpBndBox::Execute, "src"_a, "bnd_boxes"_a, "stream"_a = nullptr, "device"_a = eDeviceType::GPU,
+          R"pbdoc(
             
             Executes the BndBox operation on the given HIP stream.
 
@@ -66,8 +64,8 @@ void PyOpBndBox::Export(py::module& m) {
                 rocpycv.Tensor: The output tensor.
 
             )pbdoc");
-    m.def("bndbox_into", &PyOpBndBox::ExecuteInto, "dst"_a, "src"_a, "bnd_boxes"_a, 
-                            "stream"_a = nullptr, "device"_a = eDeviceType::GPU, R"pbdoc(
+    m.def("bndbox_into", &PyOpBndBox::ExecuteInto, "dst"_a, "src"_a, "bnd_boxes"_a, "stream"_a = nullptr,
+          "device"_a = eDeviceType::GPU, R"pbdoc(
 
             Executes the BndBox operation on the given HIP stream.
 

--- a/python/src/operators/py_op_custom_crop.cpp
+++ b/python/src/operators/py_op_custom_crop.cpp
@@ -26,7 +26,7 @@ THE SOFTWARE.
 
 using namespace py::literals;
 
-void PyOpCustomCrop::ExecuteInto(PyTensor& output, PyTensor& input, Box_t cropRect,
+void PyOpCustomCrop::ExecuteInto(PyTensor& output, PyTensor& input, roccv::Box_t cropRect,
                                  std::optional<std::reference_wrapper<PyStream>> stream, eDeviceType device) {
     hipStream_t hipStream = stream.has_value() ? stream.value().get().getStream() : nullptr;
 
@@ -34,7 +34,7 @@ void PyOpCustomCrop::ExecuteInto(PyTensor& output, PyTensor& input, Box_t cropRe
     op(hipStream, *input.getTensor(), *output.getTensor(), cropRect, device);
 }
 
-PyTensor PyOpCustomCrop::Execute(PyTensor& input, Box_t cropRect,
+PyTensor PyOpCustomCrop::Execute(PyTensor& input, roccv::Box_t cropRect,
                                  std::optional<std::reference_wrapper<PyStream>> stream, eDeviceType device) {
     hipStream_t hipStream = stream.has_value() ? stream.value().get().getStream() : nullptr;
 

--- a/python/src/py_structs.cpp
+++ b/python/src/py_structs.cpp
@@ -28,36 +28,33 @@ THE SOFTWARE.
 using namespace py::literals;
 
 void PyStructs::Export(py::module& m) {
-    py::class_<Box_t>(m, "Box")
+    py::class_<roccv::Box_t>(m, "Box")
         .def(py::init<>())
         .def(py::init<int64_t, int64_t, int32_t, int32_t>(), "x"_a, "y"_a, "width"_a, "height"_a)
-        .def_readwrite("x", &Box_t::x)
-        .def_readwrite("y", &Box_t::y)
-        .def_readwrite("width", &Box_t::width)
-        .def_readwrite("height", &Box_t::height);
-    
-    py::class_<Color4_t>(m, "Color4")
-        .def(py::init<>())
-        .def(py::init<uint8_t, uint8_t, uint8_t, uint8_t>(), "c0"_a, "c1"_a, "c2"_a, "c3"_a)
-        .def_readwrite("c0", &Color4_t::c0)
-        .def_readwrite("c1", &Color4_t::c1)
-        .def_readwrite("c2", &Color4_t::c2)
-        .def_readwrite("c3", &Color4_t::c3);
-    
-    py::class_<BndBox_t>(m, "BndBox")
-        .def(py::init<>())
-        .def(py::init<Box_t, int32_t, Color4_t, Color4_t>(), "box"_a, "thickness"_a, "borderColor"_a, "fillColor"_a)
-        .def_readwrite("box", &BndBox_t::box)
-        .def_readwrite("thickness", &BndBox_t::thickness)
-        .def_readwrite("borderColor", &BndBox_t::borderColor)
-        .def_readwrite("fillColor", &BndBox_t::fillColor);
+        .def_readwrite("x", &roccv::Box_t::x)
+        .def_readwrite("y", &roccv::Box_t::y)
+        .def_readwrite("width", &roccv::Box_t::width)
+        .def_readwrite("height", &roccv::Box_t::height);
 
-    py::class_<BndBoxes_t>(m, "BndBoxes")
+    py::class_<roccv::ColorRGBA_t>(m, "ColorRGBA")
         .def(py::init<>())
-        .def(py::init<int64_t, std::vector<int32_t>, std::vector<BndBox_t>>(), "batch"_a, "numBoxes"_a, "boxes"_a)
-        .def_readwrite("batch", &BndBoxes_t::batch)
-        .def_readwrite("numBoxes", &BndBoxes_t::numBoxes)
-        .def_readwrite("boxes", &BndBoxes_t::boxes);
+        .def(py::init<uint8_t, uint8_t, uint8_t, uint8_t>(), "r"_a, "g"_a, "b"_a, "a"_a)
+        .def_readwrite("c0", &roccv::ColorRGBA_t::r)
+        .def_readwrite("c1", &roccv::ColorRGBA_t::g)
+        .def_readwrite("c2", &roccv::ColorRGBA_t::b)
+        .def_readwrite("c3", &roccv::ColorRGBA_t::a);
+
+    py::class_<roccv::BndBox_t>(m, "BndBox")
+        .def(py::init<>())
+        .def(py::init<roccv::Box_t, int32_t, roccv::ColorRGBA_t, roccv::ColorRGBA_t>(), "box"_a, "thickness"_a,
+             "borderColor"_a, "fillColor"_a)
+        .def_readwrite("box", &roccv::BndBox_t::box)
+        .def_readwrite("thickness", &roccv::BndBox_t::thickness)
+        .def_readwrite("borderColor", &roccv::BndBox_t::borderColor)
+        .def_readwrite("fillColor", &roccv::BndBox_t::fillColor);
+
+    py::class_<roccv::BndBoxes>(m, "BndBoxes")
+        .def(py::init<const std::vector<std::vector<roccv::BndBox_t>>&>(), "bndboxes"_a);
 
     py::class_<roccv::Size2D>(m, "Size2D")
         .def(py::init<>())

--- a/python/src/rocpycv/rocpycv.pyi
+++ b/python/src/rocpycv/rocpycv.pyi
@@ -54,9 +54,9 @@ YUV: eChannelType
 YVU: eChannelType
 
 class BndBox:
-    borderColor: Color4
+    borderColor: ColorRGBA
     box: Box
-    fillColor: Color4
+    fillColor: ColorRGBA
     thickness: int
     @overload
     def __init__(self) -> None:
@@ -65,40 +65,21 @@ class BndBox:
 
         1. __init__(self: rocpycv.rocpycv.BndBox) -> None
 
-        2. __init__(self: rocpycv.rocpycv.BndBox, box: rocpycv.rocpycv.Box, thickness: int, borderColor: rocpycv.rocpycv.Color4, fillColor: rocpycv.rocpycv.Color4) -> None
+        2. __init__(self: rocpycv.rocpycv.BndBox, box: rocpycv.rocpycv.Box, thickness: int, borderColor: rocpycv.rocpycv.ColorRGBA, fillColor: rocpycv.rocpycv.ColorRGBA) -> None
         """
     @overload
-    def __init__(self, box: Box, thickness: int, borderColor: Color4, fillColor: Color4) -> None:
+    def __init__(self, box: Box, thickness: int, borderColor: ColorRGBA, fillColor: ColorRGBA) -> None:
         """__init__(*args, **kwargs)
         Overloaded function.
 
         1. __init__(self: rocpycv.rocpycv.BndBox) -> None
 
-        2. __init__(self: rocpycv.rocpycv.BndBox, box: rocpycv.rocpycv.Box, thickness: int, borderColor: rocpycv.rocpycv.Color4, fillColor: rocpycv.rocpycv.Color4) -> None
+        2. __init__(self: rocpycv.rocpycv.BndBox, box: rocpycv.rocpycv.Box, thickness: int, borderColor: rocpycv.rocpycv.ColorRGBA, fillColor: rocpycv.rocpycv.ColorRGBA) -> None
         """
 
 class BndBoxes:
-    batch: int
-    boxes: list[BndBox]
-    numBoxes: list[int]
-    @overload
-    def __init__(self) -> None:
-        """__init__(*args, **kwargs)
-        Overloaded function.
-
-        1. __init__(self: rocpycv.rocpycv.BndBoxes) -> None
-
-        2. __init__(self: rocpycv.rocpycv.BndBoxes, batch: int, numBoxes: list[int], boxes: list[rocpycv.rocpycv.BndBox]) -> None
-        """
-    @overload
-    def __init__(self, batch: int, numBoxes: list[int], boxes: list[BndBox]) -> None:
-        """__init__(*args, **kwargs)
-        Overloaded function.
-
-        1. __init__(self: rocpycv.rocpycv.BndBoxes) -> None
-
-        2. __init__(self: rocpycv.rocpycv.BndBoxes, batch: int, numBoxes: list[int], boxes: list[rocpycv.rocpycv.BndBox]) -> None
-        """
+    def __init__(self, bndboxes: list[list[BndBox]]) -> None:
+        """__init__(self: rocpycv.rocpycv.BndBoxes, bndboxes: list[list[rocpycv.rocpycv.BndBox]]) -> None"""
 
 class Box:
     height: int
@@ -124,7 +105,7 @@ class Box:
         2. __init__(self: rocpycv.rocpycv.Box, x: int, y: int, width: int, height: int) -> None
         """
 
-class Color4:
+class ColorRGBA:
     c0: int
     c1: int
     c2: int
@@ -134,18 +115,18 @@ class Color4:
         """__init__(*args, **kwargs)
         Overloaded function.
 
-        1. __init__(self: rocpycv.rocpycv.Color4) -> None
+        1. __init__(self: rocpycv.rocpycv.ColorRGBA) -> None
 
-        2. __init__(self: rocpycv.rocpycv.Color4, c0: int, c1: int, c2: int, c3: int) -> None
+        2. __init__(self: rocpycv.rocpycv.ColorRGBA, r: int, g: int, b: int, a: int) -> None
         """
     @overload
-    def __init__(self, c0: int, c1: int, c2: int, c3: int) -> None:
+    def __init__(self, r: int, g: int, b: int, a: int) -> None:
         """__init__(*args, **kwargs)
         Overloaded function.
 
-        1. __init__(self: rocpycv.rocpycv.Color4) -> None
+        1. __init__(self: rocpycv.rocpycv.ColorRGBA) -> None
 
-        2. __init__(self: rocpycv.rocpycv.Color4, c0: int, c1: int, c2: int, c3: int) -> None
+        2. __init__(self: rocpycv.rocpycv.ColorRGBA, r: int, g: int, b: int, a: int) -> None
         """
 
 class Exception(Exception): ...
@@ -930,8 +911,8 @@ def gamma_contrast_into(dst: Tensor, src: Tensor, gamma: float, stream: Stream |
                     None
         
     """
-def histogram(src: Tensor, mask: Tensor, stream: Stream | None = ..., device: eDeviceType = ...) -> Tensor:
-    """histogram(src: rocpycv.rocpycv.Tensor, mask: rocpycv.rocpycv.Tensor, stream: Optional[rocpycv.rocpycv.Stream] = None, device: rocpycv.rocpycv.eDeviceType = <eDeviceType.GPU: 0>) -> rocpycv.rocpycv.Tensor
+def histogram(src: Tensor, mask: Tensor | None, stream: Stream | None = ..., device: eDeviceType = ...) -> Tensor:
+    """histogram(src: rocpycv.rocpycv.Tensor, mask: Optional[rocpycv.rocpycv.Tensor], stream: Optional[rocpycv.rocpycv.Stream] = None, device: rocpycv.rocpycv.eDeviceType = <eDeviceType.GPU: 0>) -> rocpycv.rocpycv.Tensor
 
 
 
@@ -951,8 +932,8 @@ def histogram(src: Tensor, mask: Tensor, stream: Stream | None = ..., device: eD
 
     
     """
-def histogram_into(dst: Tensor, src: Tensor, mask: Tensor, stream: Stream | None = ..., device: eDeviceType = ...) -> None:
-    """histogram_into(dst: rocpycv.rocpycv.Tensor, src: rocpycv.rocpycv.Tensor, mask: rocpycv.rocpycv.Tensor, stream: Optional[rocpycv.rocpycv.Stream] = None, device: rocpycv.rocpycv.eDeviceType = <eDeviceType.GPU: 0>) -> None
+def histogram_into(dst: Tensor, src: Tensor, mask: Tensor | None, stream: Stream | None = ..., device: eDeviceType = ...) -> None:
+    """histogram_into(dst: rocpycv.rocpycv.Tensor, src: rocpycv.rocpycv.Tensor, mask: Optional[rocpycv.rocpycv.Tensor], stream: Optional[rocpycv.rocpycv.Stream] = None, device: rocpycv.rocpycv.eDeviceType = <eDeviceType.GPU: 0>) -> None
 
 
 
@@ -1222,7 +1203,7 @@ def threshold(src: Tensor, thresh: Tensor, maxVal: Tensor, maxBatchSize: int, th
                 Args:
                     src (rocpycv.Tensor): Input tensor containing one or more images.
                     thresh (rocpycv.Tensor): thresh an array of size maxBatch that gives the threshold value of each image.
-                    maxVal (rocpycv.Tensor): maxval an array of size maxBatch that gives the maxval value of each image, using with the NVCV_THRESH_BINARY and NVCV_THRESH_BINARY_INV thresholding types.
+                    maxVal (rocpycv.Tensor): maxval an array of size maxBatch that gives the maxval value of each image, used with the NVCV_THRESH_BINARY and NVCV_THRESH_BINARY_INV thresholding types.
                     maxBatchSize (uint32_t): The maximum batch size.
                     threshType (eThresholdType): Threshold type
                     stream (rocpycv.Stream, optional): HIP stream to run this operation on.
@@ -1244,7 +1225,7 @@ def threshold_into(dst: Tensor, src: Tensor, thresh: Tensor, maxVal: Tensor, max
                     dst (rocpycv.Tensor): The output tensor which results are written to.
                     src (rocpycv.Tensor): Input tensor containing one or more images.
                     thresh (rocpycv.Tensor): thresh an array of size maxBatch that gives the threshold value of each image.
-                    maxVal (rocpycv.Tensor): maxval an array of size maxBatch that gives the maxval value of each image, using with the NVCV_THRESH_BINARY and NVCV_THRESH_BINARY_INV thresholding types.
+                    maxVal (rocpycv.Tensor): maxval an array of size maxBatch that gives the maxval value of each image, used with the NVCV_THRESH_BINARY and NVCV_THRESH_BINARY_INV thresholding types.
                     maxBatchSize (uint32_t): The maximum batch size.
                     threshType (eThresholdType): Threshold type
                     stream (rocpycv.Stream, optional): HIP stream to run this operation on.

--- a/samples/bnd_box.cpp
+++ b/samples/bnd_box.cpp
@@ -135,7 +135,7 @@ int main(int argc, char** argv) {
     }
 
     int batchSize = 1;
-    std::vector<std::vector<BndBoxT>> bbox_vector;
+    std::vector<std::vector<BndBox_t>> bbox_vector;
     if (boxSet) {
         std::ifstream box_list_file(box_file_path);
         if (box_list_file.is_open()) {
@@ -151,7 +151,7 @@ int main(int argc, char** argv) {
                         int currBoxIdx = bbox_vector.size();
                         bbox_vector.resize(currBoxIdx + numBoxes);
                         for (int b = currBoxIdx; b < numBoxes + currBoxIdx; b++) {
-                            BndBoxT box;
+                            BndBox_t box;
                             std::getline(box_list_file, line);
                             box.box.x = std::atoi(line.c_str());
                             std::getline(box_list_file, line);

--- a/samples/bnd_box.cpp
+++ b/samples/bnd_box.cpp
@@ -149,7 +149,6 @@ int main(int argc, char** argv) {
                     int numBoxes = std::stoi(line.c_str());
                     if (numBoxes > 0) {
                         int currBoxIdx = bbox_vector.size();
-                        bbox_vector.resize(currBoxIdx + numBoxes);
                         for (int b = currBoxIdx; b < numBoxes + currBoxIdx; b++) {
                             BndBox_t box;
                             std::getline(box_list_file, line);

--- a/samples/bnd_box.cpp
+++ b/samples/bnd_box.cpp
@@ -21,10 +21,11 @@ THE SOFTWARE.
 */
 
 #include <core/hip_assert.h>
-#include <op_bnd_box.hpp>
+
 #include <core/tensor.hpp>
-#include <iostream>
 #include <fstream>
+#include <iostream>
+#include <op_bnd_box.hpp>
 #include <opencv2/opencv.hpp>
 
 using namespace roccv;
@@ -65,13 +66,14 @@ using namespace roccv;
  * 0 <-- alpha component of box fill color of box 2
  */
 
- void ShowHelpAndExit(const char *option = NULL) {
+void ShowHelpAndExit(const char* option = NULL) {
     std::cout << "Options: " << option << std::endl
-    << "-i Input File Path - required" << std::endl
-    << "-o Output File Path - optional; default: output.bmp" << std::endl
-    << "-cpu Select CPU instead of GPU to perform operation - optional; default choice is GPU path" << std::endl
-    << "-d GPU device ID (0 for the first device, 1 for the second, etc.) - optional; default: 0" << std::endl
-    << "-box_file Bounding box list file - optional; default: use the set value in the app" << std::endl;
+              << "-i Input File Path - required" << std::endl
+              << "-o Output File Path - optional; default: output.bmp" << std::endl
+              << "-cpu Select CPU instead of GPU to perform operation - optional; default choice is GPU path"
+              << std::endl
+              << "-d GPU device ID (0 for the first device, 1 for the second, etc.) - optional; default: 0" << std::endl
+              << "-box_file Bounding box list file - optional; default: use the set value in the app" << std::endl;
     exit(0);
 }
 
@@ -79,12 +81,12 @@ int main(int argc, char** argv) {
     std::string input_file_path;
     std::string box_file_path;
     std::string output_file_path = "output.bmp";
-    bool gpuPath = true; // use GPU by default
+    bool gpuPath = true;  // use GPU by default
     eDeviceType device = eDeviceType::GPU;
     int deviceId = 0;
-    bool boxSet = false; // User sets the bounding box list data in a text file
+    bool boxSet = false;  // User sets the bounding box list data in a text file
 
-    if(argc < 3) {
+    if (argc < 3) {
         ShowHelpAndExit("-h");
     }
     for (int i = 1; i < argc; i++) {
@@ -133,8 +135,7 @@ int main(int argc, char** argv) {
     }
 
     int batchSize = 1;
-    std::vector<int32_t> bboxes_size_vector;
-    std::vector<BndBox_t> bbox_vector;
+    std::vector<std::vector<BndBoxT>> bbox_vector;
     if (boxSet) {
         std::ifstream box_list_file(box_file_path);
         if (box_list_file.is_open()) {
@@ -142,43 +143,46 @@ int main(int argc, char** argv) {
             std::getline(box_list_file, line);
             batchSize = std::stoi(line.c_str());
             if (batchSize > 0) {
-                bboxes_size_vector.resize(batchSize);
+                bbox_vector.resize(batchSize);
                 for (int i = 0; i < batchSize; i++) {
                     std::getline(box_list_file, line);
                     int numBoxes = std::stoi(line.c_str());
                     if (numBoxes > 0) {
-                        bboxes_size_vector[i] = numBoxes;
                         int currBoxIdx = bbox_vector.size();
                         bbox_vector.resize(currBoxIdx + numBoxes);
                         for (int b = currBoxIdx; b < numBoxes + currBoxIdx; b++) {
+                            BndBoxT box;
                             std::getline(box_list_file, line);
-                            bbox_vector[b].box.x = std::atoi(line.c_str());
+                            box.box.x = std::atoi(line.c_str());
                             std::getline(box_list_file, line);
-                            bbox_vector[b].box.y = std::atoi(line.c_str());
+                            box.box.y = std::atoi(line.c_str());
                             std::getline(box_list_file, line);
-                            bbox_vector[b].box.width = std::atoi(line.c_str());
+                            box.box.width = std::atoi(line.c_str());
                             std::getline(box_list_file, line);
-                            bbox_vector[b].box.height = std::atoi(line.c_str());
+                            box.box.height = std::atoi(line.c_str());
 
                             std::getline(box_list_file, line);
-                            bbox_vector[b].thickness = std::atoi(line.c_str());
+                            box.thickness = std::atoi(line.c_str());
 
                             std::getline(box_list_file, line);
-                            bbox_vector[b].borderColor.c0 = std::atoi(line.c_str());
+                            box.borderColor.r = std::atoi(line.c_str());
                             std::getline(box_list_file, line);
-                            bbox_vector[b].borderColor.c1 = std::atoi(line.c_str());
+                            box.borderColor.g = std::atoi(line.c_str());
                             std::getline(box_list_file, line);
-                            bbox_vector[b].borderColor.c2 = std::atoi(line.c_str());
+                            box.borderColor.b = std::atoi(line.c_str());
                             std::getline(box_list_file, line);
-                            bbox_vector[b].borderColor.c3 = std::atoi(line.c_str());
+                            box.borderColor.a = std::atoi(line.c_str());
+
                             std::getline(box_list_file, line);
-                            bbox_vector[b].fillColor.c0 = std::atoi(line.c_str());
+                            box.fillColor.r = std::atoi(line.c_str());
                             std::getline(box_list_file, line);
-                            bbox_vector[b].fillColor.c1 = std::atoi(line.c_str());
+                            box.fillColor.g = std::atoi(line.c_str());
                             std::getline(box_list_file, line);
-                            bbox_vector[b].fillColor.c2 = std::atoi(line.c_str());
+                            box.fillColor.b = std::atoi(line.c_str());
                             std::getline(box_list_file, line);
-                            bbox_vector[b].fillColor.c3 = std::atoi(line.c_str());
+                            box.fillColor.a = std::atoi(line.c_str());
+
+                            bbox_vector[i].push_back(box);
                         }
                     } else {
                         std::cerr << "Invalid number of boxes: " << numBoxes << "for image: " << i << std::endl;
@@ -196,34 +200,19 @@ int main(int argc, char** argv) {
     } else {
         auto width = imageData.cols;
         auto height = imageData.rows;
-        batchSize = 1;
-        bboxes_size_vector.resize(1, 3);
-        bbox_vector.resize(3);
-        bbox_vector[0].box.x = width / 4;
-        bbox_vector[0].box.y = height / 4;
-        bbox_vector[0].box.width = width / 2;
-        bbox_vector[0].box.height = height / 2;
-        bbox_vector[0].thickness = 5;
-        bbox_vector[0].borderColor = {0, 0, 255, 200};
-        bbox_vector[0].fillColor = {0, 255, 0, 100};
-        bbox_vector[1].box.x = width / 3;
-        bbox_vector[1].box.y = height / 3;
-        bbox_vector[1].box.width = width / 3 * 2;
-        bbox_vector[1].box.height = height / 4;
-        bbox_vector[1].thickness = -1;
-        bbox_vector[1].borderColor = {90, 16, 181, 50};
-        bbox_vector[2].box.x = -50;
-        bbox_vector[2].box.y = (2 * height) / 3;
-        bbox_vector[2].box.width = width + 50;
-        bbox_vector[2].box.height = height / 3 + 50;
-        bbox_vector[2].thickness = 0;
-        bbox_vector[2].borderColor = {0, 0, 0, 50};
-        bbox_vector[2].fillColor = {111, 159, 232, 150};
+        bbox_vector = {
+            {
+                {{width / 4, height / 4, width / 2, height / 2}, 5, {0, 0, 255, 200}, {0, 255, 0, 100}},
+                {{width / 3, height / 3, width / 3 * 2, height / 4}, -1, {90, 16, 181, 50}, {0, 0, 0, 0}},
+                {{-50, (height * 2) / 3, width + 50, height / 3 + 50}, 0, {0, 0, 0, 0}, {111, 159, 232, 150}},
+            },
+        };
     }
-    BndBoxes_t bboxes{batchSize, bboxes_size_vector, bbox_vector};
+    BndBoxes bboxes(bbox_vector);
 
     // Create input/output tensors for the image.
-    TensorShape imageShape(TensorLayout(eTensorLayout::TENSOR_LAYOUT_NHWC), {1, imageData.rows, imageData.cols, imageData.channels()});
+    TensorShape imageShape(TensorLayout(eTensorLayout::TENSOR_LAYOUT_NHWC),
+                           {1, imageData.rows, imageData.cols, imageData.channels()});
     DataType dtype(eDataType::DATA_TYPE_U8);
     Tensor input(imageShape, dtype, device);
     Tensor output(imageShape, dtype, device);
@@ -237,7 +226,8 @@ int main(int argc, char** argv) {
     size_t imageSizeInByte = input.shape().size() * input.dtype().size();
     auto inputData = input.exportData<TensorDataStrided>();
     if (gpuPath) {
-        HIP_VALIDATE_NO_ERRORS(hipMemcpyAsync(inputData.basePtr(), imageData.data, imageSizeInByte, hipMemcpyHostToDevice, stream));
+        HIP_VALIDATE_NO_ERRORS(
+            hipMemcpyAsync(inputData.basePtr(), imageData.data, imageSizeInByte, hipMemcpyHostToDevice, stream));
     } else {
         memcpy(inputData.basePtr(), imageData.data, imageSizeInByte);
     }
@@ -250,7 +240,8 @@ int main(int argc, char** argv) {
     auto outData = output.exportData<TensorDataStrided>();
     std::vector<uint8_t> h_output(outputSize);
     if (gpuPath) {
-        HIP_VALIDATE_NO_ERRORS(hipMemcpyAsync(h_output.data(), outData.basePtr(), outputSize, hipMemcpyDeviceToHost, stream));
+        HIP_VALIDATE_NO_ERRORS(
+            hipMemcpyAsync(h_output.data(), outData.basePtr(), outputSize, hipMemcpyDeviceToHost, stream));
         HIP_VALIDATE_NO_ERRORS(hipStreamSynchronize(stream));
     } else {
         memcpy(h_output.data(), outData.basePtr(), outputSize);

--- a/samples/cropandresize/cpp/main.cpp
+++ b/samples/cropandresize/cpp/main.cpp
@@ -159,7 +159,7 @@ int main(int argc, char *argv[]) {
     int resizeHeight = 240;
 
     //  Create the crop rect for the cropping operator
-    Box_t crpRect = {cropX, cropY, cropWidth, cropHeight};
+    roccv::Box_t crpRect = {cropX, cropY, cropWidth, cropHeight};
 
     // tag: Allocate Tensors for Crop and Resize
     // Create a rocCV Tensor based on the crop window size.

--- a/src/op_bnd_box.cpp
+++ b/src/op_bnd_box.cpp
@@ -22,17 +22,18 @@ THE SOFTWARE.
 #include "op_bnd_box.hpp"
 
 #include <hip/hip_runtime.h>
-#include <functional>
+
 #include <algorithm>
 #include <cstring>
+#include <functional>
 #include <iostream>
 #include <vector>
 
-#include "core/wrappers/image_wrapper.hpp"
 #include "common/math_vector.hpp"
 #include "common/strided_data_wrap.hpp"
 #include "common/validation_helpers.hpp"
 #include "core/tensor.hpp"
+#include "core/wrappers/image_wrapper.hpp"
 #include "kernels/device/bnd_box_device.hpp"
 #include "kernels/host/bnd_box_host.hpp"
 
@@ -42,7 +43,8 @@ BndBox::BndBox() {}
 BndBox::~BndBox() {}
 
 template <bool has_alpha, typename T>
-void dispatch_bnd_box_dtype(hipStream_t stream, const Tensor& input, const Tensor& output, std::vector<Rect_t> rects, const eDeviceType device) {
+void dispatch_bnd_box_dtype(hipStream_t stream, const Tensor &input, const Tensor &output, std::vector<Rect_t> rects,
+                            const eDeviceType device) {
     ImageWrapper<T> inputWrapper(input);
     ImageWrapper<T> outputWrapper(output);
 
@@ -65,8 +67,8 @@ void dispatch_bnd_box_dtype(hipStream_t stream, const Tensor& input, const Tenso
                     hipMemcpyAsync(rects_ptr, rects.data(), sizeof(Rect_t) * n_rects, hipMemcpyHostToDevice, stream));
             }
             Kernels::Device::bndbox_kernel<has_alpha, T>
-                    <<<dim3(xGridSize, yGridSize, zGridSize), dim3(blockSize, blockSize, 1), 0, stream>>>(
-                        inputWrapper, outputWrapper, rects_ptr, n_rects, batch_size, height, width);
+                <<<dim3(xGridSize, yGridSize, zGridSize), dim3(blockSize, blockSize, 1), 0, stream>>>(
+                    inputWrapper, outputWrapper, rects_ptr, n_rects, batch_size, height, width);
             if (n_rects > 0) {
                 HIP_VALIDATE_NO_ERRORS(hipFreeAsync(rects_ptr, stream));
             }
@@ -74,14 +76,15 @@ void dispatch_bnd_box_dtype(hipStream_t stream, const Tensor& input, const Tenso
         }
 
         case eDeviceType::CPU: {
-            Kernels::Host::bndbox_kernel<has_alpha, T>(inputWrapper, outputWrapper, rects.data(), rects.size(), batch_size, height, width);
+            Kernels::Host::bndbox_kernel<has_alpha, T>(inputWrapper, outputWrapper, rects.data(), rects.size(),
+                                                       batch_size, height, width);
             break;
         }
     }
 }
 
-void BndBox::operator()(hipStream_t stream, const Tensor &input, const Tensor &output,
-                        const BndBoxes_t bnd_boxes, eDeviceType device) {
+void BndBox::operator()(hipStream_t stream, const Tensor &input, const Tensor &output, const BndBoxes &bnd_boxes,
+                        eDeviceType device) {
     // Verify that the tensors are located on the right device (CPU or GPU).
     CHECK_TENSOR_DEVICE(input, device);
     CHECK_TENSOR_DEVICE(output, device);
@@ -120,49 +123,43 @@ void BndBox::operator()(hipStream_t stream, const Tensor &input, const Tensor &o
     // clang-format on
 
     auto func = funcs.at(input.dtype().etype())[input.shape(input.layout().channels_index()) - 1];
-    if (func == 0)
-        throw Exception("Not mapped to a defined function.", eStatusType::INVALID_OPERATION);
+    if (func == 0) throw Exception("Not mapped to a defined function.", eStatusType::INVALID_OPERATION);
     func(stream, input, output, rects, device);
 }
 
-void BndBox::generateRects(std::vector<Rect_t> &rects, const BndBoxes_t &bnd_boxes, int64_t height, int64_t width) {
-    if (bnd_boxes.batch == 0) {
+void BndBox::generateRects(std::vector<Rect_t> &rects, const BndBoxes &bnd_boxes, int64_t height, int64_t width) {
+    if (bnd_boxes.batch() == 0) {
         return;
     }
 
-    if (bnd_boxes.numBoxes.empty() || bnd_boxes.boxes.empty()) {
-        throw Exception("Invalid BndBoxes_t: has a nullptr but batch != 0.", eStatusType::INVALID_POINTER);
-    }
-
-    int32_t total_boxes = 0;
-    for (int64_t batch = 0; batch < bnd_boxes.batch; batch++) {
-        const auto numBoxes = bnd_boxes.numBoxes[batch];
+    for (int64_t batch = 0; batch < bnd_boxes.batch(); batch++) {
+        const auto numBoxes = bnd_boxes.numBoxesAt(batch);
 
         for (int32_t i = 0; i < numBoxes; i++) {
-            const auto curr_box = bnd_boxes.boxes[total_boxes + i];
-            const auto left = std::max(std::min(curr_box.box.x, width - 1), static_cast<int64_t>(0));
-            const auto top = std::max(std::min(curr_box.box.y, height - 1), static_cast<int64_t>(0));
-            const auto right = std::max(std::min(left + curr_box.box.width - 1, width - 1), static_cast<int64_t>(0));
-            const auto bottom = std::max(std::min(top + curr_box.box.height - 1, height - 1), static_cast<int64_t>(0));
+            const auto curr_box = bnd_boxes.boxAt(batch, i);
+            const auto left = std::max(std::min<int32_t>(curr_box.box.x, width - 1), 0);
+            const auto top = std::max(std::min<int32_t>(curr_box.box.y, height - 1), 0);
+            const auto right = std::max(std::min<int32_t>(left + curr_box.box.width - 1, width - 1), 0);
+            const auto bottom = std::max(std::min<int32_t>(top + curr_box.box.height - 1, height - 1), 0);
 
             if (left == right || top == bottom || curr_box.box.width <= 0 || curr_box.box.height <= 0) {
                 continue;
             }
 
-            if (curr_box.borderColor.c3 == 0 && curr_box.fillColor.c3 == 0) {
+            if (curr_box.borderColor.a == 0 && curr_box.fillColor.a == 0) {
                 continue;
             }
 
             // no border
-            if (curr_box.thickness == -1 && curr_box.borderColor.c3 != 0) {
+            if (curr_box.thickness == -1 && curr_box.borderColor.a != 0) {
                 Rect_t rect;
 
                 rect.batch = batch;
                 rect.bordered = false;
-                rect.color.x = curr_box.borderColor.c0;
-                rect.color.y = curr_box.borderColor.c1;
-                rect.color.z = curr_box.borderColor.c2;
-                rect.color.w = curr_box.borderColor.c3;
+                rect.color.x = curr_box.borderColor.r;
+                rect.color.y = curr_box.borderColor.g;
+                rect.color.z = curr_box.borderColor.b;
+                rect.color.w = curr_box.borderColor.a;
 
                 rect.o_left = left;
                 rect.o_right = right;
@@ -177,10 +174,10 @@ void BndBox::generateRects(std::vector<Rect_t> &rects, const BndBoxes_t &bnd_box
 
                     rect.batch = batch;
                     rect.bordered = false;
-                    rect.color.x = curr_box.fillColor.c0;
-                    rect.color.y = curr_box.fillColor.c1;
-                    rect.color.z = curr_box.fillColor.c2;
-                    rect.color.w = curr_box.fillColor.c3;
+                    rect.color.x = curr_box.fillColor.r;
+                    rect.color.y = curr_box.fillColor.g;
+                    rect.color.z = curr_box.fillColor.b;
+                    rect.color.w = curr_box.fillColor.a;
 
                     rect.o_left = left;
                     rect.o_right = right;
@@ -208,10 +205,10 @@ void BndBox::generateRects(std::vector<Rect_t> &rects, const BndBoxes_t &bnd_box
                     rect.i_top = top + half_thickness;
                     rect.i_bottom = bottom - half_thickness;
 
-                    rect.color.x = curr_box.borderColor.c0;
-                    rect.color.y = curr_box.borderColor.c1;
-                    rect.color.z = curr_box.borderColor.c2;
-                    rect.color.w = curr_box.borderColor.c3;
+                    rect.color.x = curr_box.borderColor.r;
+                    rect.color.y = curr_box.borderColor.g;
+                    rect.color.z = curr_box.borderColor.b;
+                    rect.color.w = curr_box.borderColor.a;
 
                     rects.push_back(rect);
                 }
@@ -219,8 +216,6 @@ void BndBox::generateRects(std::vector<Rect_t> &rects, const BndBoxes_t &bnd_box
                 continue;
             }
         }
-
-        total_boxes += numBoxes;
     }
 }
 }  // namespace roccv

--- a/src/op_bnd_box.cpp
+++ b/src/op_bnd_box.cpp
@@ -43,8 +43,8 @@ BndBox::BndBox() {}
 BndBox::~BndBox() {}
 
 template <bool has_alpha, typename T>
-void dispatch_bnd_box_dtype(hipStream_t stream, const Tensor &input, const Tensor &output, std::vector<Rect_t> rects,
-                            const eDeviceType device) {
+void dispatch_bnd_box_dtype(hipStream_t stream, const Tensor &input, const Tensor &output,
+                            const std::vector<Rect_t> &rects, const eDeviceType device) {
     ImageWrapper<T> inputWrapper(input);
     ImageWrapper<T> outputWrapper(output);
 
@@ -114,7 +114,7 @@ void BndBox::operator()(hipStream_t stream, const Tensor &input, const Tensor &o
     // Select kernel dispatcher based on number of channels and a base datatype.
     // clang-format off
     static const std::unordered_map<
-    eDataType, std::array<std::function<void(hipStream_t, const Tensor &, const Tensor &, const std::vector<Rect_t>, const eDeviceType)>, 4>>
+    eDataType, std::array<std::function<void(hipStream_t, const Tensor &, const Tensor &, const std::vector<Rect_t>&, const eDeviceType)>, 4>>
         funcs =
         {
             {eDataType::DATA_TYPE_U8, {0, 0, dispatch_bnd_box_dtype<false, uchar3>, dispatch_bnd_box_dtype<true, uchar4>}},

--- a/src/op_center_crop.cpp
+++ b/src/op_center_crop.cpp
@@ -27,7 +27,6 @@ THE SOFTWARE.
 namespace roccv {
 void CenterCrop::operator()(hipStream_t stream, const Tensor& input, const Tensor& output, const Size2D cropSize,
                             const eDeviceType device) const {
-
     auto i_height = input.shape()[input.shape().layout().height_index()];
     auto i_width = input.shape()[input.shape().layout().width_index()];
 
@@ -40,8 +39,8 @@ void CenterCrop::operator()(hipStream_t stream, const Tensor& input, const Tenso
     int32_t half_cropWidth = cropWidth >> 1;
     int32_t half_cropHeight = cropHeight >> 1;
 
-    int64_t upper_left_corner_x = half_width - half_cropWidth;
-    int64_t upper_left_corner_y = half_height - half_cropHeight;
+    int32_t upper_left_corner_x = half_width - half_cropWidth;
+    int32_t upper_left_corner_y = half_height - half_cropHeight;
 
     Box_t cropRect{upper_left_corner_x, upper_left_corner_y, cropWidth, cropHeight};
 

--- a/src/operator_types.cpp
+++ b/src/operator_types.cpp
@@ -22,11 +22,11 @@
 #include "operator_types.h"
 
 namespace roccv {
-BndBoxes::BndBoxes(const std::vector<std::vector<BndBoxT>> &bndboxesVec) : m_bndboxesVec(bndboxesVec) {}
+BndBoxes::BndBoxes(const std::vector<std::vector<BndBox_t>> &bndboxesVec) : m_bndboxesVec(bndboxesVec) {}
 
 int32_t BndBoxes::batch() const { return m_bndboxesVec.size(); }
 
 int32_t BndBoxes::numBoxesAt(int32_t b) const { return m_bndboxesVec[b].size(); }
 
-BndBoxT BndBoxes::boxAt(int32_t b, int32_t i) const { return m_bndboxesVec[b][i]; }
+BndBox_t BndBoxes::boxAt(int32_t b, int32_t i) const { return m_bndboxesVec[b][i]; }
 }  // namespace roccv

--- a/src/operator_types.cpp
+++ b/src/operator_types.cpp
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "operator_types.h"
+
+namespace roccv {
+BndBoxes::BndBoxes(const std::vector<std::vector<BndBoxT>> &bndboxesVec) : m_bndboxesVec(bndboxesVec) {}
+
+int32_t BndBoxes::batch() const { return m_bndboxesVec.size(); }
+
+int32_t BndBoxes::numBoxesAt(int32_t b) const { return m_bndboxesVec[b].size(); }
+
+BndBoxT BndBoxes::boxAt(int32_t b, int32_t i) const { return m_bndboxesVec[b][i]; }
+}  // namespace roccv

--- a/tests/roccv/cpp/test_op_bnd_box.cpp
+++ b/tests/roccv/cpp/test_op_bnd_box.cpp
@@ -21,11 +21,12 @@ THE SOFTWARE.
 */
 
 #include <algorithm>
-#include <iostream>
 #include <core/detail/casting.hpp>
 #include <core/detail/type_traits.hpp>
 #include <core/wrappers/image_wrapper.hpp>
+#include <iostream>
 #include <op_bnd_box.hpp>
+
 #include "common/math_vector.hpp"
 #include "test_helpers.hpp"
 
@@ -81,7 +82,8 @@ void shadeBBRect(const Rect_t &rect, int ix, int iy, T *out_color) {
  * @return None.
  */
 template <typename T, typename BT = detail::BaseType<T>>
-void GenerateGoldenBndBox(std::vector<BT>& input, std::vector<BT>& output, int32_t batchSize, int32_t width, int32_t height, BndBoxes_t bboxes) {
+void GenerateGoldenBndBox(std::vector<BT> &input, std::vector<BT> &output, int32_t batchSize, int32_t width,
+                          int32_t height, const BndBoxes &bboxes) {
     // Wrap input/output vectors for simplified data access
     ImageWrapper<T> src(input, batchSize, width, height);
     ImageWrapper<T> dst(output, batchSize, width, height);
@@ -107,15 +109,13 @@ void GenerateGoldenBndBox(std::vector<BT>& input, std::vector<BT>& output, int32
 
                 for (size_t i = 0; i < rects.size(); i++) {
                     Rect_t curr_rect = rects[i];
-                    if (curr_rect.batch <= b_idx)
-                        shadeBBRect<WorkType>(curr_rect, x_idx, y_idx, &shaded_pixel);
+                    if (curr_rect.batch <= b_idx) shadeBBRect<WorkType>(curr_rect, x_idx, y_idx, &shaded_pixel);
                 }
 
                 WorkType out_color = MathVector::fill(src.at(b_idx, y_idx, x_idx, 0));
                 out_color.w = has_alpha ? out_color.w : (std::numeric_limits<BT>::max());
 
-                if (shaded_pixel.w != 0)
-                    alphaBlend<WorkType>(out_color, shaded_pixel);
+                if (shaded_pixel.w != 0) alphaBlend<WorkType>(out_color, shaded_pixel);
 
                 MathVector::trunc(out_color, &dst.at(b_idx, y_idx, x_idx, 0));
             }
@@ -146,29 +146,14 @@ void TestCorrectness(int batchSize, int width, int height, ImageFormat format, e
     // Copy generated input data into input tensor
     CopyVectorIntoTensor(input, inputData);
 
-    std::vector<int32_t> bboxes_size_vector(1, 3);
-    std::vector<BndBox_t> bbox_vector(3);
-    bbox_vector[0].box.x = width / 4;
-    bbox_vector[0].box.y = height / 4;
-    bbox_vector[0].box.width = width / 2;
-    bbox_vector[0].box.height = height / 2;
-    bbox_vector[0].thickness = 5;
-    bbox_vector[0].borderColor = {0, 0, 255, 200};
-    bbox_vector[0].fillColor = {0, 255, 0, 100};
-    bbox_vector[1].box.x = width / 3;
-    bbox_vector[1].box.y = height / 3;
-    bbox_vector[1].box.width = width / 3 * 2;
-    bbox_vector[1].box.height = height / 4;
-    bbox_vector[1].thickness = -1;
-    bbox_vector[1].borderColor = {90, 16, 181, 50};
-    bbox_vector[2].box.x = -50;
-    bbox_vector[2].box.y = (2 * height) / 3;
-    bbox_vector[2].box.width = width + 50;
-    bbox_vector[2].box.height = height / 3 + 50;
-    bbox_vector[2].thickness = 0;
-    bbox_vector[2].borderColor = {0, 0, 0, 50};
-    bbox_vector[2].fillColor = {111, 159, 232, 150};
-    BndBoxes_t bboxes{1, bboxes_size_vector, bbox_vector};
+    std::vector<std::vector<BndBoxT>> bboxesVec = {
+        {
+            {{width / 4, height / 4, width / 2, height / 2}, 5, {0, 0, 255, 200}, {0, 255, 0, 100}},
+            {{width / 3, height / 3, width / 3 * 2, height / 4}, -1, {90, 16, 181, 50}, {0, 0, 0, 0}},
+            {{-50, (height * 2) / 3, width + 50, height / 3 + 50}, 0, {0, 0, 0, 0}, {111, 159, 232, 150}},
+        },
+    };
+    BndBoxes bboxes(bboxesVec);
 
     hipStream_t stream;
     HIP_VALIDATE_NO_ERRORS(hipStreamCreate(&stream));

--- a/tests/roccv/cpp/test_op_bnd_box.cpp
+++ b/tests/roccv/cpp/test_op_bnd_box.cpp
@@ -146,7 +146,7 @@ void TestCorrectness(int batchSize, int width, int height, ImageFormat format, e
     // Copy generated input data into input tensor
     CopyVectorIntoTensor(input, inputData);
 
-    std::vector<std::vector<BndBoxT>> bboxesVec = {
+    std::vector<std::vector<BndBox_t>> bboxesVec = {
         {
             {{width / 4, height / 4, width / 2, height / 2}, 5, {0, 0, 255, 200}, {0, 255, 0, 100}},
             {{width / 3, height / 3, width / 3 * 2, height / 4}, -1, {90, 16, 181, 50}, {0, 0, 0, 0}},

--- a/tests/roccv/python/test_op_bnd_box.py
+++ b/tests/roccv/python/test_op_bnd_box.py
@@ -29,7 +29,7 @@ from test_helpers import generate_tensor, compare_tensors
 
 
 def generate_boxes(samples: int, height: int, width: int) -> rocpycv.BndBoxes:
-    num_boxes = [random.randint(1, 3) for i in range(samples)]
+    num_boxes = [random.randint(1, 3) for _ in range(samples)]
     boxes = []
     for sample in range(samples):
         box_list = []

--- a/tests/roccv/python/test_op_bnd_box.py
+++ b/tests/roccv/python/test_op_bnd_box.py
@@ -32,12 +32,14 @@ def generate_boxes(samples: int, height: int, width: int) -> rocpycv.BndBoxes:
     num_boxes = [random.randint(1, 3) for i in range(samples)]
     boxes = []
     for sample in range(samples):
-        for box in range(num_boxes[sample]):
-            rand_color = rocpycv.Color4(random.randint(0, 255), random.randint(0, 255),
-                                        random.randint(0, 255), random.randint(0, 255))
+        box_list = []
+        for _ in range(num_boxes[sample]):
+            rand_color = rocpycv.ColorRGBA(random.randint(0, 255), random.randint(0, 255),
+                                           random.randint(0, 255), random.randint(0, 255))
             rand_box = rocpycv.Box(0, 0, random.randint(0, width - 5), random.randint(0, height - 5))
-            boxes.append(rocpycv.BndBox(rand_box, random.randint(0, 2), rand_color, rand_color))
-    return rocpycv.BndBoxes(samples, num_boxes, boxes)
+            box_list.append(rocpycv.BndBox(rand_box, random.randint(0, 2), rand_color, rand_color))
+        boxes.append(box_list)
+    return rocpycv.BndBoxes(boxes)
 
 
 @pytest.mark.parametrize("device", [rocpycv.eDeviceType.GPU, rocpycv.eDeviceType.CPU])


### PR DESCRIPTION
## Motivation

Change how bounding boxes are passed in as a parameter to the BndBox operator. Also fix unnecessary copies made within the operator call to improve performance.

## Technical Details

* Changed the name of various structs under `operator_types.h`.
* Modified BndBox operator call to no longer make unnecessary copies (passes by reference instead).
* Refactored existing test cases/samples to work with the changes.

## Test Plan

Ensure C++/Python test suites pass as expected.

## Test Result

All test suites passing as expected.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
