### PR TITLE
[Bugfix]: Use size_t for TensorShape size method

### DIFF
--- a/include/core/tensor_shape.hpp
+++ b/include/core/tensor_shape.hpp
@@ -83,7 +83,7 @@ class TensorShape {
      *
      * @return The size of the tensor.
      */
-    int size() const;
+    size_t size() const;
 
     // Operators
     int64_t operator[](int32_t i) const;

--- a/src/core/tensor_shape.cpp
+++ b/src/core/tensor_shape.cpp
@@ -116,7 +116,7 @@ bool TensorShape::operator==(const TensorShape &rhs) const {
 
 bool TensorShape::operator!=(const TensorShape &rhs) const { return !(*this == rhs); }
 
-int TensorShape::size() const { return m_size; }
+size_t TensorShape::size() const { return m_size; }
 
 const TensorLayout &TensorShape::layout() const { return m_layout; }
 }  // namespace roccv


### PR DESCRIPTION
## Motivation

* Fix overflow bug which occurs for very large tensors.

## Technical Details

* Uses `size_t` for `TensorShape::size()` method instead of `int`.

## Test Plan

* Ensure current C++/Python tests still pass.
* Ensure benchmarks can be run for Resize at a batch size of 128 (where this issue was originally showing itself)

## Test Result

* C++/Python tests pass. Resize benchmarks no longer throwing out of memory errors on large batch sizes.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
