### PR TITLE
Added handling of dividing by zero in warp perspective.

### DIFF
--- a/include/kernels/device/warp_perspective_device.hpp
+++ b/include/kernels/device/warp_perspective_device.hpp
@@ -37,9 +37,16 @@ __global__ void warp_perspective(SrcWrapper input, DstWrapper output, Mat mat) {
 
     if (x >= output.width() || y >= output.height()) return;
 
-    const float coeff = 1.0f / (mat[6] * x + mat[7] * y + mat[8]);
-    const float ox = (mat[0] * x + mat[1] * y + mat[2]) * coeff;
-    const float oy = (mat[3] * x + mat[4] * y + mat[5]) * coeff;
+    float ox,oy;
+    const float denom = mat[6] * x + mat[7] * y + mat[8];
+    if (denom != 0.0) {
+        const float coeff = 1.0f / denom;
+        ox = (mat[0] * x + mat[1] * y + mat[2]) * coeff;
+        oy = (mat[3] * x + mat[4] * y + mat[5]) * coeff;
+    } else {
+        ox = 0.0;
+        oy = 0.0;
+    }
 
     output.at(b, y, x, 0) = input.at(b, oy, ox, 0);
 }

--- a/include/kernels/device/warp_perspective_device.hpp
+++ b/include/kernels/device/warp_perspective_device.hpp
@@ -43,12 +43,16 @@ __global__ void warp_perspective(SrcWrapper input, DstWrapper output, Mat mat) {
         const float coeff = 1.0f / denom;
         ox = (mat[0] * x + mat[1] * y + mat[2]) * coeff;
         oy = (mat[3] * x + mat[4] * y + mat[5]) * coeff;
+        output.at(b, y, x, 0) = input.at(b, oy, ox, 0);
     } else {
-        ox = 0.0;
-        oy = 0.0;
+        if ( x > 0) {
+            output.at(b, y, x, 0) = output.at(b, y, x - 1, 0);
+        } else if ( y > 0) {
+            output.at(b, y, x, 0) = output.at(b, y - 1, x, 0);
+        } else {
+            output.at(b, y, x, 0) = input.at(b, 0, 0, 0);
+        }
     }
-
-    output.at(b, y, x, 0) = input.at(b, oy, ox, 0);
 }
 }  // namespace Device
 }  // namespace Kernels

--- a/include/kernels/device/warp_perspective_device.hpp
+++ b/include/kernels/device/warp_perspective_device.hpp
@@ -37,22 +37,11 @@ __global__ void warp_perspective(SrcWrapper input, DstWrapper output, Mat mat) {
 
     if (x >= output.width() || y >= output.height()) return;
 
-    float ox,oy;
     const float denom = mat[6] * x + mat[7] * y + mat[8];
-    if (denom != 0.0) {
-        const float coeff = 1.0f / denom;
-        ox = (mat[0] * x + mat[1] * y + mat[2]) * coeff;
-        oy = (mat[3] * x + mat[4] * y + mat[5]) * coeff;
-        output.at(b, y, x, 0) = input.at(b, oy, ox, 0);
-    } else {
-        if ( x > 0) {
-            output.at(b, y, x, 0) = output.at(b, y, x - 1, 0);
-        } else if ( y > 0) {
-            output.at(b, y, x, 0) = output.at(b, y - 1, x, 0);
-        } else {
-            output.at(b, y, x, 0) = input.at(b, 0, 0, 0);
-        }
-    }
+    const float coeff = denom == 0.0 ? std::numeric_limits<float>::max() : 1.0f / denom;
+    const float ox = (mat[0] * x + mat[1] * y + mat[2]) * coeff;
+    const float oy = (mat[3] * x + mat[4] * y + mat[5]) * coeff;
+    output.at(b, y, x, 0) = input.at(b, oy, ox, 0);
 }
 }  // namespace Device
 }  // namespace Kernels

