### PR TITLE
[Refactor]: Change TensorRequirements fields and specify resource requirements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Miscellaneous
+.notes
+
 # Build files
 .build/
 build
@@ -8,6 +11,8 @@ data/samples/python/output
 # Configuration files
 .devenv/
 .vscode/
+.clangd
+pyrightconfig.json
 
 # vcpkg installs
 vcpkg_installed

--- a/include/core/tensor.hpp
+++ b/include/core/tensor.hpp
@@ -21,9 +21,11 @@ THE SOFTWARE.
 */
 #pragma once
 
+#include <array>
 #include <memory>
 
 #include "core/detail/allocators/i_allocator.hpp"
+#include "core/tensor_layout.hpp"
 #include "tensor_data.hpp"
 #include "tensor_requirements.hpp"
 #include "tensor_storage.hpp"
@@ -98,14 +100,14 @@ class Tensor {
      *
      * @return The location of the tensor data.
      */
-    const eDeviceType device() const;
+    eDeviceType device() const;
 
     /**
      * @brief Returns the shape of the tensor
      *
      * @return Shape of the tensor
      */
-    const TensorShape &shape() const;
+    TensorShape shape() const;
 
     /**
      * @brief Retrieves a specific dimension size from the tensor shape.
@@ -113,21 +115,21 @@ class Tensor {
      * @param[in] d The index of the dimension.
      * @return The size of the specified dimension.
      */
-    const int64_t shape(int d) const &;
+    int64_t shape(int d) const &;
 
     /**
      * @brief Returns the data type of the tensor
      *
      * @return Data type of the tensor
      */
-    const DataType &dtype() const;
+    DataType dtype() const;
 
     /**
      * @brief Returns the layout of the tensor
      *
      * @return Layout of the tensor
      */
-    const TensorLayout &layout() const;
+    TensorLayout layout() const;
 
     /**
      * @brief Exports the tensor data of the tensor
@@ -197,6 +199,15 @@ class Tensor {
      */
     static Requirements CalcRequirements(int num_images, Size2D image_size, ImageFormat fmt,
                                          eDeviceType device = eDeviceType::GPU);
+
+    /**
+     * @brief Calculates strides required for a tensor.
+     *
+     * @param shape The tensor shape.
+     * @param dtype The datatype of the tensor.
+     * @return An array containing strides for the given parameters.
+     */
+    static std::array<int64_t, ROCCV_TENSOR_MAX_RANK> CalcStrides(const TensorShape &shape, const DataType &dtype);
 
    private:
     TensorRequirements m_requirements;      // Tensor metadata

--- a/include/core/tensor.hpp
+++ b/include/core/tensor.hpp
@@ -24,8 +24,10 @@ THE SOFTWARE.
 #include <array>
 #include <memory>
 
+#include "core/data_type.hpp"
 #include "core/detail/allocators/i_allocator.hpp"
 #include "core/tensor_layout.hpp"
+#include "core/util_enums.h"
 #include "tensor_data.hpp"
 #include "tensor_requirements.hpp"
 #include "tensor_storage.hpp"
@@ -185,8 +187,21 @@ class Tensor {
      * @return A TensorRequirements object representing this tensor's
      * requirements.
      */
-    static Requirements CalcRequirements(const TensorShape &shape, DataType dtype,
+    static Requirements CalcRequirements(const TensorShape &shape, const DataType &dtype,
                                          const eDeviceType device = eDeviceType::GPU);
+
+    /**
+     * @brief Calculates tensor requirements.
+     *
+     * @param[in] shape The shape describing the tensor.
+     * @param[in] dtype The type of the tensor's data.
+     * @param[in] strides The tensor's strides.
+     * @param[in] device The device the tensor data belongs on. (Default: GPU)
+     * @return Tensor requirements.
+     */
+    static Requirements CalcRequirements(const TensorShape &shape, const DataType &dtype,
+                                         std::array<int64_t, ROCCV_TENSOR_MAX_RANK> strides,
+                                         eDeviceType device = eDeviceType::GPU);
 
     /**
      * @brief Calculates tensor requirements using image-based parameters.

--- a/include/core/tensor_buffer.hpp
+++ b/include/core/tensor_buffer.hpp
@@ -31,20 +31,21 @@ THE SOFTWARE.
 namespace roccv {
 
 /**
+ * @brief A tensor buffer with strided data.
+ *
+ */
+struct TensorBufferStrided {
+    void* basePtr;
+    std::array<int64_t, ROCCV_TENSOR_MAX_RANK> strides;
+};
+
+/**
  * @brief A tensor buffer. Stores the raw data associated with a tensor. Data
  * should be allocated by the user and set to the basePtr of the buffer.
  *
  */
 struct TensorBuffer {
-    void* basePtr;
-};
-
-/**
- * @brief A tensor buffer with strided data.
- *
- */
-struct TensorBufferStrided : public TensorBuffer {
-    std::array<int64_t, ROCCV_TENSOR_MAX_RANK> strides;
+    TensorBufferStrided strided;
 };
 
 }  // namespace roccv

--- a/include/core/tensor_data.hpp
+++ b/include/core/tensor_data.hpp
@@ -91,8 +91,15 @@ class TensorData {
     std::optional<Derived> cast() const {
         static_assert(std::is_base_of<TensorData, Derived>::value, "Cannot cast TensorData to an unrelated type.");
         static_assert(sizeof(Derived) == sizeof(TensorData), "Derived type must not add any additional data members.");
+
+        if (!Derived::IsCompatibleKind(m_bufferType)) {
+            return std::nullopt;
+        }
+
         return std::optional(Derived(m_shape, m_dtype, m_buffer, m_deviceType));
     }
+
+    static bool IsCompatibleKind(TensorBufferType bufferType);
 
    protected:
     TensorData(const TensorShape &tshape, const DataType &dtype, const TensorBuffer &buffer,
@@ -129,6 +136,8 @@ class TensorDataStrided : public TensorData {
      */
     TensorDataStrided(const TensorShape &tshape, const DataType &dtype, const TensorBufferStrided &buffer,
                       const eDeviceType device = eDeviceType::GPU);
+
+    static bool IsCompatibleKind(TensorBufferType bufferType);
 
     /**
      * @brief Returns the base pointer of the tensor data in memory.

--- a/include/core/tensor_data.hpp
+++ b/include/core/tensor_data.hpp
@@ -96,14 +96,13 @@ class TensorData {
             return std::nullopt;
         }
 
-        return std::optional(Derived(m_shape, m_dtype, m_buffer, m_deviceType));
+        return std::optional(Derived(m_shape, m_dtype, m_buffer));
     }
 
     static bool IsCompatibleKind(TensorBufferType bufferType);
 
    protected:
-    TensorData(const TensorShape &tshape, const DataType &dtype, const TensorBuffer &buffer,
-               const eDeviceType device = eDeviceType::GPU);
+    TensorData(const TensorShape &tshape, const DataType &dtype, const TensorBuffer &buffer);
 
     TensorShape m_shape;
     DataType m_dtype;
@@ -122,20 +121,7 @@ class TensorDataStrided : public TensorData {
    public:
     using Buffer = TensorBufferStrided;
 
-    TensorDataStrided(const TensorShape &shape, const DataType &dtype, const TensorBuffer &buffer,
-                      eDeviceType device = eDeviceType::GPU);
-
-    /**
-     * @brief Constructs a TensorDataStrided object.
-     *
-     * @param[in] tshape The shape of the tensor.
-     * @param[in] dtype The datatype of the tensor.
-     * @param[in] buffer The buffer containing the tensor's underlying data.
-     * @param[in] data_location The data location of the tensor (default:
-     * DATA_ON_DEVICE).
-     */
-    TensorDataStrided(const TensorShape &tshape, const DataType &dtype, const TensorBufferStrided &buffer,
-                      const eDeviceType device = eDeviceType::GPU);
+    TensorDataStrided(const TensorShape &shape, const DataType &dtype, const TensorBuffer &buffer);
 
     static bool IsCompatibleKind(TensorBufferType bufferType);
 
@@ -153,5 +139,49 @@ class TensorDataStrided : public TensorData {
      * @return The stride for the given dimension.
      */
     const int64_t stride(int d) const;
+};
+
+/**
+ * @brief GPU-accessible strided tensor data.
+ *
+ */
+class TensorDataStridedHip : public TensorDataStrided {
+   public:
+    using Buffer = TensorBufferStrided;
+
+    TensorDataStridedHip(const TensorShape &shape, const DataType &dtype, const TensorBuffer &buffer);
+
+    /**
+     * @brief Creates a GPU-accessible strided tensor data object.
+     *
+     * @param[in] shape The tensor's shape.
+     * @param[in] dtype The datatype of the underlying  data.
+     * @param[in] buffer A strided tensor buffer with data allocated on the GPU.
+     */
+    TensorDataStridedHip(const TensorShape &shape, const DataType &dtype, const Buffer &buffer);
+
+    static bool IsCompatibleKind(TensorBufferType bufferType);
+};
+
+/**
+ * @brief Host-accessible strided tensor data.
+ *
+ */
+class TensorDataStridedHost : public TensorDataStrided {
+   public:
+    using Buffer = TensorBufferStrided;
+
+    TensorDataStridedHost(const TensorShape &shape, const DataType &dtype, const TensorBuffer &buffer);
+
+    /**
+     * @brief Creates a host-accessible strided tensor data object.
+     *
+     * @param[in] shape The tensor's shape.
+     * @param[in] dtype The datatype of the underlying  data.
+     * @param[in] buffer A strided tensor buffer with data allocated on the host.
+     */
+    TensorDataStridedHost(const TensorShape &shape, const DataType &dtype, const Buffer &buffer);
+
+    static bool IsCompatibleKind(TensorBufferType bufferType);
 };
 }  // namespace roccv

--- a/include/core/tensor_data.hpp
+++ b/include/core/tensor_data.hpp
@@ -96,7 +96,7 @@ class TensorData {
             return std::nullopt;
         }
 
-        return std::optional(Derived(m_shape, m_dtype, m_buffer));
+        return std::make_optional<Derived>(m_shape, m_dtype, m_buffer);
     }
 
     static bool IsCompatibleKind(TensorBufferType bufferType);
@@ -155,7 +155,7 @@ class TensorDataStridedHip : public TensorDataStrided {
      * @brief Creates a GPU-accessible strided tensor data object.
      *
      * @param[in] shape The tensor's shape.
-     * @param[in] dtype The datatype of the underlying  data.
+     * @param[in] dtype The datatype of the underlying data.
      * @param[in] buffer A strided tensor buffer with data allocated on the GPU.
      */
     TensorDataStridedHip(const TensorShape &shape, const DataType &dtype, const Buffer &buffer);
@@ -177,7 +177,7 @@ class TensorDataStridedHost : public TensorDataStrided {
      * @brief Creates a host-accessible strided tensor data object.
      *
      * @param[in] shape The tensor's shape.
-     * @param[in] dtype The datatype of the underlying  data.
+     * @param[in] dtype The datatype of the underlying data.
      * @param[in] buffer A strided tensor buffer with data allocated on the host.
      */
     TensorDataStridedHost(const TensorShape &shape, const DataType &dtype, const Buffer &buffer);

--- a/include/core/tensor_data.hpp
+++ b/include/core/tensor_data.hpp
@@ -24,14 +24,20 @@ THE SOFTWARE.
 
 #include <stdint.h>
 
-#include <iostream>
 #include <optional>
 
-#include "data_type.hpp"
-#include "tensor_buffer.hpp"
-#include "tensor_shape.hpp"
+#include "core/data_type.hpp"
+#include "core/tensor_buffer.hpp"
+#include "core/tensor_shape.hpp"
+#include "core/util_enums.h"
 
 namespace roccv {
+
+enum class TensorBufferType {
+    TENSOR_BUFFER_NONE,         // Default/invalid buffer type. Used when no buffer type is specified.
+    TENSOR_BUFFER_STRIDED_HIP,  // GPU-accessible buffer with strided access.
+    TENSOR_BUFFER_STRIDED_HOST  // Host accessible buffer with strided access.
+};
 
 /**
  * @brief Holds the underlying tensor data alongside metadata (shape, layout,
@@ -74,13 +80,6 @@ class TensorData {
     virtual const DataType &dtype() const;
 
     /**
-     * @brief Returns the base pointer of the tensor data in memory.
-     *
-     * @return A pointer to the tensor data in memory.
-     */
-    virtual void *basePtr() const;
-
-    /**
      * @brief Retrieves the location where the tensor data is allocated, either
      * on the device or the host.
      *
@@ -89,20 +88,21 @@ class TensorData {
     virtual const eDeviceType device() const;
 
     template <typename Derived>
-    std::optional<Derived> cast() {
+    std::optional<Derived> cast() const {
         static_assert(std::is_base_of<TensorData, Derived>::value, "Cannot cast TensorData to an unrelated type.");
         static_assert(sizeof(Derived) == sizeof(TensorData), "Derived type must not add any additional data members.");
         return std::optional(Derived(m_shape, m_dtype, m_buffer, m_deviceType));
     }
 
    protected:
-    TensorData(const TensorShape &tshape, const DataType &dtype, const TensorBufferStrided &buffer,
+    TensorData(const TensorShape &tshape, const DataType &dtype, const TensorBuffer &buffer,
                const eDeviceType device = eDeviceType::GPU);
 
     TensorShape m_shape;
     DataType m_dtype;
     eDeviceType m_deviceType;
-    TensorBufferStrided m_buffer;
+    TensorBufferType m_bufferType;
+    TensorBuffer m_buffer;
 };
 
 /**
@@ -114,6 +114,10 @@ class TensorData {
 class TensorDataStrided : public TensorData {
    public:
     using Buffer = TensorBufferStrided;
+
+    TensorDataStrided(const TensorShape &shape, const DataType &dtype, const TensorBuffer &buffer,
+                      eDeviceType device = eDeviceType::GPU);
+
     /**
      * @brief Constructs a TensorDataStrided object.
      *
@@ -125,6 +129,13 @@ class TensorDataStrided : public TensorData {
      */
     TensorDataStrided(const TensorShape &tshape, const DataType &dtype, const TensorBufferStrided &buffer,
                       const eDeviceType device = eDeviceType::GPU);
+
+    /**
+     * @brief Returns the base pointer of the tensor data in memory.
+     *
+     * @return A pointer to the tensor data in memory.
+     */
+    void *basePtr() const;
 
     /**
      * @brief Returns the stride at a given dimension.

--- a/include/core/tensor_requirements.hpp
+++ b/include/core/tensor_requirements.hpp
@@ -30,7 +30,7 @@ THE SOFTWARE.
 namespace roccv {
 
 struct MemRequirements {
-    size_t bytes;
+    size_t bytes = 0;
 };
 
 struct ResourceRequirements {

--- a/include/core/tensor_requirements.hpp
+++ b/include/core/tensor_requirements.hpp
@@ -22,21 +22,31 @@ THE SOFTWARE.
 
 #pragma once
 
-#include "data_type.hpp"
-#include "tensor_layout.hpp"
+#include <array>
+
+#include "core/tensor_layout.hpp"
+#include "core/util_enums.h"
 
 namespace roccv {
+
+struct MemRequirements {
+    size_t bytes;
+};
+
+struct ResourceRequirements {
+    MemRequirements deviceMem;
+    MemRequirements hostMem;
+    MemRequirements pinnedMem;
+};
+
 struct TensorRequirements {
-    // The data type of the tensor.
-    DataType dtype;
-
-    // Location of the tensor's underlying data.
-    eDeviceType device;
-
-    // The shape of the tensor.
-    TensorShape shape;
-
-    // Distance in bytes between each element of a given dimension.
+    eDataType dtype;
+    eTensorLayout layout;
+    int32_t rank;
+    std::array<int64_t, ROCCV_TENSOR_MAX_RANK> shape;
     std::array<int64_t, ROCCV_TENSOR_MAX_RANK> strides;
+    int32_t alignBytes;
+    ResourceRequirements res;
+    eDeviceType device;
 };
 }  // namespace roccv

--- a/include/core/tensor_shape.hpp
+++ b/include/core/tensor_shape.hpp
@@ -24,6 +24,7 @@ THE SOFTWARE.
 
 #include <span>
 
+#include "core/util_enums.h"
 #include "tensor_layout.hpp"
 
 namespace roccv {
@@ -72,6 +73,7 @@ class TensorShape {
     TensorShape(const std::initializer_list<const int64_t> shape, const std::string &layoutDesc);
 
     TensorShape(const std::span<const int64_t> shape, int rank, const TensorLayout &layout);
+    TensorShape(const std::span<const int64_t> shape, int rank, eTensorLayout layout);
 
     /**
      * @brief Retrieves the layout of the tensor.

--- a/include/core/tensor_shape.hpp
+++ b/include/core/tensor_shape.hpp
@@ -71,6 +71,8 @@ class TensorShape {
      */
     TensorShape(const std::initializer_list<const int64_t> shape, const std::string &layoutDesc);
 
+    TensorShape(const std::span<const int64_t> shape, int rank, const TensorLayout &layout);
+
     /**
      * @brief Retrieves the layout of the tensor.
      *
@@ -84,6 +86,13 @@ class TensorShape {
      * @return The size of the tensor.
      */
     size_t size() const;
+
+    /**
+     * @brief Returns the underlying shape data of the TensorShape.
+     *
+     * @return Shape data of the tensor shape.
+     */
+    const std::array<int64_t, ROCCV_TENSOR_MAX_RANK> &shape() const;
 
     // Operators
     int64_t operator[](int32_t i) const;

--- a/samples/cropandresize/cpp/main.cpp
+++ b/samples/cropandresize/cpp/main.cpp
@@ -32,6 +32,7 @@
 #include <string>
 
 #include "common/utils.hpp"
+#include "core/tensor_shape.hpp"
 
 /**
  * @brief Crop and Resize sample app.
@@ -132,7 +133,8 @@ int main(int argc, char *argv[]) {
         roccv::Tensor::CalcRequirements(batchSize, {maxImageWidth, maxImageHeight}, roccv::FMT_RGB8);
 
     // Create a tensor buffer to store the data pointer and pitch bytes for each plane
-    roccv::TensorDataStrided inData(inReqs.shape, inReqs.dtype, inBuf);
+    roccv::TensorDataStrided inData(roccv::TensorShape{inReqs.shape, inReqs.rank, inReqs.layout},
+                                    roccv::DataType{inReqs.dtype}, inBuf);
 
     // Wrap tensor data in a rocCV tensor for use with the rocCV operators.
     roccv::Tensor inTensor = roccv::TensorWrapData(inData);

--- a/samples/cropandresize/cpp/main.cpp
+++ b/samples/cropandresize/cpp/main.cpp
@@ -133,8 +133,8 @@ int main(int argc, char *argv[]) {
         roccv::Tensor::CalcRequirements(batchSize, {maxImageWidth, maxImageHeight}, roccv::FMT_RGB8);
 
     // Create a tensor buffer to store the data pointer and pitch bytes for each plane
-    roccv::TensorDataStrided inData(roccv::TensorShape{inReqs.shape, inReqs.rank, inReqs.layout},
-                                    roccv::DataType{inReqs.dtype}, inBuf);
+    roccv::TensorDataStridedHip inData(roccv::TensorShape{inReqs.shape, inReqs.rank, inReqs.layout},
+                                       roccv::DataType{inReqs.dtype}, inBuf);
 
     // Wrap tensor data in a rocCV tensor for use with the rocCV operators.
     roccv::Tensor inTensor = roccv::TensorWrapData(inData);

--- a/src/core/tensor.cpp
+++ b/src/core/tensor.cpp
@@ -22,10 +22,15 @@ THE SOFTWARE.
 
 #include "core/tensor.hpp"
 
+#include "core/data_type.hpp"
 #include "core/detail/context.hpp"
 #include "core/exception.hpp"
 #include "core/hip_assert.h"
 #include "core/image_format.hpp"
+#include "core/tensor_layout.hpp"
+#include "core/tensor_requirements.hpp"
+#include "core/tensor_shape.hpp"
+#include "core/util_enums.h"
 #include "operator_types.h"
 
 namespace roccv {
@@ -34,7 +39,8 @@ namespace roccv {
 Tensor::Tensor(const TensorRequirements& reqs) : Tensor(reqs, GlobalContext().getDefaultAllocator()) {}
 
 Tensor::Tensor(const TensorRequirements& reqs, const IAllocator& alloc) : m_requirements(reqs), m_allocator(alloc) {
-    m_data = std::make_shared<TensorStorage>(reqs.shape.size() * reqs.dtype.size(), reqs.device, alloc);
+    size_t numBytes = reqs.device == eDeviceType::GPU ? reqs.res.deviceMem.bytes : reqs.res.hostMem.bytes;
+    m_data = std::make_shared<TensorStorage>(numBytes, reqs.device, alloc);
 }
 Tensor::Tensor(const TensorRequirements& reqs, std::shared_ptr<TensorStorage> data)
     : Tensor(reqs, data, GlobalContext().getDefaultAllocator()) {}
@@ -60,17 +66,17 @@ Tensor::Tensor(Tensor&& other)
       m_allocator(other.m_allocator) {}
 
 // Member definitions
-int Tensor::rank() const { return m_requirements.shape.layout().rank(); }
+int Tensor::rank() const { return m_requirements.rank; }
 
-const eDeviceType Tensor::device() const { return m_requirements.device; }
+eDeviceType Tensor::device() const { return m_requirements.device; }
 
-const TensorShape& Tensor::shape() const { return m_requirements.shape; }
+TensorShape Tensor::shape() const { return TensorShape(m_requirements.shape, m_requirements.rank, layout()); }
 
-const int64_t Tensor::shape(int d) const& { return m_requirements.shape[d]; }
+int64_t Tensor::shape(int d) const& { return shape()[d]; }
 
-const DataType& Tensor::dtype() const { return m_requirements.dtype; }
+DataType Tensor::dtype() const { return DataType(m_requirements.dtype); }
 
-const TensorLayout& Tensor::layout() const { return m_requirements.shape.layout(); }
+TensorLayout Tensor::layout() const { return TensorLayout(m_requirements.layout); }
 
 TensorData Tensor::exportData() const {
     TensorBufferStrided buffer;
@@ -107,14 +113,24 @@ Tensor& Tensor::operator=(const Tensor& other) {
 }
 
 TensorRequirements Tensor::CalcRequirements(const TensorShape& shape, DataType dtype, const eDeviceType device) {
-    // Calculate strides based on the given tensor shape. Strides are byte-wise.
-    std::array<int64_t, ROCCV_TENSOR_MAX_RANK> strides;
-    strides[shape.layout().rank() - 1] = dtype.size();
-    for (int i = shape.layout().rank() - 2; i >= 0; i--) {
-        strides[i] = strides[i + 1] * shape[i + 1];
-    }
+    TensorRequirements reqs;
 
-    TensorRequirements reqs = {dtype, device, shape, strides};
+    reqs.shape = shape.shape();
+    reqs.rank = shape.layout().rank();
+    reqs.layout = shape.layout().elayout();
+    reqs.strides = CalcStrides(shape, dtype);
+    reqs.dtype = dtype.etype();
+    reqs.alignBytes = 0;  // TODO: Must be specified later
+    reqs.device = device;
+
+    // TODO: Resource requirements should be calculated differently later, once padded/aligned strides have been
+    // implemented
+    size_t numBytes = reqs.strides[0] * reqs.shape[0];
+    if (reqs.device == eDeviceType::GPU) {
+        reqs.res.deviceMem.bytes = numBytes;
+    } else if (reqs.device == eDeviceType::CPU) {
+        reqs.res.hostMem.bytes = numBytes;
+    }
 
     return reqs;
 }
@@ -125,6 +141,18 @@ TensorRequirements Tensor::CalcRequirements(int num_images, Size2D image_size, I
     TensorShape shape(TensorLayout(eTensorLayout::TENSOR_LAYOUT_NHWC),
                       {num_images, image_size.h, image_size.w, fmt.channels()});
     return CalcRequirements(shape, DataType(fmt.dtype()), device);
+}
+
+std::array<int64_t, ROCCV_TENSOR_MAX_RANK> Tensor::CalcStrides(const TensorShape& shape, const DataType& dtype) {
+    // TODO: Support memory alignment and padding in stride calculations
+
+    // Calculate strides based on the given tensor shape. Strides are byte-wise.
+    std::array<int64_t, ROCCV_TENSOR_MAX_RANK> strides;
+    strides[shape.layout().rank() - 1] = dtype.size();
+    for (int i = shape.layout().rank() - 2; i >= 0; i--) {
+        strides[i] = strides[i + 1] * shape[i + 1];
+    }
+    return strides;
 }
 
 Tensor TensorWrapData(const TensorData& tensor_data) {

--- a/src/core/tensor.cpp
+++ b/src/core/tensor.cpp
@@ -25,8 +25,9 @@ THE SOFTWARE.
 #include "core/data_type.hpp"
 #include "core/detail/context.hpp"
 #include "core/exception.hpp"
-#include "core/hip_assert.h"
 #include "core/image_format.hpp"
+#include "core/status_type.h"
+#include "core/tensor_data.hpp"
 #include "core/tensor_layout.hpp"
 #include "core/tensor_requirements.hpp"
 #include "core/tensor_shape.hpp"
@@ -156,9 +157,26 @@ std::array<int64_t, ROCCV_TENSOR_MAX_RANK> Tensor::CalcStrides(const TensorShape
 }
 
 Tensor TensorWrapData(const TensorData& tensor_data) {
-    TensorRequirements req = Tensor::CalcRequirements(tensor_data.shape(), tensor_data.dtype(), tensor_data.device());
-    auto data = std::make_shared<TensorStorage>(tensor_data.basePtr(), tensor_data.device(), eOwnership::OWNING);
-    return Tensor(req, data);
+    auto tensorDataStrided = tensor_data.cast<TensorDataStrided>();
+    if (!tensorDataStrided.has_value()) {
+        throw Exception("TensorData could not be cast to TensorDataStrided. Tensors can only wrap strided tensor data.",
+                        eStatusType::INVALID_VALUE);
+    }
+
+    TensorRequirements reqs;
+    reqs.layout = tensorDataStrided->shape().layout().elayout();
+    reqs.rank = tensorDataStrided->rank();
+    reqs.device = tensorDataStrided->device();
+    reqs.dtype = tensorDataStrided->dtype().etype();
+    reqs.shape = tensorDataStrided->shape().shape();
+
+    for (int i = 0; i < reqs.rank; i++) {
+        reqs.strides[i] = tensorDataStrided->stride(i);
+    }
+
+    auto data =
+        std::make_shared<TensorStorage>(tensorDataStrided->basePtr(), tensorDataStrided->device(), eOwnership::OWNING);
+    return Tensor(reqs, data);
 }
 
 }  // namespace roccv

--- a/src/core/tensor.cpp
+++ b/src/core/tensor.cpp
@@ -22,6 +22,8 @@ THE SOFTWARE.
 
 #include "core/tensor.hpp"
 
+#include <array>
+
 #include "core/data_type.hpp"
 #include "core/detail/context.hpp"
 #include "core/exception.hpp"
@@ -113,13 +115,20 @@ Tensor& Tensor::operator=(const Tensor& other) {
     return *this;
 }
 
-TensorRequirements Tensor::CalcRequirements(const TensorShape& shape, DataType dtype, const eDeviceType device) {
+TensorRequirements Tensor::CalcRequirements(const TensorShape& shape, const DataType& dtype, const eDeviceType device) {
+    std::array<int64_t, ROCCV_TENSOR_MAX_RANK> strides = CalcStrides(shape, dtype);
+    TensorRequirements reqs = CalcRequirements(shape, dtype, strides, device);
+    return reqs;
+}
+
+TensorRequirements Tensor::CalcRequirements(const TensorShape& shape, const DataType& dtype,
+                                            std::array<int64_t, ROCCV_TENSOR_MAX_RANK> strides, eDeviceType device) {
     TensorRequirements reqs;
 
     reqs.shape = shape.shape();
     reqs.rank = shape.layout().rank();
     reqs.layout = shape.layout().elayout();
-    reqs.strides = CalcStrides(shape, dtype);
+    reqs.strides = strides;
     reqs.dtype = dtype.etype();
     reqs.alignBytes = 0;  // TODO: Must be specified later
     reqs.device = device;
@@ -163,16 +172,12 @@ Tensor TensorWrapData(const TensorData& tensor_data) {
                         eStatusType::INVALID_VALUE);
     }
 
-    TensorRequirements reqs;
-    reqs.layout = tensorDataStrided->shape().layout().elayout();
-    reqs.rank = tensorDataStrided->rank();
-    reqs.device = tensorDataStrided->device();
-    reqs.dtype = tensorDataStrided->dtype().etype();
-    reqs.shape = tensorDataStrided->shape().shape();
-
-    for (int i = 0; i < reqs.rank; i++) {
-        reqs.strides[i] = tensorDataStrided->stride(i);
+    std::array<int64_t, ROCCV_TENSOR_MAX_RANK> strides;
+    for (int i = 0; i < tensorDataStrided->rank(); i++) {
+        strides[i] = tensorDataStrided->stride(i);
     }
+    TensorRequirements reqs = Tensor::CalcRequirements(tensorDataStrided->shape(), tensorDataStrided->dtype(), strides,
+                                                       tensorDataStrided->device());
 
     auto data =
         std::make_shared<TensorStorage>(tensorDataStrided->basePtr(), tensorDataStrided->device(), eOwnership::OWNING);

--- a/src/core/tensor.cpp
+++ b/src/core/tensor.cpp
@@ -85,8 +85,16 @@ TensorData Tensor::exportData() const {
     TensorBufferStrided buffer;
     buffer.basePtr = m_data->data();
     buffer.strides = m_requirements.strides;
-    TensorDataStrided data(shape(), dtype(), buffer, device());
-    return data;
+
+    switch (device()) {
+        case eDeviceType::GPU: {
+            return TensorDataStridedHip(shape(), dtype(), buffer);
+        }
+
+        case eDeviceType::CPU: {
+            return TensorDataStridedHost(shape(), dtype(), buffer);
+        }
+    }
 }
 
 Tensor Tensor::reshape(const TensorShape& new_shape) const {

--- a/src/core/tensor.cpp
+++ b/src/core/tensor.cpp
@@ -94,6 +94,10 @@ TensorData Tensor::exportData() const {
         case eDeviceType::CPU: {
             return TensorDataStridedHost(shape(), dtype(), buffer);
         }
+
+        default: {
+            throw Exception("Unsupported device type in Tensor::exportData().", eStatusType::INVALID_VALUE);
+        }
     }
 }
 

--- a/src/core/tensor_data.cpp
+++ b/src/core/tensor_data.cpp
@@ -23,10 +23,9 @@ THE SOFTWARE.
 #include "core/tensor_data.hpp"
 
 #include "core/data_type.hpp"
+#include "core/util_enums.h"
 
 namespace roccv {
-
-void* roccv::TensorData::basePtr() const { return m_buffer.basePtr; }
 
 int TensorData::rank() const { return m_shape.layout().rank(); }
 
@@ -38,13 +37,35 @@ const DataType& TensorData::dtype() const { return m_dtype; }
 
 const eDeviceType TensorData::device() const { return m_deviceType; }
 
-TensorData::TensorData(const TensorShape& tshape, const DataType& dtype, const TensorBufferStrided& buffer,
+TensorData::TensorData(const TensorShape& tshape, const DataType& dtype, const TensorBuffer& buffer,
                        const eDeviceType device)
-    : m_shape(tshape), m_dtype(dtype), m_deviceType(device), m_buffer(buffer) {}
+    : m_shape(tshape),
+      m_dtype(dtype),
+      m_deviceType(device),
+      m_bufferType(TensorBufferType::TENSOR_BUFFER_NONE),
+      m_buffer(buffer) {}
+
+TensorDataStrided::TensorDataStrided(const TensorShape& tshape, const DataType& dtype, const TensorBuffer& buffer,
+                                     const eDeviceType device)
+    : TensorData(tshape, dtype, buffer, device) {
+    switch (device) {
+        case eDeviceType::GPU: {
+            m_bufferType = TensorBufferType::TENSOR_BUFFER_STRIDED_HIP;
+            break;
+        }
+
+        case eDeviceType::CPU: {
+            m_bufferType = TensorBufferType::TENSOR_BUFFER_STRIDED_HOST;
+            break;
+        }
+    }
+}
 
 TensorDataStrided::TensorDataStrided(const TensorShape& tshape, const DataType& dtype,
                                      const TensorBufferStrided& buffer, const eDeviceType device)
-    : TensorData(tshape, dtype, buffer, device) {}
+    : TensorDataStrided(tshape, dtype, {.strided = buffer}, device) {}
 
-const int64_t TensorDataStrided::stride(int d) const { return m_buffer.strides[d]; }
+void* roccv::TensorDataStrided::basePtr() const { return m_buffer.strided.basePtr; }
+
+const int64_t TensorDataStrided::stride(int d) const { return m_buffer.strided.strides[d]; }
 }  // namespace roccv

--- a/src/core/tensor_data.cpp
+++ b/src/core/tensor_data.cpp
@@ -23,6 +23,7 @@ THE SOFTWARE.
 #include "core/tensor_data.hpp"
 
 #include "core/data_type.hpp"
+#include "core/tensor_buffer.hpp"
 #include "core/util_enums.h"
 
 namespace roccv {
@@ -37,37 +38,15 @@ const DataType& TensorData::dtype() const { return m_dtype; }
 
 const eDeviceType TensorData::device() const { return m_deviceType; }
 
-TensorData::TensorData(const TensorShape& tshape, const DataType& dtype, const TensorBuffer& buffer,
-                       const eDeviceType device)
-    : m_shape(tshape),
-      m_dtype(dtype),
-      m_deviceType(device),
-      m_bufferType(TensorBufferType::TENSOR_BUFFER_NONE),
-      m_buffer(buffer) {}
+TensorData::TensorData(const TensorShape& tshape, const DataType& dtype, const TensorBuffer& buffer)
+    : m_shape(tshape), m_dtype(dtype), m_bufferType(TensorBufferType::TENSOR_BUFFER_NONE), m_buffer(buffer) {}
 
 bool TensorData::IsCompatibleKind(TensorBufferType bufferType) {
     return bufferType != TensorBufferType::TENSOR_BUFFER_NONE;
 }
 
-TensorDataStrided::TensorDataStrided(const TensorShape& tshape, const DataType& dtype, const TensorBuffer& buffer,
-                                     const eDeviceType device)
-    : TensorData(tshape, dtype, buffer, device) {
-    switch (device) {
-        case eDeviceType::GPU: {
-            m_bufferType = TensorBufferType::TENSOR_BUFFER_STRIDED_HIP;
-            break;
-        }
-
-        case eDeviceType::CPU: {
-            m_bufferType = TensorBufferType::TENSOR_BUFFER_STRIDED_HOST;
-            break;
-        }
-    }
-}
-
-TensorDataStrided::TensorDataStrided(const TensorShape& tshape, const DataType& dtype,
-                                     const TensorBufferStrided& buffer, const eDeviceType device)
-    : TensorDataStrided(tshape, dtype, {.strided = buffer}, device) {}
+TensorDataStrided::TensorDataStrided(const TensorShape& tshape, const DataType& dtype, const TensorBuffer& buffer)
+    : TensorData(tshape, dtype, buffer) {}
 
 bool TensorDataStrided::IsCompatibleKind(TensorBufferType bufferType) {
     return bufferType == TensorBufferType::TENSOR_BUFFER_STRIDED_HIP ||
@@ -77,4 +56,33 @@ bool TensorDataStrided::IsCompatibleKind(TensorBufferType bufferType) {
 void* roccv::TensorDataStrided::basePtr() const { return m_buffer.strided.basePtr; }
 
 const int64_t TensorDataStrided::stride(int d) const { return m_buffer.strided.strides[d]; }
+
+TensorDataStridedHip::TensorDataStridedHip(const TensorShape& shape, const DataType& dtype, const TensorBuffer& buffer)
+    : TensorDataStrided(shape, dtype, buffer) {
+    m_bufferType = TensorBufferType::TENSOR_BUFFER_STRIDED_HIP;
+    m_deviceType = eDeviceType::GPU;
+}
+
+TensorDataStridedHip::TensorDataStridedHip(const TensorShape& shape, const DataType& dtype,
+                                           const TensorDataStridedHip::Buffer& buffer)
+    : TensorDataStridedHip(shape, dtype, {.strided = buffer}) {}
+
+bool TensorDataStridedHip::IsCompatibleKind(TensorBufferType bufferType) {
+    return bufferType == TensorBufferType::TENSOR_BUFFER_STRIDED_HIP;
+}
+
+TensorDataStridedHost::TensorDataStridedHost(const TensorShape& shape, const DataType& dtype,
+                                             const TensorBuffer& buffer)
+    : TensorDataStrided(shape, dtype, buffer) {
+    m_bufferType = TensorBufferType::TENSOR_BUFFER_STRIDED_HOST;
+    m_deviceType = eDeviceType::CPU;
+}
+
+TensorDataStridedHost::TensorDataStridedHost(const TensorShape& shape, const DataType& dtype, const Buffer& buffer)
+    : TensorDataStridedHost(shape, dtype, {.strided = buffer}) {}
+
+bool TensorDataStridedHost::IsCompatibleKind(TensorBufferType bufferType) {
+    return bufferType == TensorBufferType::TENSOR_BUFFER_STRIDED_HOST;
+}
+
 }  // namespace roccv

--- a/src/core/tensor_data.cpp
+++ b/src/core/tensor_data.cpp
@@ -45,6 +45,10 @@ TensorData::TensorData(const TensorShape& tshape, const DataType& dtype, const T
       m_bufferType(TensorBufferType::TENSOR_BUFFER_NONE),
       m_buffer(buffer) {}
 
+bool TensorData::IsCompatibleKind(TensorBufferType bufferType) {
+    return bufferType != TensorBufferType::TENSOR_BUFFER_NONE;
+}
+
 TensorDataStrided::TensorDataStrided(const TensorShape& tshape, const DataType& dtype, const TensorBuffer& buffer,
                                      const eDeviceType device)
     : TensorData(tshape, dtype, buffer, device) {
@@ -64,6 +68,11 @@ TensorDataStrided::TensorDataStrided(const TensorShape& tshape, const DataType& 
 TensorDataStrided::TensorDataStrided(const TensorShape& tshape, const DataType& dtype,
                                      const TensorBufferStrided& buffer, const eDeviceType device)
     : TensorDataStrided(tshape, dtype, {.strided = buffer}, device) {}
+
+bool TensorDataStrided::IsCompatibleKind(TensorBufferType bufferType) {
+    return bufferType == TensorBufferType::TENSOR_BUFFER_STRIDED_HIP ||
+           bufferType == TensorBufferType::TENSOR_BUFFER_STRIDED_HOST;
+}
 
 void* roccv::TensorDataStrided::basePtr() const { return m_buffer.strided.basePtr; }
 

--- a/src/core/tensor_data.cpp
+++ b/src/core/tensor_data.cpp
@@ -39,7 +39,11 @@ const DataType& TensorData::dtype() const { return m_dtype; }
 const eDeviceType TensorData::device() const { return m_deviceType; }
 
 TensorData::TensorData(const TensorShape& tshape, const DataType& dtype, const TensorBuffer& buffer)
-    : m_shape(tshape), m_dtype(dtype), m_bufferType(TensorBufferType::TENSOR_BUFFER_NONE), m_buffer(buffer) {}
+    : m_shape(tshape),
+      m_dtype(dtype),
+      m_deviceType(eDeviceType::GPU),
+      m_bufferType(TensorBufferType::TENSOR_BUFFER_NONE),
+      m_buffer(buffer) {}
 
 bool TensorData::IsCompatibleKind(TensorBufferType bufferType) {
     return bufferType != TensorBufferType::TENSOR_BUFFER_NONE;

--- a/src/core/tensor_shape.cpp
+++ b/src/core/tensor_shape.cpp
@@ -24,6 +24,8 @@ THE SOFTWARE.
 
 #include <algorithm>
 
+#include "core/exception.hpp"
+#include "core/status_type.h"
 #include "core/tensor_layout.hpp"
 
 namespace roccv {
@@ -44,12 +46,29 @@ const TensorLayout GetLayoutFromString(const std::string &desc) {
     return TensorLayout(layoutDescToEnum.at(desc));
 }
 
-TensorShape::TensorShape(const TensorLayout &layout, const std::span<const int64_t> shape) : m_layout(layout) {
-    if (shape.size() != layout.rank()) {
+TensorShape::TensorShape(const TensorLayout &layout, const std::span<const int64_t> shape)
+    : TensorShape(shape, shape.size(), layout) {}
+
+TensorShape::TensorShape(const TensorLayout &layout, const std::initializer_list<const int64_t> shape)
+    : TensorShape(layout, std::span<const int64_t>(shape.begin(), shape.end())) {}
+
+TensorShape::TensorShape(const std::initializer_list<const int64_t> shape, const std::string &layoutDesc)
+    : TensorShape(GetLayoutFromString(layoutDesc), shape) {}
+
+TensorShape::TensorShape(const std::span<const int64_t> shape, const std::string &layoutDesc)
+    : TensorShape(GetLayoutFromString(layoutDesc), shape) {}
+
+TensorShape::TensorShape(const std::span<const int64_t> shape, int rank, const TensorLayout &layout)
+    : m_layout(layout) {
+    if (rank != layout.rank()) {
         throw Exception(
             "Invalid shape size: The size of the shape must match the rank of "
             "the provided layout.",
             eStatusType::OUT_OF_BOUNDS);
+    }
+
+    if (shape.size() < rank) {
+        throw Exception("Size of the input shape data is less than the rank provided.", eStatusType::OUT_OF_BOUNDS);
     }
 
     for (int i = 0; i < layout.rank(); i++) {
@@ -62,7 +81,7 @@ TensorShape::TensorShape(const TensorLayout &layout, const std::span<const int64
     }
 
     // Copy the std::span shape into the internal shape array.
-    std::copy(shape.begin(), shape.end(), m_shape.begin());
+    std::copy_n(shape.begin(), rank, m_shape.begin());
 
     // Calculate shape size
     m_size = 1;
@@ -70,15 +89,6 @@ TensorShape::TensorShape(const TensorLayout &layout, const std::span<const int64
         m_size *= dim_size;
     }
 }
-
-TensorShape::TensorShape(const TensorLayout &layout, const std::initializer_list<const int64_t> shape)
-    : TensorShape(layout, std::span<const int64_t>(shape.begin(), shape.end())) {}
-
-TensorShape::TensorShape(const std::initializer_list<const int64_t> shape, const std::string &layoutDesc)
-    : TensorShape(GetLayoutFromString(layoutDesc), shape) {}
-
-TensorShape::TensorShape(const std::span<const int64_t> shape, const std::string &layoutDesc)
-    : TensorShape(GetLayoutFromString(layoutDesc), shape) {}
 
 TensorShape &TensorShape::operator=(const TensorShape &other) {
     if (this != &other) {
@@ -119,4 +129,7 @@ bool TensorShape::operator!=(const TensorShape &rhs) const { return !(*this == r
 size_t TensorShape::size() const { return m_size; }
 
 const TensorLayout &TensorShape::layout() const { return m_layout; }
+
+const std::array<int64_t, ROCCV_TENSOR_MAX_RANK> &TensorShape::shape() const { return m_shape; }
+
 }  // namespace roccv

--- a/src/core/tensor_shape.cpp
+++ b/src/core/tensor_shape.cpp
@@ -74,7 +74,7 @@ TensorShape::TensorShape(const std::span<const int64_t> shape, int rank, const T
         throw Exception("Size of the input shape data is less than the rank provided.", eStatusType::OUT_OF_BOUNDS);
     }
 
-    for (int i = 0; i < layout.rank(); i++) {
+    for (int i = 0; i < rank; i++) {
         if (shape[i] <= 0) {
             throw Exception(
                 "Invalid shape dimension: values of elements in the "
@@ -88,8 +88,8 @@ TensorShape::TensorShape(const std::span<const int64_t> shape, int rank, const T
 
     // Calculate shape size
     m_size = 1;
-    for (int64_t dim_size : shape) {
-        m_size *= dim_size;
+    for (int i = 0; i < rank; i++) {
+        m_size *= m_shape[i];
     }
 }
 

--- a/src/core/tensor_shape.cpp
+++ b/src/core/tensor_shape.cpp
@@ -58,6 +58,9 @@ TensorShape::TensorShape(const std::initializer_list<const int64_t> shape, const
 TensorShape::TensorShape(const std::span<const int64_t> shape, const std::string &layoutDesc)
     : TensorShape(GetLayoutFromString(layoutDesc), shape) {}
 
+TensorShape::TensorShape(const std::span<const int64_t> shape, int rank, eTensorLayout layout)
+    : TensorShape(shape, rank, TensorLayout(layout)) {}
+
 TensorShape::TensorShape(const std::span<const int64_t> shape, int rank, const TensorLayout &layout)
     : m_layout(layout) {
     if (rank != layout.rank()) {

--- a/src/core/tensor_shape.cpp
+++ b/src/core/tensor_shape.cpp
@@ -63,6 +63,10 @@ TensorShape::TensorShape(const std::span<const int64_t> shape, int rank, eTensor
 
 TensorShape::TensorShape(const std::span<const int64_t> shape, int rank, const TensorLayout &layout)
     : m_layout(layout) {
+    if (rank < 0) {
+        throw Exception("Rank must be a non-negative integer.", eStatusType::OUT_OF_BOUNDS);
+    }
+
     if (rank != layout.rank()) {
         throw Exception(
             "Invalid shape size: The size of the shape must match the rank of "
@@ -70,7 +74,7 @@ TensorShape::TensorShape(const std::span<const int64_t> shape, int rank, const T
             eStatusType::OUT_OF_BOUNDS);
     }
 
-    if (shape.size() < rank) {
+    if (shape.size() < static_cast<size_t>(rank)) {
         throw Exception("Size of the input shape data is less than the rank provided.", eStatusType::OUT_OF_BOUNDS);
     }
 


### PR DESCRIPTION
## Motivation

Make changes to TensorData/TensorRequirements to lay the required groundwork for padded data support in Tensors. Mainly adds an additional field to keep track of memory usage, separate from the tensor's shape.

## Technical Details

* Changes metadata in TensorRequirements. Adds `TensorResources` field to specify device, host, and pinned memory usage in bytes.
* `TensorDataStrided` is now split into `TensorDataStridedHip` and `TensorDataStridedHost` objects to define tensor data on the device and host respectively.
* Changes to `TensorData` and its associated classes ensure better checking when casting from one type to another by checking the underlying tensor buffer type.

## Test Plan

Ensure the full project compiles after the changes. Ensure C++/Python unit tests still pass after changes.

## Test Result

Project compiles, C++/Python tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