--- a/include/kernels/host/warp_perspective_host.hpp
+++ b/include/kernels/host/warp_perspective_host.hpp
@@ -37,12 +37,17 @@ void warp_perspective(SrcWrapper input, DstWrapper output, Mat mat) {
                     const float coeff = 1.0f / denom;
                     ox = (mat[0] * x + mat[1] * y + mat[2]) * coeff;
                     oy = (mat[3] * x + mat[4] * y + mat[5]) * coeff;
+                    output.at(b, y, x, 0) = input.at(b, oy, ox, 0);
                 } else {
-                    ox = 0.0;
-                    oy = 0.0;
+                    if ( x > 0) {
+                        output.at(b, y, x, 0) = output.at(b, y, x - 1, 0);
+                    } else if ( y > 0) {
+                        output.at(b, y, x, 0) = output.at(b, y - 1, x, 0);
+                    } else {
+                        output.at(b, y, x, 0) = input.at(b, 0, 0, 0);
+                    }
                 }
 
-                output.at(b, y, x, 0) = input.at(b, oy, ox, 0);
             }
         }
     }

--- a/include/kernels/host/warp_perspective_host.hpp
+++ b/include/kernels/host/warp_perspective_host.hpp
@@ -31,23 +31,11 @@ void warp_perspective(SrcWrapper input, DstWrapper output, Mat mat) {
     for (int b = 0; b < output.batches(); b++) {
         for (int y = 0; y < output.height(); y++) {
             for (int x = 0; x < output.width(); x++) {
-                float ox, oy;
                 const float denom = mat[6] * x + mat[7] * y + mat[8];
-                if (denom != 0.0) {
-                    const float coeff = 1.0f / denom;
-                    ox = (mat[0] * x + mat[1] * y + mat[2]) * coeff;
-                    oy = (mat[3] * x + mat[4] * y + mat[5]) * coeff;
-                    output.at(b, y, x, 0) = input.at(b, oy, ox, 0);
-                } else {
-                    if ( x > 0) {
-                        output.at(b, y, x, 0) = output.at(b, y, x - 1, 0);
-                    } else if ( y > 0) {
-                        output.at(b, y, x, 0) = output.at(b, y - 1, x, 0);
-                    } else {
-                        output.at(b, y, x, 0) = input.at(b, 0, 0, 0);
-                    }
-                }
-
+                const float coeff = denom == 0.0 ? std::numeric_limits<float>::max() : 1.0f / denom;
+                const float ox = (mat[0] * x + mat[1] * y + mat[2]) * coeff;
+                const float oy = (mat[3] * x + mat[4] * y + mat[5]) * coeff;
+                output.at(b, y, x, 0) = input.at(b, oy, ox, 0);
             }
         }
     }

--- a/include/kernels/host/warp_perspective_host.hpp
+++ b/include/kernels/host/warp_perspective_host.hpp
@@ -31,9 +31,16 @@ void warp_perspective(SrcWrapper input, DstWrapper output, Mat mat) {
     for (int b = 0; b < output.batches(); b++) {
         for (int y = 0; y < output.height(); y++) {
             for (int x = 0; x < output.width(); x++) {
-                const float coeff = 1.0f / (mat[6] * x + mat[7] * y + mat[8]);
-                const float ox = (mat[0] * x + mat[1] * y + mat[2]) * coeff;
-                const float oy = (mat[3] * x + mat[4] * y + mat[5]) * coeff;
+                float ox, oy;
+                const float denom = mat[6] * x + mat[7] * y + mat[8];
+                if (denom != 0.0) {
+                    const float coeff = 1.0f / denom;
+                    ox = (mat[0] * x + mat[1] * y + mat[2]) * coeff;
+                    oy = (mat[3] * x + mat[4] * y + mat[5]) * coeff;
+                } else {
+                    ox = 0.0;
+                    oy = 0.0;
+                }
 
                 output.at(b, y, x, 0) = input.at(b, oy, ox, 0);
             }

--- a/tests/roccv/cpp/common/math_utils.cpp
+++ b/tests/roccv/cpp/common/math_utils.cpp
@@ -24,7 +24,7 @@
 #include <cmath>
 
 namespace roccv::tests {
-Point2D MatTransform(const Point2D point, const std::array<float, 9>& mat) {
+Point2D MatTransform(const Point2D point, const std::array<float, 9>& mat, bool& valid) {
     // Assuming mat is a 3x3 matrix stored in row-major order
     float oX = mat[0] * point.x + mat[1] * point.y + mat[2];
     float oY = mat[3] * point.x + mat[4] * point.y + mat[5];
@@ -34,9 +34,11 @@ Point2D MatTransform(const Point2D point, const std::array<float, 9>& mat) {
     if (oW != 0.0f) {
         oX /= oW;
         oY /= oW;
+        valid = true;
     } else {
         oX = 0.0;
         oY = 0.0;
+        valid = false;
     }
 
     return Point2D{oX, oY};

--- a/tests/roccv/cpp/common/math_utils.cpp
+++ b/tests/roccv/cpp/common/math_utils.cpp
@@ -24,7 +24,7 @@
 #include <cmath>
 
 namespace roccv::tests {
-Point2D MatTransform(const Point2D point, const std::array<float, 9>& mat, bool& valid) {
+Point2D MatTransform(const Point2D point, const std::array<float, 9>& mat) {
     // Assuming mat is a 3x3 matrix stored in row-major order
     float oX = mat[0] * point.x + mat[1] * point.y + mat[2];
     float oY = mat[3] * point.x + mat[4] * point.y + mat[5];
@@ -34,11 +34,9 @@ Point2D MatTransform(const Point2D point, const std::array<float, 9>& mat, bool&
     if (oW != 0.0f) {
         oX /= oW;
         oY /= oW;
-        valid = true;
     } else {
-        oX = 0.0;
-        oY = 0.0;
-        valid = false;
+        oX *= std::numeric_limits<float>::max();
+        oY *= std::numeric_limits<float>::max();
     }
 
     return Point2D{oX, oY};

--- a/tests/roccv/cpp/common/math_utils.cpp
+++ b/tests/roccv/cpp/common/math_utils.cpp
@@ -34,6 +34,9 @@ Point2D MatTransform(const Point2D point, const std::array<float, 9>& mat) {
     if (oW != 0.0f) {
         oX /= oW;
         oY /= oW;
+    } else {
+        oX = 0.0;
+        oY = 0.0;
     }
 
     return Point2D{oX, oY};

--- a/tests/roccv/cpp/common/math_utils.hpp
+++ b/tests/roccv/cpp/common/math_utils.hpp
@@ -34,7 +34,7 @@ struct Point2D {
  * @param mat A row-major, 3x3 transformation matrix.
  * @return The transformed x and y coordinates.
  */
-extern Point2D MatTransform(const Point2D point, const std::array<float, 9>& mat, bool& valid);
+extern Point2D MatTransform(const Point2D point, const std::array<float, 9>& mat);
 
 /**
  * @brief Calculates the determinant of a 3x3 matrix.

--- a/tests/roccv/cpp/common/math_utils.hpp
+++ b/tests/roccv/cpp/common/math_utils.hpp
@@ -34,7 +34,7 @@ struct Point2D {
  * @param mat A row-major, 3x3 transformation matrix.
  * @return The transformed x and y coordinates.
  */
-extern Point2D MatTransform(const Point2D point, const std::array<float, 9>& mat);
+extern Point2D MatTransform(const Point2D point, const std::array<float, 9>& mat, bool& valid);
 
 /**
  * @brief Calculates the determinant of a 3x3 matrix.

--- a/tests/roccv/cpp/test_op_warp_affine.cpp
+++ b/tests/roccv/cpp/test_op_warp_affine.cpp
@@ -80,9 +80,9 @@ std::vector<detail::BaseType<T>> GoldenWarpAffine(std::vector<detail::BaseType<T
     for (int b = 0; b < outputWrap.batches(); b++) {
         for (int y = 0; y < outputWrap.height(); y++) {
             for (int x = 0; x < outputWrap.width(); x++) {
+                bool valid = false;
                 // Get transformed input point by multiplying by the given perspective transformation matrix
-                Point2D inputCoord =
-                    MatTransform((Point2D){static_cast<float>(x), static_cast<float>(y)}, invMat.value());
+                Point2D inputCoord = MatTransform((Point2D){static_cast<float>(x), static_cast<float>(y)}, invMat.value(), valid);
                 outputWrap.at(b, y, x, 0) = inputWrap.at(b, inputCoord.y, inputCoord.x, 0);
             }
         }

--- a/tests/roccv/cpp/test_op_warp_affine.cpp
+++ b/tests/roccv/cpp/test_op_warp_affine.cpp
@@ -80,9 +80,8 @@ std::vector<detail::BaseType<T>> GoldenWarpAffine(std::vector<detail::BaseType<T
     for (int b = 0; b < outputWrap.batches(); b++) {
         for (int y = 0; y < outputWrap.height(); y++) {
             for (int x = 0; x < outputWrap.width(); x++) {
-                bool valid = false;
                 // Get transformed input point by multiplying by the given perspective transformation matrix
-                Point2D inputCoord = MatTransform((Point2D){static_cast<float>(x), static_cast<float>(y)}, invMat.value(), valid);
+                Point2D inputCoord = MatTransform((Point2D){static_cast<float>(x), static_cast<float>(y)}, invMat.value());
                 outputWrap.at(b, y, x, 0) = inputWrap.at(b, inputCoord.y, inputCoord.x, 0);
             }
         }

--- a/tests/roccv/cpp/test_op_warp_perspective.cpp
+++ b/tests/roccv/cpp/test_op_warp_perspective.cpp
@@ -75,9 +75,19 @@ std::vector<detail::BaseType<T>> GoldenWarpPerspective(std::vector<detail::BaseT
         for (int y = 0; y < outputWrap.height(); y++) {
             for (int x = 0; x < outputWrap.width(); x++) {
                 // Get transformed input point by multiplying by the given perspective transformation matrix
-                Point2D inputCoord =
-                    MatTransform((Point2D){static_cast<float>(x), static_cast<float>(y)}, invMat.value());
-                outputWrap.at(b, y, x, 0) = inputWrap.at(b, inputCoord.y, inputCoord.x, 0);
+                bool valid = false;
+                Point2D inputCoord = MatTransform((Point2D){static_cast<float>(x), static_cast<float>(y)}, invMat.value(), valid);
+                if (valid) {
+                    outputWrap.at(b, y, x, 0) = inputWrap.at(b, inputCoord.y, inputCoord.x, 0);
+                } else {
+                    if (x > 0) {
+                        outputWrap.at(b, y, x, 0) = outputWrap.at(b, y, x - 1, 0);
+                    } else if (y > 0) {
+                        outputWrap.at(b, y, x, 0) = outputWrap.at(b, y - 1, x, 0);
+                    } else {
+                        outputWrap.at(b, y, x, 0) = inputWrap.at(b, 0, 0, 0);
+                    }
+                }
             }
         }
     }

--- a/tests/roccv/cpp/test_op_warp_perspective.cpp
+++ b/tests/roccv/cpp/test_op_warp_perspective.cpp
@@ -75,19 +75,8 @@ std::vector<detail::BaseType<T>> GoldenWarpPerspective(std::vector<detail::BaseT
         for (int y = 0; y < outputWrap.height(); y++) {
             for (int x = 0; x < outputWrap.width(); x++) {
                 // Get transformed input point by multiplying by the given perspective transformation matrix
-                bool valid = false;
-                Point2D inputCoord = MatTransform((Point2D){static_cast<float>(x), static_cast<float>(y)}, invMat.value(), valid);
-                if (valid) {
-                    outputWrap.at(b, y, x, 0) = inputWrap.at(b, inputCoord.y, inputCoord.x, 0);
-                } else {
-                    if (x > 0) {
-                        outputWrap.at(b, y, x, 0) = outputWrap.at(b, y, x - 1, 0);
-                    } else if (y > 0) {
-                        outputWrap.at(b, y, x, 0) = outputWrap.at(b, y - 1, x, 0);
-                    } else {
-                        outputWrap.at(b, y, x, 0) = inputWrap.at(b, 0, 0, 0);
-                    }
-                }
+                Point2D inputCoord = MatTransform((Point2D){static_cast<float>(x), static_cast<float>(y)}, invMat.value());
+                outputWrap.at(b, y, x, 0) = inputWrap.at(b, inputCoord.y, inputCoord.x, 0);
             }
         }
     }


### PR DESCRIPTION
## Motivation

This PR added the handling of dividing by zero in warp perspective operation.

## Technical Details

- Some perspective transform matrixes result in 0 value divider in the mapped pixel position calculation. In this case, the pixel is assigned to a border pixel.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
