### PR TITLE
[Bugfix]: Switch from RangeCast to SaturateCast for border value type conversions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The full documentation for rocCV is available at [https://rocm.docs.amd.com/proj
 ### Changed
 
 - `Pybind11` and `DLPack` requirements moved to git submodules.
+- Border value parameters now use Saturate cast instead of Range cast when being converted to their internal types. This means passing in `1.0f` as a value for a `U8` image will result in a value of `1`, whereas previously it would have been converted to `255`.
 
 ### Known issues
 

--- a/src/op_bilateral_filter.cpp
+++ b/src/op_bilateral_filter.cpp
@@ -26,6 +26,7 @@ THE SOFTWARE.
 #include <functional>
 #include <iostream>
 #include <numeric>
+
 #include "common/array_wrapper.hpp"
 #include "common/validation_helpers.hpp"
 #include "core/detail/casting.hpp"
@@ -80,7 +81,7 @@ void dispatch_bilateral_filter_border_mode(hipStream_t stream, const Tensor &inp
         Kernels::Device::bilateral_filter<T><<<grid, block, 0, stream>>>(
             inputWrapper, outputWrapper, radius, sigmaColor, sigmaSpace, spaceCoeff, colorCoeff);
     } else if (device == eDeviceType::CPU) {
-        int divisor = std::gcd(4, outputWrapper.height()); // greatest common divisor
+        int divisor = std::gcd(4, outputWrapper.height());  // greatest common divisor
         int dividend = std::gcd((numThreads / divisor), outputWrapper.width());
 
         int factorW = outputWrapper.width() / dividend;
@@ -130,7 +131,7 @@ void dispatch_bilateral_filter_dtype(hipStream_t stream, const Tensor &input, co
     }
 
     auto func = funcs.at(borderMode);
-    func(stream, input, output, diameter, sigmaColor, sigmaSpace, detail::RangeCast<T>(borderValue), device);
+    func(stream, input, output, diameter, sigmaColor, sigmaSpace, detail::SaturateCast<T>(borderValue), device);
 }
 
 void BilateralFilter::operator()(hipStream_t stream, const roccv::Tensor &input, const roccv::Tensor &output,
@@ -141,8 +142,10 @@ void BilateralFilter::operator()(hipStream_t stream, const roccv::Tensor &input,
     CHECK_TENSOR_DEVICE(output, device);
 
     // Ensure all tensors are using supported datatypes
-    CHECK_TENSOR_DATATYPES(input, DATA_TYPE_U8, DATA_TYPE_S8, DATA_TYPE_U16, DATA_TYPE_S16, DATA_TYPE_U32, DATA_TYPE_S32, DATA_TYPE_F32, DATA_TYPE_F64);
-    CHECK_TENSOR_DATATYPES(output, DATA_TYPE_U8, DATA_TYPE_S8, DATA_TYPE_U16, DATA_TYPE_S16, DATA_TYPE_U32, DATA_TYPE_S32, DATA_TYPE_F32, DATA_TYPE_F64);
+    CHECK_TENSOR_DATATYPES(input, DATA_TYPE_U8, DATA_TYPE_S8, DATA_TYPE_U16, DATA_TYPE_S16, DATA_TYPE_U32,
+                           DATA_TYPE_S32, DATA_TYPE_F32, DATA_TYPE_F64);
+    CHECK_TENSOR_DATATYPES(output, DATA_TYPE_U8, DATA_TYPE_S8, DATA_TYPE_U16, DATA_TYPE_S16, DATA_TYPE_U32,
+                           DATA_TYPE_S32, DATA_TYPE_F32, DATA_TYPE_F64);
 
     // Ensure all tensors are using supported layouts.
     CHECK_TENSOR_LAYOUT(input, TENSOR_LAYOUT_NHWC, TENSOR_LAYOUT_HWC);

--- a/src/op_copy_make_border.cpp
+++ b/src/op_copy_make_border.cpp
@@ -78,7 +78,7 @@ void dispatch_copy_make_border(hipStream_t stream, const Tensor& input, const Te
     }
 
     auto func = funcs.at(border_mode);
-    func(stream, input, output, top, left, detail::RangeCast<T>(border_value), device);
+    func(stream, input, output, top, left, detail::SaturateCast<T>(border_value), device);
 }
 
 void CopyMakeBorder::operator()(hipStream_t stream, const Tensor& input, const Tensor& output, int32_t top,

--- a/src/op_remap.cpp
+++ b/src/op_remap.cpp
@@ -128,7 +128,7 @@ void dispatch_remap_dtype(hipStream_t stream, const Tensor &input, const Tensor 
 
     auto func = funcs.at(borderType);
     func(stream, input, output, map, inInterpolation, mapInterpolation, mapValueType, alignCorners,
-         detail::RangeCast<T>(borderValue), device);
+         detail::SaturateCast<T>(borderValue), device);
 }
 
 void Remap::operator()(hipStream_t stream, const Tensor &input, const Tensor &output, const Tensor &map,
@@ -154,9 +154,9 @@ void Remap::operator()(hipStream_t stream, const Tensor &input, const Tensor &ou
     CHECK_TENSOR_COMPARISON(input.layout() == output.layout());
     CHECK_TENSOR_COMPARISON(input.shape() == output.shape());
     CHECK_TENSOR_COMPARISON(map.layout() == output.layout());
-    
+
     // If the input tensor has a batch index, check that the input and map batch sizes are the same
-    if(input.layout().batch_index() != -1) { 
+    if (input.layout().batch_index() != -1) {
         CHECK_TENSOR_COMPARISON(input.shape(input.layout().batch_index()) == map.shape(map.layout().batch_index()));
     }
     CHECK_TENSOR_COMPARISON(input.shape(input.layout().width_index()) == map.shape(map.layout().width_index()));

--- a/src/op_rotate.cpp
+++ b/src/op_rotate.cpp
@@ -52,7 +52,7 @@ void dispatch_rotate_interp(hipStream_t stream, const Tensor &input, const Tenso
     // Wrap in a kernel-friendly fixed size array to ensure the affine matrix gets transferred to the device properly.
     ArrayWrapper<double, 6> matWrap(mat);
 
-    T borderVal = detail::RangeCast<T>(make_float4(0.0f, 0.0f, 0.0f, 0.0f));
+    T borderVal = detail::SaturateCast<T>(make_float4(0.0f, 0.0f, 0.0f, 0.0f));
 
     ImageWrapper<T> outputWrap(output);
     InterpolationWrapper<T, eBorderType::BORDER_TYPE_CONSTANT, InterpType> inputWrap(input, borderVal);

--- a/src/op_warp_perspective.cpp
+++ b/src/op_warp_perspective.cpp
@@ -98,7 +98,7 @@ void dispatch_warp_perspective_dtype(hipStream_t stream, const Tensor &input, co
     }
 
     auto func = funcs.at(borderType);
-    func(stream, input, output, transMatrix, interpolation, detail::RangeCast<T>(borderValue), device);
+    func(stream, input, output, transMatrix, interpolation, detail::SaturateCast<T>(borderValue), device);
 }
 
 void WarpPerspective::operator()(hipStream_t stream, const Tensor &input, const Tensor &output,

--- a/tests/roccv/cpp/test_border_wrapper.cpp
+++ b/tests/roccv/cpp/test_border_wrapper.cpp
@@ -143,7 +143,7 @@ void TestCorrectness(float4 borderValue, int32_t batchSize, Size2D imageSize, in
         batchSize * (imageSize.w + borderRadius * 2) * (imageSize.h + borderRadius * 2) * channels;
 
     // Convert borderValue to the same type as the image pixels
-    T borderVal = detail::RangeCast<T>(borderValue);
+    T borderVal = detail::SaturateCast<T>(borderValue);
 
     // Generate synthetic data
     std::vector<BT> inputData(numElements);

--- a/tests/roccv/cpp/test_op_bilateral_filter.cpp
+++ b/tests/roccv/cpp/test_op_bilateral_filter.cpp
@@ -22,10 +22,11 @@ THE SOFTWARE.
 
 #include <core/detail/casting.hpp>
 #include <core/detail/type_traits.hpp>
-#include <core/wrappers/image_wrapper.hpp>
-#include <core/wrappers/border_wrapper.hpp>
 #include <core/detail/vector_utils.hpp>
+#include <core/wrappers/border_wrapper.hpp>
+#include <core/wrappers/image_wrapper.hpp>
 #include <op_bilateral_filter.hpp>
+
 #include "test_helpers.hpp"
 
 using namespace roccv;
@@ -48,7 +49,8 @@ namespace {
  * @return None.
  */
 template <typename T, eBorderType borderMode, typename BT = detail::BaseType<T>>
-void GenerateGoldenBilateral(std::vector<BT>& input, std::vector<BT>& output, int32_t batchSize, Size2D imageSize, int diameter, float sigmaColor, float sigmaSpace, T borderValue) {
+void GenerateGoldenBilateral(std::vector<BT>& input, std::vector<BT>& output, int32_t batchSize, Size2D imageSize,
+                             int diameter, float sigmaColor, float sigmaSpace, T borderValue) {
     BorderWrapper<T, borderMode> src(ImageWrapper<T>(input, batchSize, imageSize.w, imageSize.h), borderValue);
     ImageWrapper<T> dst(output, batchSize, imageSize.w, imageSize.h);
     using namespace roccv::detail;
@@ -122,7 +124,8 @@ void GenerateGoldenBilateral(std::vector<BT>& input, std::vector<BT>& output, in
  * @param[in] device Device this correctness test should be run on.
  */
 template <typename T, eBorderType BorderMode, typename BT = detail::BaseType<T>>
-void TestCorrectness(int batchSize, int width, int height, ImageFormat format, int diameter, float sigmaColor, float sigmaSpace, float4 borderColor, eDeviceType device) {
+void TestCorrectness(int batchSize, int width, int height, ImageFormat format, int diameter, float sigmaColor,
+                     float sigmaSpace, float4 borderColor, eDeviceType device) {
     // Create input and output tensor based on test parameters
     Tensor input(batchSize, {width, height}, format, device);
     Tensor output(batchSize, {width, height}, format, device);
@@ -152,141 +155,224 @@ void TestCorrectness(int batchSize, int width, int height, ImageFormat format, i
 
     // Calculate golden reference
     std::vector<BT> refData(output.shape().size());
-    GenerateGoldenBilateral<T, BorderMode>(inputData, refData, batchSize, {width, height}, diameter, sigmaColor, sigmaSpace, detail::RangeCast<T>(borderColor));
+    GenerateGoldenBilateral<T, BorderMode>(inputData, refData, batchSize, {width, height}, diameter, sigmaColor,
+                                           sigmaSpace, detail::SaturateCast<T>(borderColor));
 
     // Compare data in actual output versus the generated golden reference image
     CompareVectorsNear(outputData, refData, 1);
 }
 
-}
+}  // namespace
 
-eTestStatusType test_op_bilateral_filter(int argc, char **argv) {
+eTestStatusType test_op_bilateral_filter(int argc, char** argv) {
     TEST_CASES_BEGIN();
 
     // GPU correctness tests
-    TEST_CASE((TestCorrectness<uchar, BORDER_TYPE_CONSTANT>(1, 20, 20, FMT_U8, 4, 50.0f, 3.0f, {0.0, 0.0, 0.0, 0.0}, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<uchar, BORDER_TYPE_REPLICATE>(4, 20, 20, FMT_U8, 4, 50.0f, 3.0f, {0.0, 0.0, 0.0, 0.0}, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<uchar, BORDER_TYPE_CONSTANT>(1, 20, 20, FMT_U8, 4, 50.0f, 3.0f, {0.0, 0.0, 0.0, 0.0},
+                                                            eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<uchar, BORDER_TYPE_REPLICATE>(4, 20, 20, FMT_U8, 4, 50.0f, 3.0f, {0.0, 0.0, 0.0, 0.0},
+                                                             eDeviceType::GPU)));
 
-    TEST_CASE((TestCorrectness<uchar3, BORDER_TYPE_CONSTANT>(1, 20, 20, FMT_RGB8, 4, 50.0f, 3.0f, {0.0, 0.0, 0.0, 0.0}, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<uchar3, BORDER_TYPE_REFLECT>(2, 20, 20, FMT_RGB8, 4, 50.0f, 5.0f, {100.0, 100.0, 0.0, 0.0}, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<uchar3, BORDER_TYPE_CONSTANT>(1, 20, 20, FMT_RGB8, 4, 50.0f, 3.0f, {0.0, 0.0, 0.0, 0.0},
+                                                             eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<uchar3, BORDER_TYPE_REFLECT>(2, 20, 20, FMT_RGB8, 4, 50.0f, 5.0f,
+                                                            {100.0, 100.0, 0.0, 0.0}, eDeviceType::GPU)));
 
-    TEST_CASE((TestCorrectness<uchar4, BORDER_TYPE_WRAP>(1, 10, 10, FMT_RGBA8, 5, 50.0f, 4.0f, {0.0, 0.0, 0.0, 0.0}, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<uchar4, BORDER_TYPE_REPLICATE>(5, 64, 64, FMT_RGBA8, 5, 50.0f, 4.0f, {0.0, 0.0, 0.0, 0.0}, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<uchar4, BORDER_TYPE_WRAP>(1, 10, 10, FMT_RGBA8, 5, 50.0f, 4.0f, {0.0, 0.0, 0.0, 0.0},
+                                                         eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<uchar4, BORDER_TYPE_REPLICATE>(5, 64, 64, FMT_RGBA8, 5, 50.0f, 4.0f,
+                                                              {0.0, 0.0, 0.0, 0.0}, eDeviceType::GPU)));
 
-    TEST_CASE((TestCorrectness<char1, BORDER_TYPE_CONSTANT>(1, 20, 20, FMT_S8, 4, 50.0f, 3.0f, {100.0, 0.0, 100.0, 0.0}, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<char1, BORDER_TYPE_WRAP>(3, 30, 20, FMT_S8, 4, 50.0f, 3.0f, {100.0, 0.0, 100.0, 0.0}, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<char1, BORDER_TYPE_CONSTANT>(1, 20, 20, FMT_S8, 4, 50.0f, 3.0f, {100.0, 0.0, 100.0, 0.0},
+                                                            eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<char1, BORDER_TYPE_WRAP>(3, 30, 20, FMT_S8, 4, 50.0f, 3.0f, {100.0, 0.0, 100.0, 0.0},
+                                                        eDeviceType::GPU)));
 
-    TEST_CASE((TestCorrectness<char3, BORDER_TYPE_REPLICATE>(2, 22, 24, FMT_RGBs8, 5, 60.0f, 3.0f, {100.0, 0.0, 100.0, 0.0}, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<char3, BORDER_TYPE_WRAP>(5, 32, 24, FMT_RGBs8, 5, 60.0f, 5.0f, {100.0, 0.0, 100.0, 0.0}, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<char3, BORDER_TYPE_REPLICATE>(2, 22, 24, FMT_RGBs8, 5, 60.0f, 3.0f,
+                                                             {100.0, 0.0, 100.0, 0.0}, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<char3, BORDER_TYPE_WRAP>(5, 32, 24, FMT_RGBs8, 5, 60.0f, 5.0f, {100.0, 0.0, 100.0, 0.0},
+                                                        eDeviceType::GPU)));
 
-    TEST_CASE((TestCorrectness<char4, BORDER_TYPE_REFLECT>(1, 64, 24, FMT_RGBAs8, 5, 60.0f, 3.0f, {100.0, 0.0, 100.0, 0.0}, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<char4, BORDER_TYPE_CONSTANT>(5, 64, 24, FMT_RGBAs8, 5, 60.0f, 3.0f, {100.0, 100.0, 100.0, 0.0}, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<char4, BORDER_TYPE_REFLECT>(1, 64, 24, FMT_RGBAs8, 5, 60.0f, 3.0f,
+                                                           {100.0, 0.0, 100.0, 0.0}, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<char4, BORDER_TYPE_CONSTANT>(5, 64, 24, FMT_RGBAs8, 5, 60.0f, 3.0f,
+                                                            {100.0, 100.0, 100.0, 0.0}, eDeviceType::GPU)));
 
-    TEST_CASE((TestCorrectness<ushort1, BORDER_TYPE_CONSTANT>(1, 20, 20, FMT_U16, 4, 500.0f, 3.0f, {0.0, 0.0, 0.0, 0.0}, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<ushort1, BORDER_TYPE_REFLECT>(2, 20, 20, FMT_U16, 4, 500.0f, 3.0f, {0.0, 0.0, 0.0, 0.0}, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<ushort1, BORDER_TYPE_CONSTANT>(1, 20, 20, FMT_U16, 4, 500.0f, 3.0f, {0.0, 0.0, 0.0, 0.0},
+                                                              eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<ushort1, BORDER_TYPE_REFLECT>(2, 20, 20, FMT_U16, 4, 500.0f, 3.0f, {0.0, 0.0, 0.0, 0.0},
+                                                             eDeviceType::GPU)));
 
-    TEST_CASE((TestCorrectness<ushort3, BORDER_TYPE_CONSTANT>(1, 20, 20, FMT_RGB16, 4, 500.0f, 3.0f, {500.0, 600.0, 0.0, 0.0}, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<ushort3, BORDER_TYPE_REFLECT>(2, 20, 20, FMT_RGB16, 4, 500.0f, 3.0f, {0.0, 0.0, 0.0, 0.0}, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<ushort3, BORDER_TYPE_CONSTANT>(1, 20, 20, FMT_RGB16, 4, 500.0f, 3.0f,
+                                                              {500.0, 600.0, 0.0, 0.0}, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<ushort3, BORDER_TYPE_REFLECT>(2, 20, 20, FMT_RGB16, 4, 500.0f, 3.0f,
+                                                             {0.0, 0.0, 0.0, 0.0}, eDeviceType::GPU)));
 
-    TEST_CASE((TestCorrectness<ushort4, BORDER_TYPE_REFLECT>(1, 20, 20, FMT_RGBA16, 4, 600.0f, 3.0f, {500.0, 600.0, 0.0, 0.0}, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<ushort4, BORDER_TYPE_WRAP>(2, 20, 20, FMT_RGBA16, 4, 500.0f, 3.0f, {0.0, 0.0, 0.0, 0.0}, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<ushort4, BORDER_TYPE_REFLECT>(1, 20, 20, FMT_RGBA16, 4, 600.0f, 3.0f,
+                                                             {500.0, 600.0, 0.0, 0.0}, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<ushort4, BORDER_TYPE_WRAP>(2, 20, 20, FMT_RGBA16, 4, 500.0f, 3.0f, {0.0, 0.0, 0.0, 0.0},
+                                                          eDeviceType::GPU)));
 
-    TEST_CASE((TestCorrectness<short1, BORDER_TYPE_CONSTANT>(1, 20, 20, FMT_S16, 4, 500.0f, 3.0f, {500.0, 500.0, 0.0, 0.0}, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<short1, BORDER_TYPE_REFLECT>(3, 20, 20, FMT_S16, 4, 500.0f, 3.0f, {500.0, 500.0, 0.0, 0.0}, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<short1, BORDER_TYPE_CONSTANT>(1, 20, 20, FMT_S16, 4, 500.0f, 3.0f,
+                                                             {500.0, 500.0, 0.0, 0.0}, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<short1, BORDER_TYPE_REFLECT>(3, 20, 20, FMT_S16, 4, 500.0f, 3.0f,
+                                                            {500.0, 500.0, 0.0, 0.0}, eDeviceType::GPU)));
 
-    TEST_CASE((TestCorrectness<uint1, BORDER_TYPE_CONSTANT>(1, 20, 20, FMT_U32, 4, 500.0f, 3.0f, {500.0, 500.0, 0.0, 0.0}, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<uint1, BORDER_TYPE_REPLICATE>(2, 24, 16, FMT_U32, 4, 500.0f, 3.0f, {500.0, 500.0, 0.0, 0.0}, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<uint1, BORDER_TYPE_CONSTANT>(1, 20, 20, FMT_U32, 4, 500.0f, 3.0f,
+                                                            {500.0, 500.0, 0.0, 0.0}, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<uint1, BORDER_TYPE_REPLICATE>(2, 24, 16, FMT_U32, 4, 500.0f, 3.0f,
+                                                             {500.0, 500.0, 0.0, 0.0}, eDeviceType::GPU)));
 
-    TEST_CASE((TestCorrectness<uint3, BORDER_TYPE_CONSTANT>(1, 20, 20, FMT_RGB32, 4, 500.0f, 3.0f, {500.0, 500.0, 0.0, 0.0}, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<uint3, BORDER_TYPE_WRAP>(2, 24, 16, FMT_RGB32, 4, 500.0f, 3.0f, {500.0, 500.0, 0.0, 0.0}, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<uint3, BORDER_TYPE_CONSTANT>(1, 20, 20, FMT_RGB32, 4, 500.0f, 3.0f,
+                                                            {500.0, 500.0, 0.0, 0.0}, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<uint3, BORDER_TYPE_WRAP>(2, 24, 16, FMT_RGB32, 4, 500.0f, 3.0f, {500.0, 500.0, 0.0, 0.0},
+                                                        eDeviceType::GPU)));
 
-    TEST_CASE((TestCorrectness<uint4, BORDER_TYPE_REPLICATE>(1, 20, 20, FMT_RGBA32, 4, 500.0f, 3.0f, {500.0, 500.0, 0.0, 0.0}, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<uint4, BORDER_TYPE_WRAP>(2, 24, 16, FMT_RGBA32, 4, 500.0f, 3.0f, {500.0, 500.0, 0.0, 0.0}, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<uint4, BORDER_TYPE_REPLICATE>(1, 20, 20, FMT_RGBA32, 4, 500.0f, 3.0f,
+                                                             {500.0, 500.0, 0.0, 0.0}, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<uint4, BORDER_TYPE_WRAP>(2, 24, 16, FMT_RGBA32, 4, 500.0f, 3.0f,
+                                                        {500.0, 500.0, 0.0, 0.0}, eDeviceType::GPU)));
 
-    TEST_CASE((TestCorrectness<int1, BORDER_TYPE_CONSTANT>(1, 32, 32, FMT_S32, 4, 500.0f, 3.0f, {500.0, 500.0, 0.0, 0.0}, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<int1, BORDER_TYPE_WRAP>(2, 32, 32, FMT_S32, 4, 500.0f, 3.0f, {500.0, 500.0, 0.0, 0.0}, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<int1, BORDER_TYPE_CONSTANT>(1, 32, 32, FMT_S32, 4, 500.0f, 3.0f,
+                                                           {500.0, 500.0, 0.0, 0.0}, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<int1, BORDER_TYPE_WRAP>(2, 32, 32, FMT_S32, 4, 500.0f, 3.0f, {500.0, 500.0, 0.0, 0.0},
+                                                       eDeviceType::GPU)));
 
-    TEST_CASE((TestCorrectness<float1, BORDER_TYPE_REPLICATE>(1, 24, 24, FMT_F32, 4, 500.0f, 3.0f, {500.0, 500.0, 0.0, 0.0}, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<float1, BORDER_TYPE_WRAP>(2, 24, 24, FMT_F32, 4, 600.0f, 3.0f, {500.0, 500.0, 0.0, 0.0}, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<float1, BORDER_TYPE_REPLICATE>(1, 24, 24, FMT_F32, 4, 500.0f, 3.0f,
+                                                              {500.0, 500.0, 0.0, 0.0}, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<float1, BORDER_TYPE_WRAP>(2, 24, 24, FMT_F32, 4, 600.0f, 3.0f, {500.0, 500.0, 0.0, 0.0},
+                                                         eDeviceType::GPU)));
 
-    TEST_CASE((TestCorrectness<float3, BORDER_TYPE_REPLICATE>(1, 24, 24, FMT_RGBf32, 4, 500.0f, 3.0f, {500.0, 500.0, 0.0, 0.0}, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<float3, BORDER_TYPE_WRAP>(2, 24, 24, FMT_RGBf32, 4, 600.0f, 3.0f, {500.0, 500.0, 0.0, 0.0}, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<float3, BORDER_TYPE_REPLICATE>(1, 24, 24, FMT_RGBf32, 4, 500.0f, 3.0f,
+                                                              {500.0, 500.0, 0.0, 0.0}, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<float3, BORDER_TYPE_WRAP>(2, 24, 24, FMT_RGBf32, 4, 600.0f, 3.0f,
+                                                         {500.0, 500.0, 0.0, 0.0}, eDeviceType::GPU)));
 
-    TEST_CASE((TestCorrectness<float4, BORDER_TYPE_REPLICATE>(1, 24, 24, FMT_RGBAf32, 4, 500.0f, 3.0f, {500.0, 500.0, 0.0, 0.0}, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<float4, BORDER_TYPE_WRAP>(2, 24, 24, FMT_RGBAf32, 4, 600.0f, 3.0f, {500.0, 500.0, 0.0, 0.0}, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<float4, BORDER_TYPE_REPLICATE>(1, 24, 24, FMT_RGBAf32, 4, 500.0f, 3.0f,
+                                                              {500.0, 500.0, 0.0, 0.0}, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<float4, BORDER_TYPE_WRAP>(2, 24, 24, FMT_RGBAf32, 4, 600.0f, 3.0f,
+                                                         {500.0, 500.0, 0.0, 0.0}, eDeviceType::GPU)));
 
-    TEST_CASE((TestCorrectness<double1, BORDER_TYPE_REPLICATE>(1, 24, 24, FMT_F64, 4, 500.0f, 3.0f, {500.0, 500.0, 0.0, 0.0}, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<double1, BORDER_TYPE_WRAP>(2, 24, 24, FMT_F64, 4, 600.0f, 3.0f, {500.0, 500.0, 0.0, 0.0}, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<double1, BORDER_TYPE_REPLICATE>(1, 24, 24, FMT_F64, 4, 500.0f, 3.0f,
+                                                               {500.0, 500.0, 0.0, 0.0}, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<double1, BORDER_TYPE_WRAP>(2, 24, 24, FMT_F64, 4, 600.0f, 3.0f, {500.0, 500.0, 0.0, 0.0},
+                                                          eDeviceType::GPU)));
 
-    TEST_CASE((TestCorrectness<double3, BORDER_TYPE_REPLICATE>(1, 24, 24, FMT_RGBf64, 4, 500.0f, 3.0f, {500.0, 500.0, 0.0, 0.0}, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<double3, BORDER_TYPE_WRAP>(2, 24, 24, FMT_RGBf64, 4, 600.0f, 3.0f, {500.0, 500.0, 0.0, 0.0}, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<double3, BORDER_TYPE_REPLICATE>(1, 24, 24, FMT_RGBf64, 4, 500.0f, 3.0f,
+                                                               {500.0, 500.0, 0.0, 0.0}, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<double3, BORDER_TYPE_WRAP>(2, 24, 24, FMT_RGBf64, 4, 600.0f, 3.0f,
+                                                          {500.0, 500.0, 0.0, 0.0}, eDeviceType::GPU)));
 
-    TEST_CASE((TestCorrectness<double4, BORDER_TYPE_REPLICATE>(1, 24, 24, FMT_RGBAf64, 4, 500.0f, 3.0f, {500.0, 500.0, 0.0, 0.0}, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<double4, BORDER_TYPE_WRAP>(2, 24, 24, FMT_RGBAf64, 4, 600.0f, 3.0f, {500.0, 500.0, 0.0, 0.0}, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<double4, BORDER_TYPE_REPLICATE>(1, 24, 24, FMT_RGBAf64, 4, 500.0f, 3.0f,
+                                                               {500.0, 500.0, 0.0, 0.0}, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<double4, BORDER_TYPE_WRAP>(2, 24, 24, FMT_RGBAf64, 4, 600.0f, 3.0f,
+                                                          {500.0, 500.0, 0.0, 0.0}, eDeviceType::GPU)));
 
     // CPU correctness tests
-    TEST_CASE((TestCorrectness<uchar, BORDER_TYPE_CONSTANT>(1, 20, 20, FMT_U8, 4, 50.0f, 3.0f, {0.0, 0.0, 0.0, 0.0}, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<uchar, BORDER_TYPE_REPLICATE>(4, 20, 20, FMT_U8, 4, 50.0f, 3.0f, {0.0, 0.0, 0.0, 0.0}, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uchar, BORDER_TYPE_CONSTANT>(1, 20, 20, FMT_U8, 4, 50.0f, 3.0f, {0.0, 0.0, 0.0, 0.0},
+                                                            eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uchar, BORDER_TYPE_REPLICATE>(4, 20, 20, FMT_U8, 4, 50.0f, 3.0f, {0.0, 0.0, 0.0, 0.0},
+                                                             eDeviceType::CPU)));
 
-    TEST_CASE((TestCorrectness<uchar3, BORDER_TYPE_CONSTANT>(1, 20, 20, FMT_RGB8, 4, 50.0f, 3.0f, {0.0, 0.0, 0.0, 0.0}, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<uchar3, BORDER_TYPE_REFLECT>(2, 20, 20, FMT_RGB8, 4, 50.0f, 5.0f, {100.0, 100.0, 0.0, 0.0}, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uchar3, BORDER_TYPE_CONSTANT>(1, 20, 20, FMT_RGB8, 4, 50.0f, 3.0f, {0.0, 0.0, 0.0, 0.0},
+                                                             eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uchar3, BORDER_TYPE_REFLECT>(2, 20, 20, FMT_RGB8, 4, 50.0f, 5.0f,
+                                                            {100.0, 100.0, 0.0, 0.0}, eDeviceType::CPU)));
 
-    TEST_CASE((TestCorrectness<uchar4, BORDER_TYPE_WRAP>(1, 10, 10, FMT_RGBA8, 5, 50.0f, 4.0f, {0.0, 0.0, 0.0, 0.0}, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<uchar4, BORDER_TYPE_REPLICATE>(5, 64, 64, FMT_RGBA8, 5, 50.0f, 4.0f, {0.0, 0.0, 0.0, 0.0}, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uchar4, BORDER_TYPE_WRAP>(1, 10, 10, FMT_RGBA8, 5, 50.0f, 4.0f, {0.0, 0.0, 0.0, 0.0},
+                                                         eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uchar4, BORDER_TYPE_REPLICATE>(5, 64, 64, FMT_RGBA8, 5, 50.0f, 4.0f,
+                                                              {0.0, 0.0, 0.0, 0.0}, eDeviceType::CPU)));
 
-    TEST_CASE((TestCorrectness<char1, BORDER_TYPE_CONSTANT>(1, 20, 20, FMT_S8, 4, 50.0f, 3.0f, {100.0, 0.0, 100.0, 0.0}, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<char1, BORDER_TYPE_WRAP>(3, 30, 20, FMT_S8, 4, 50.0f, 3.0f, {100.0, 0.0, 100.0, 0.0}, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<char1, BORDER_TYPE_CONSTANT>(1, 20, 20, FMT_S8, 4, 50.0f, 3.0f, {100.0, 0.0, 100.0, 0.0},
+                                                            eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<char1, BORDER_TYPE_WRAP>(3, 30, 20, FMT_S8, 4, 50.0f, 3.0f, {100.0, 0.0, 100.0, 0.0},
+                                                        eDeviceType::CPU)));
 
-    TEST_CASE((TestCorrectness<char3, BORDER_TYPE_REPLICATE>(2, 22, 24, FMT_RGBs8, 5, 60.0f, 3.0f, {100.0, 0.0, 100.0, 0.0}, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<char3, BORDER_TYPE_WRAP>(5, 32, 24, FMT_RGBs8, 5, 60.0f, 5.0f, {100.0, 0.0, 100.0, 0.0}, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<char3, BORDER_TYPE_REPLICATE>(2, 22, 24, FMT_RGBs8, 5, 60.0f, 3.0f,
+                                                             {100.0, 0.0, 100.0, 0.0}, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<char3, BORDER_TYPE_WRAP>(5, 32, 24, FMT_RGBs8, 5, 60.0f, 5.0f, {100.0, 0.0, 100.0, 0.0},
+                                                        eDeviceType::CPU)));
 
-    TEST_CASE((TestCorrectness<char4, BORDER_TYPE_REFLECT>(1, 64, 24, FMT_RGBAs8, 5, 60.0f, 3.0f, {100.0, 0.0, 100.0, 0.0}, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<char4, BORDER_TYPE_CONSTANT>(5, 64, 24, FMT_RGBAs8, 5, 60.0f, 3.0f, {100.0, 100.0, 100.0, 0.0}, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<char4, BORDER_TYPE_REFLECT>(1, 64, 24, FMT_RGBAs8, 5, 60.0f, 3.0f,
+                                                           {100.0, 0.0, 100.0, 0.0}, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<char4, BORDER_TYPE_CONSTANT>(5, 64, 24, FMT_RGBAs8, 5, 60.0f, 3.0f,
+                                                            {100.0, 100.0, 100.0, 0.0}, eDeviceType::CPU)));
 
-    TEST_CASE((TestCorrectness<ushort1, BORDER_TYPE_CONSTANT>(1, 20, 20, FMT_U16, 4, 500.0f, 3.0f, {0.0, 0.0, 0.0, 0.0}, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<ushort1, BORDER_TYPE_REFLECT>(2, 20, 20, FMT_U16, 4, 500.0f, 3.0f, {0.0, 0.0, 0.0, 0.0}, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<ushort1, BORDER_TYPE_CONSTANT>(1, 20, 20, FMT_U16, 4, 500.0f, 3.0f, {0.0, 0.0, 0.0, 0.0},
+                                                              eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<ushort1, BORDER_TYPE_REFLECT>(2, 20, 20, FMT_U16, 4, 500.0f, 3.0f, {0.0, 0.0, 0.0, 0.0},
+                                                             eDeviceType::CPU)));
 
-    TEST_CASE((TestCorrectness<ushort3, BORDER_TYPE_CONSTANT>(1, 20, 20, FMT_RGB16, 4, 500.0f, 3.0f, {500.0, 600.0, 0.0, 0.0}, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<ushort3, BORDER_TYPE_REFLECT>(2, 20, 20, FMT_RGB16, 4, 500.0f, 3.0f, {0.0, 0.0, 0.0, 0.0}, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<ushort3, BORDER_TYPE_CONSTANT>(1, 20, 20, FMT_RGB16, 4, 500.0f, 3.0f,
+                                                              {500.0, 600.0, 0.0, 0.0}, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<ushort3, BORDER_TYPE_REFLECT>(2, 20, 20, FMT_RGB16, 4, 500.0f, 3.0f,
+                                                             {0.0, 0.0, 0.0, 0.0}, eDeviceType::CPU)));
 
-    TEST_CASE((TestCorrectness<ushort4, BORDER_TYPE_REFLECT>(1, 20, 20, FMT_RGBA16, 4, 600.0f, 3.0f, {500.0, 600.0, 0.0, 0.0}, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<ushort4, BORDER_TYPE_WRAP>(2, 20, 20, FMT_RGBA16, 4, 500.0f, 3.0f, {0.0, 0.0, 0.0, 0.0}, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<ushort4, BORDER_TYPE_REFLECT>(1, 20, 20, FMT_RGBA16, 4, 600.0f, 3.0f,
+                                                             {500.0, 600.0, 0.0, 0.0}, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<ushort4, BORDER_TYPE_WRAP>(2, 20, 20, FMT_RGBA16, 4, 500.0f, 3.0f, {0.0, 0.0, 0.0, 0.0},
+                                                          eDeviceType::CPU)));
 
-    TEST_CASE((TestCorrectness<short1, BORDER_TYPE_CONSTANT>(1, 20, 20, FMT_S16, 4, 500.0f, 3.0f, {500.0, 500.0, 0.0, 0.0}, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<short1, BORDER_TYPE_REFLECT>(3, 20, 20, FMT_S16, 4, 500.0f, 3.0f, {500.0, 500.0, 0.0, 0.0}, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<short1, BORDER_TYPE_CONSTANT>(1, 20, 20, FMT_S16, 4, 500.0f, 3.0f,
+                                                             {500.0, 500.0, 0.0, 0.0}, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<short1, BORDER_TYPE_REFLECT>(3, 20, 20, FMT_S16, 4, 500.0f, 3.0f,
+                                                            {500.0, 500.0, 0.0, 0.0}, eDeviceType::CPU)));
 
-    TEST_CASE((TestCorrectness<uint1, BORDER_TYPE_CONSTANT>(1, 20, 20, FMT_U32, 4, 500.0f, 3.0f, {500.0, 500.0, 0.0, 0.0}, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<uint1, BORDER_TYPE_REPLICATE>(2, 24, 16, FMT_U32, 4, 500.0f, 3.0f, {500.0, 500.0, 0.0, 0.0}, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uint1, BORDER_TYPE_CONSTANT>(1, 20, 20, FMT_U32, 4, 500.0f, 3.0f,
+                                                            {500.0, 500.0, 0.0, 0.0}, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uint1, BORDER_TYPE_REPLICATE>(2, 24, 16, FMT_U32, 4, 500.0f, 3.0f,
+                                                             {500.0, 500.0, 0.0, 0.0}, eDeviceType::CPU)));
 
-    TEST_CASE((TestCorrectness<uint3, BORDER_TYPE_CONSTANT>(1, 20, 20, FMT_RGB32, 4, 500.0f, 3.0f, {500.0, 500.0, 0.0, 0.0}, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<uint3, BORDER_TYPE_WRAP>(2, 24, 16, FMT_RGB32, 4, 500.0f, 3.0f, {500.0, 500.0, 0.0, 0.0}, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uint3, BORDER_TYPE_CONSTANT>(1, 20, 20, FMT_RGB32, 4, 500.0f, 3.0f,
+                                                            {500.0, 500.0, 0.0, 0.0}, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uint3, BORDER_TYPE_WRAP>(2, 24, 16, FMT_RGB32, 4, 500.0f, 3.0f, {500.0, 500.0, 0.0, 0.0},
+                                                        eDeviceType::CPU)));
 
-    TEST_CASE((TestCorrectness<uint4, BORDER_TYPE_REFLECT>(1, 20, 20, FMT_RGBA32, 4, 500.0f, 3.0f, {500.0, 500.0, 0.0, 0.0}, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<uint4, BORDER_TYPE_WRAP>(2, 24, 16, FMT_RGBA32, 4, 500.0f, 3.0f, {500.0, 500.0, 0.0, 0.0}, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uint4, BORDER_TYPE_REFLECT>(1, 20, 20, FMT_RGBA32, 4, 500.0f, 3.0f,
+                                                           {500.0, 500.0, 0.0, 0.0}, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uint4, BORDER_TYPE_WRAP>(2, 24, 16, FMT_RGBA32, 4, 500.0f, 3.0f,
+                                                        {500.0, 500.0, 0.0, 0.0}, eDeviceType::CPU)));
 
-    TEST_CASE((TestCorrectness<int1, BORDER_TYPE_CONSTANT>(1, 32, 32, FMT_S32, 4, 500.0f, 3.0f, {500.0, 500.0, 0.0, 0.0}, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<int1, BORDER_TYPE_WRAP>(2, 32, 32, FMT_S32, 4, 500.0f, 3.0f, {500.0, 500.0, 0.0, 0.0}, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<int1, BORDER_TYPE_CONSTANT>(1, 32, 32, FMT_S32, 4, 500.0f, 3.0f,
+                                                           {500.0, 500.0, 0.0, 0.0}, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<int1, BORDER_TYPE_WRAP>(2, 32, 32, FMT_S32, 4, 500.0f, 3.0f, {500.0, 500.0, 0.0, 0.0},
+                                                       eDeviceType::CPU)));
 
-    TEST_CASE((TestCorrectness<float1, BORDER_TYPE_REPLICATE>(1, 24, 24, FMT_F32, 4, 500.0f, 3.0f, {500.0, 500.0, 0.0, 0.0}, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<float1, BORDER_TYPE_WRAP>(2, 24, 24, FMT_F32, 4, 600.0f, 3.0f, {500.0, 500.0, 0.0, 0.0}, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<float1, BORDER_TYPE_REPLICATE>(1, 24, 24, FMT_F32, 4, 500.0f, 3.0f,
+                                                              {500.0, 500.0, 0.0, 0.0}, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<float1, BORDER_TYPE_WRAP>(2, 24, 24, FMT_F32, 4, 600.0f, 3.0f, {500.0, 500.0, 0.0, 0.0},
+                                                         eDeviceType::CPU)));
 
-    TEST_CASE((TestCorrectness<float3, BORDER_TYPE_REPLICATE>(1, 24, 24, FMT_RGBf32, 4, 500.0f, 3.0f, {500.0, 500.0, 0.0, 0.0}, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<float3, BORDER_TYPE_WRAP>(2, 24, 24, FMT_RGBf32, 4, 600.0f, 3.0f, {500.0, 500.0, 0.0, 0.0}, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<float3, BORDER_TYPE_REPLICATE>(1, 24, 24, FMT_RGBf32, 4, 500.0f, 3.0f,
+                                                              {500.0, 500.0, 0.0, 0.0}, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<float3, BORDER_TYPE_WRAP>(2, 24, 24, FMT_RGBf32, 4, 600.0f, 3.0f,
+                                                         {500.0, 500.0, 0.0, 0.0}, eDeviceType::CPU)));
 
-    TEST_CASE((TestCorrectness<float4, BORDER_TYPE_REPLICATE>(1, 24, 24, FMT_RGBAf32, 4, 500.0f, 3.0f, {500.0, 500.0, 0.0, 0.0}, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<float4, BORDER_TYPE_WRAP>(2, 24, 24, FMT_RGBAf32, 4, 600.0f, 3.0f, {500.0, 500.0, 0.0, 0.0}, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<float4, BORDER_TYPE_REPLICATE>(1, 24, 24, FMT_RGBAf32, 4, 500.0f, 3.0f,
+                                                              {500.0, 500.0, 0.0, 0.0}, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<float4, BORDER_TYPE_WRAP>(2, 24, 24, FMT_RGBAf32, 4, 600.0f, 3.0f,
+                                                         {500.0, 500.0, 0.0, 0.0}, eDeviceType::CPU)));
 
-    TEST_CASE((TestCorrectness<double1, BORDER_TYPE_REPLICATE>(1, 24, 24, FMT_F64, 4, 5.0f, 3.0f, {0.0, 500.0, 0.0, 0.0}, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<double1, BORDER_TYPE_WRAP>(2, 24, 24, FMT_F64, 4, 5.0f, 3.0f, {0.0, 500.0, 0.0, 0.0}, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<double1, BORDER_TYPE_REPLICATE>(1, 24, 24, FMT_F64, 4, 5.0f, 3.0f,
+                                                               {0.0, 500.0, 0.0, 0.0}, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<double1, BORDER_TYPE_WRAP>(2, 24, 24, FMT_F64, 4, 5.0f, 3.0f, {0.0, 500.0, 0.0, 0.0},
+                                                          eDeviceType::CPU)));
 
-    TEST_CASE((TestCorrectness<double1, BORDER_TYPE_REPLICATE>(1, 24, 24, FMT_F64, 4, 500.0f, 3.0f, {500.0, 500.0, 0.0, 0.0}, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<double1, BORDER_TYPE_WRAP>(2, 24, 24, FMT_F64, 4, 600.0f, 3.0f, {500.0, 500.0, 0.0, 0.0}, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<double1, BORDER_TYPE_REPLICATE>(1, 24, 24, FMT_F64, 4, 500.0f, 3.0f,
+                                                               {500.0, 500.0, 0.0, 0.0}, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<double1, BORDER_TYPE_WRAP>(2, 24, 24, FMT_F64, 4, 600.0f, 3.0f, {500.0, 500.0, 0.0, 0.0},
+                                                          eDeviceType::CPU)));
 
-    TEST_CASE((TestCorrectness<double3, BORDER_TYPE_REPLICATE>(1, 24, 24, FMT_RGBf64, 4, 500.0f, 3.0f, {500.0, 500.0, 0.0, 0.0}, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<double3, BORDER_TYPE_WRAP>(2, 24, 24, FMT_RGBf64, 4, 600.0f, 3.0f, {500.0, 500.0, 0.0, 0.0}, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<double3, BORDER_TYPE_REPLICATE>(1, 24, 24, FMT_RGBf64, 4, 500.0f, 3.0f,
+                                                               {500.0, 500.0, 0.0, 0.0}, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<double3, BORDER_TYPE_WRAP>(2, 24, 24, FMT_RGBf64, 4, 600.0f, 3.0f,
+                                                          {500.0, 500.0, 0.0, 0.0}, eDeviceType::CPU)));
 
-    TEST_CASE((TestCorrectness<double4, BORDER_TYPE_REPLICATE>(1, 24, 24, FMT_RGBAf64, 4, 500.0f, 3.0f, {500.0, 500.0, 0.0, 0.0}, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<double4, BORDER_TYPE_WRAP>(2, 24, 24, FMT_RGBAf64, 4, 600.0f, 3.0f, {500.0, 500.0, 0.0, 0.0}, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<double4, BORDER_TYPE_REPLICATE>(1, 24, 24, FMT_RGBAf64, 4, 500.0f, 3.0f,
+                                                               {500.0, 500.0, 0.0, 0.0}, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<double4, BORDER_TYPE_WRAP>(2, 24, 24, FMT_RGBAf64, 4, 600.0f, 3.0f,
+                                                          {500.0, 500.0, 0.0, 0.0}, eDeviceType::CPU)));
 
     TEST_CASES_END();
 }

--- a/tests/roccv/cpp/test_op_copy_make_border.cpp
+++ b/tests/roccv/cpp/test_op_copy_make_border.cpp
@@ -23,6 +23,7 @@
 #include <core/wrappers/border_wrapper.hpp>
 #include <op_copy_make_border.hpp>
 
+#include "core/detail/casting.hpp"
 #include "test_helpers.hpp"
 
 using namespace roccv;
@@ -52,7 +53,7 @@ std::vector<BT> GoldenCopyMakeBorder(std::vector<BT> input, int batchSize, Size2
     int channels = detail::NumElements<T>;
 
     // Convert border value into the type of the image
-    T borderVal = detail::RangeCast<T>(borderValue);
+    T borderVal = detail::SaturateCast<T>(borderValue);
 
     // Wrap the input images in a BorderWrapper to handle out of bounds image behavior. The BorderWrapper has already
     // been tested in another test so it can be used reliably.

--- a/tests/roccv/cpp/test_op_remap.cpp
+++ b/tests/roccv/cpp/test_op_remap.cpp
@@ -21,15 +21,15 @@ THE SOFTWARE.
 */
 
 #include <algorithm>
-#include "core/detail/casting.hpp"
-#include "core/detail/type_traits.hpp"
-#include "core/detail/math/vectorized_type_math.hpp"
 #include <core/wrappers/image_wrapper.hpp>
 #include <core/wrappers/interpolation_wrapper.hpp>
 #include <iostream>
 #include <op_remap.hpp>
-#include "operator_types.h"
 
+#include "core/detail/casting.hpp"
+#include "core/detail/math/vectorized_type_math.hpp"
+#include "core/detail/type_traits.hpp"
+#include "operator_types.h"
 #include "test_helpers.hpp"
 
 using namespace roccv;
@@ -54,23 +54,24 @@ namespace {
  * @param[in] borderValue Border value to use as a fallback when going out of bounds.
  * @return Vector containing the results of the operation.
  */
-template <typename T, eBorderType BorderType, eInterpolationType InterpType, eInterpolationType MapInterpType, typename BT = detail::BaseType<T>>
-std::vector<BT> GoldenRemapAbsolute(std::vector<BT>& input, int32_t batchSize, int32_t width, int32_t height, std::vector<float2>& mapData, float4 borderValue) {
-
+template <typename T, eBorderType BorderType, eInterpolationType InterpType, eInterpolationType MapInterpType,
+          typename BT = detail::BaseType<T>>
+std::vector<BT> GoldenRemapAbsolute(std::vector<BT>& input, int32_t batchSize, int32_t width, int32_t height,
+                                    std::vector<float2>& mapData, float4 borderValue) {
     // Create an output vector the same size as the input vector
     std::vector<BT> output(input.size());
 
     // Create interpolation wrapper for input vector
     InterpolationWrapper<T, BorderType, InterpType> src((BorderWrapper<T, BorderType>(
-        ImageWrapper<T>(input, batchSize, width, height), detail::RangeCast<T>(borderValue))));
+        ImageWrapper<T>(input, batchSize, width, height), detail::SaturateCast<T>(borderValue))));
 
     // Wrap the output vector for simplified data access
     ImageWrapper<T> dst(output, batchSize, width, height);
-    
+
     // Create an interpolation wrapper for the map tensor
-    //InterpolationWrapper<float2, BorderType, MapInterpType> wrappedMapTensor(map, make_float2(0, 0));
+    // InterpolationWrapper<float2, BorderType, MapInterpType> wrappedMapTensor(map, make_float2(0, 0));
     InterpolationWrapper<float2, BorderType, MapInterpType> map((BorderWrapper<float2, BorderType>(
-        ImageWrapper<float2>(mapData.data(), batchSize, width, height), detail::RangeCast<float2>(borderValue))));
+        ImageWrapper<float2>(mapData.data(), batchSize, width, height), detail::SaturateCast<float2>(borderValue))));
 
     for (int b = 0; b < batchSize; b++) {
         for (int y = 0; y < height; y++) {
@@ -100,13 +101,14 @@ std::vector<BT> GoldenRemapAbsolute(std::vector<BT>& input, int32_t batchSize, i
  * @param mapType Type of remap to do, REMAP_ABSOLUTE, REMAP_ABSOLUTE_NORMALIZED, REMAP_RELATIVE_NORMALIZED
  * @param device The device to run the roccv::WarpPerspective operator on.
  */
-template <typename T, eBorderType BorderType, eInterpolationType InterpType, eInterpolationType MapInterpType, typename BT = detail::BaseType<T>>
-void TestCorrectness(int batchSize, int width, int height, ImageFormat format, float4 borderValue, eRemapType mapType, eDeviceType device) {
-    
+template <typename T, eBorderType BorderType, eInterpolationType InterpType, eInterpolationType MapInterpType,
+          typename BT = detail::BaseType<T>>
+void TestCorrectness(int batchSize, int width, int height, ImageFormat format, float4 borderValue, eRemapType mapType,
+                     eDeviceType device) {
     // Create input and output tensor based on test parameters
     Tensor input(batchSize, {width, height}, format, device);
     Tensor output(batchSize, {width, height}, format, device);
-    
+
     // Create a vector and fill it with random data.
     std::vector<BT> inputData(input.shape().size());
     FillVector(inputData);
@@ -118,7 +120,7 @@ void TestCorrectness(int batchSize, int width, int height, ImageFormat format, f
     std::vector<float> rowRemapTable;
 
     float halfWidth = width / 2;
-    for (int b = 0; b < batchSize; b++){
+    for (int b = 0; b < batchSize; b++) {
         for (int i = 0; i < height; i++) {
             int j = 0;
             for (; j < halfWidth; j++) {
@@ -136,8 +138,6 @@ void TestCorrectness(int batchSize, int width, int height, ImageFormat format, f
     for (int i = 0; i < rowRemapTable.size(); i++) {
         mapData[i] = make_float2(colRemapTable[i], rowRemapTable[i]);
     }
-
-    
 
     // Create map tensor and fill it with mapData
     TensorShape map_shape(TensorLayout(eTensorLayout::TENSOR_LAYOUT_NHWC), {batchSize, height, width, 2});
@@ -157,7 +157,8 @@ void TestCorrectness(int batchSize, int width, int height, ImageFormat format, f
     std::vector<BT> result(output.shape().size());
     CopyTensorIntoVector(result, output);
 
-    std::vector<BT> ref = GoldenRemapAbsolute<T, BorderType, InterpType, MapInterpType>(inputData, batchSize, width, height, mapData, borderValue);
+    std::vector<BT> ref = GoldenRemapAbsolute<T, BorderType, InterpType, MapInterpType>(inputData, batchSize, width,
+                                                                                        height, mapData, borderValue);
 
     // Compare data in actual output versus the generated golden reference image
     CompareVectors(result, ref);
@@ -167,25 +168,61 @@ void TestCorrectness(int batchSize, int width, int height, ImageFormat format, f
 eTestStatusType test_op_remap(int argc, char** argv) {
     TEST_CASES_BEGIN();
 
-    TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST, eInterpolationType::INTERP_TYPE_NEAREST>(1, 480, 360, FMT_U8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<uchar3, eBorderType::BORDER_TYPE_REPLICATE, eInterpolationType::INTERP_TYPE_NEAREST, eInterpolationType::INTERP_TYPE_LINEAR>(1, 480, 360, FMT_RGB8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<uchar4, eBorderType::BORDER_TYPE_REFLECT, eInterpolationType::INTERP_TYPE_NEAREST, eInterpolationType::INTERP_TYPE_NEAREST>(1, 480, 360, FMT_RGBA8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_WRAP, eInterpolationType::INTERP_TYPE_NEAREST, eInterpolationType::INTERP_TYPE_LINEAR>(3, 480, 360, FMT_U8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<uchar3, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_LINEAR, eInterpolationType::INTERP_TYPE_NEAREST>(1, 480, 360, FMT_RGB8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<uchar4, eBorderType::BORDER_TYPE_REPLICATE, eInterpolationType::INTERP_TYPE_NEAREST, eInterpolationType::INTERP_TYPE_LINEAR>(1, 480, 360, FMT_RGBA8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_REFLECT, eInterpolationType::INTERP_TYPE_LINEAR, eInterpolationType::INTERP_TYPE_NEAREST>(5, 480, 360, FMT_U8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<uchar3, eBorderType::BORDER_TYPE_WRAP, eInterpolationType::INTERP_TYPE_NEAREST, eInterpolationType::INTERP_TYPE_LINEAR>(5, 480, 360, FMT_RGB8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<uchar4, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_LINEAR, eInterpolationType::INTERP_TYPE_NEAREST>(5, 480, 360, FMT_RGBA8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, eDeviceType::GPU)));
-    
-    TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST, eInterpolationType::INTERP_TYPE_NEAREST>(1, 480, 360, FMT_U8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<uchar3, eBorderType::BORDER_TYPE_REPLICATE, eInterpolationType::INTERP_TYPE_NEAREST, eInterpolationType::INTERP_TYPE_LINEAR>(1, 480, 360, FMT_RGB8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<uchar4, eBorderType::BORDER_TYPE_REFLECT, eInterpolationType::INTERP_TYPE_NEAREST, eInterpolationType::INTERP_TYPE_NEAREST>(1, 480, 360, FMT_RGBA8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_WRAP, eInterpolationType::INTERP_TYPE_NEAREST, eInterpolationType::INTERP_TYPE_LINEAR>(3, 480, 360, FMT_U8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<uchar3, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_LINEAR, eInterpolationType::INTERP_TYPE_NEAREST>(3, 480, 360, FMT_RGB8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<uchar4, eBorderType::BORDER_TYPE_REPLICATE, eInterpolationType::INTERP_TYPE_NEAREST, eInterpolationType::INTERP_TYPE_LINEAR>(3, 480, 360, FMT_RGBA8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_REFLECT, eInterpolationType::INTERP_TYPE_LINEAR, eInterpolationType::INTERP_TYPE_NEAREST>(5, 480, 360, FMT_U8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<uchar3, eBorderType::BORDER_TYPE_WRAP, eInterpolationType::INTERP_TYPE_NEAREST, eInterpolationType::INTERP_TYPE_LINEAR>(5, 480, 360, FMT_RGB8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<uchar4, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_LINEAR, eInterpolationType::INTERP_TYPE_NEAREST>(5, 480, 360, FMT_RGBA8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
+                               eInterpolationType::INTERP_TYPE_NEAREST>(
+        1, 480, 360, FMT_U8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<uchar3, eBorderType::BORDER_TYPE_REPLICATE, eInterpolationType::INTERP_TYPE_NEAREST,
+                               eInterpolationType::INTERP_TYPE_LINEAR>(
+        1, 480, 360, FMT_RGB8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<uchar4, eBorderType::BORDER_TYPE_REFLECT, eInterpolationType::INTERP_TYPE_NEAREST,
+                               eInterpolationType::INTERP_TYPE_NEAREST>(
+        1, 480, 360, FMT_RGBA8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_WRAP, eInterpolationType::INTERP_TYPE_NEAREST,
+                               eInterpolationType::INTERP_TYPE_LINEAR>(
+        3, 480, 360, FMT_U8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<uchar3, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_LINEAR,
+                               eInterpolationType::INTERP_TYPE_NEAREST>(
+        1, 480, 360, FMT_RGB8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<uchar4, eBorderType::BORDER_TYPE_REPLICATE, eInterpolationType::INTERP_TYPE_NEAREST,
+                               eInterpolationType::INTERP_TYPE_LINEAR>(
+        1, 480, 360, FMT_RGBA8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_REFLECT, eInterpolationType::INTERP_TYPE_LINEAR,
+                               eInterpolationType::INTERP_TYPE_NEAREST>(
+        5, 480, 360, FMT_U8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<uchar3, eBorderType::BORDER_TYPE_WRAP, eInterpolationType::INTERP_TYPE_NEAREST,
+                               eInterpolationType::INTERP_TYPE_LINEAR>(
+        5, 480, 360, FMT_RGB8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<uchar4, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_LINEAR,
+                               eInterpolationType::INTERP_TYPE_NEAREST>(
+        5, 480, 360, FMT_RGBA8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, eDeviceType::GPU)));
+
+    TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
+                               eInterpolationType::INTERP_TYPE_NEAREST>(
+        1, 480, 360, FMT_U8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uchar3, eBorderType::BORDER_TYPE_REPLICATE, eInterpolationType::INTERP_TYPE_NEAREST,
+                               eInterpolationType::INTERP_TYPE_LINEAR>(
+        1, 480, 360, FMT_RGB8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uchar4, eBorderType::BORDER_TYPE_REFLECT, eInterpolationType::INTERP_TYPE_NEAREST,
+                               eInterpolationType::INTERP_TYPE_NEAREST>(
+        1, 480, 360, FMT_RGBA8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_WRAP, eInterpolationType::INTERP_TYPE_NEAREST,
+                               eInterpolationType::INTERP_TYPE_LINEAR>(
+        3, 480, 360, FMT_U8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uchar3, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_LINEAR,
+                               eInterpolationType::INTERP_TYPE_NEAREST>(
+        3, 480, 360, FMT_RGB8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uchar4, eBorderType::BORDER_TYPE_REPLICATE, eInterpolationType::INTERP_TYPE_NEAREST,
+                               eInterpolationType::INTERP_TYPE_LINEAR>(
+        3, 480, 360, FMT_RGBA8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_REFLECT, eInterpolationType::INTERP_TYPE_LINEAR,
+                               eInterpolationType::INTERP_TYPE_NEAREST>(
+        5, 480, 360, FMT_U8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uchar3, eBorderType::BORDER_TYPE_WRAP, eInterpolationType::INTERP_TYPE_NEAREST,
+                               eInterpolationType::INTERP_TYPE_LINEAR>(
+        5, 480, 360, FMT_RGB8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uchar4, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_LINEAR,
+                               eInterpolationType::INTERP_TYPE_NEAREST>(
+        5, 480, 360, FMT_RGBA8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, eDeviceType::CPU)));
 
     TEST_CASES_END();
 }

--- a/tests/roccv/cpp/test_op_rotate.cpp
+++ b/tests/roccv/cpp/test_op_rotate.cpp
@@ -23,6 +23,7 @@ THE SOFTWARE.
 #include <core/wrappers/interpolation_wrapper.hpp>
 #include <op_rotate.hpp>
 
+#include "core/detail/casting.hpp"
 #include "math_utils.hpp"
 #include "test_helpers.hpp"
 
@@ -64,7 +65,7 @@ std::vector<detail::BaseType<T>> GoldenRotate(std::vector<detail::BaseType<T>>& 
     size_t numElements = batchSize * imageSize.w * imageSize.h * detail::NumElements<T>;
     std::vector<detail::BaseType<T>> output(numElements);
 
-    T borderVal = detail::RangeCast<T>(make_float4(0.0f, 0.0f, 0.0f, 0.0f));
+    T borderVal = detail::SaturateCast<T>(make_float4(0.0f, 0.0f, 0.0f, 0.0f));
 
     ImageWrapper<T> outputWrapper(output, batchSize, imageSize.w, imageSize.h);
     InterpolationWrapper<T, eBorderType::BORDER_TYPE_CONSTANT, InterpType> inputWrapper(

--- a/tests/roccv/cpp/test_op_warp_affine.cpp
+++ b/tests/roccv/cpp/test_op_warp_affine.cpp
@@ -24,6 +24,7 @@ THE SOFTWARE.
 #include <core/wrappers/interpolation_wrapper.hpp>
 #include <op_warp_affine.hpp>
 
+#include "core/detail/casting.hpp"
 #include "math_utils.hpp"
 #include "test_helpers.hpp"
 
@@ -55,7 +56,7 @@ std::vector<detail::BaseType<T>> GoldenWarpAffine(std::vector<detail::BaseType<T
                                                   Size2D inputSize, Size2D outputSize, float4 borderValue) {
     // Create interpolation wrapper for input vector
     InterpolationWrapper<T, BorderType, InterpType> inputWrap((BorderWrapper<T, BorderType>(
-        ImageWrapper<T>(input, batchSize, inputSize.w, inputSize.h), detail::RangeCast<T>(borderValue))));
+        ImageWrapper<T>(input, batchSize, inputSize.w, inputSize.h), detail::SaturateCast<T>(borderValue))));
 
     // Create ImageWrapper for output vector. We also need to create said output vector.
     std::vector<detail::BaseType<T>> output(batchSize * outputSize.w * outputSize.h * detail::NumElements<T>);
@@ -81,7 +82,8 @@ std::vector<detail::BaseType<T>> GoldenWarpAffine(std::vector<detail::BaseType<T
         for (int y = 0; y < outputWrap.height(); y++) {
             for (int x = 0; x < outputWrap.width(); x++) {
                 // Get transformed input point by multiplying by the given perspective transformation matrix
-                Point2D inputCoord = MatTransform((Point2D){static_cast<float>(x), static_cast<float>(y)}, invMat.value());
+                Point2D inputCoord =
+                    MatTransform((Point2D){static_cast<float>(x), static_cast<float>(y)}, invMat.value());
                 outputWrap.at(b, y, x, 0) = inputWrap.at(b, inputCoord.y, inputCoord.x, 0);
             }
         }

--- a/tests/roccv/cpp/test_op_warp_perspective.cpp
+++ b/tests/roccv/cpp/test_op_warp_perspective.cpp
@@ -53,7 +53,7 @@ std::vector<detail::BaseType<T>> GoldenWarpPerspective(std::vector<detail::BaseT
                                                        Size2D inputSize, Size2D outputSize, float4 borderValue) {
     // Create interpolation wrapper for input vector
     InterpolationWrapper<T, BorderType, InterpType> inputWrap((BorderWrapper<T, BorderType>(
-        ImageWrapper<T>(input, batchSize, inputSize.w, inputSize.h), detail::RangeCast<T>(borderValue))));
+        ImageWrapper<T>(input, batchSize, inputSize.w, inputSize.h), detail::SaturateCast<T>(borderValue))));
 
     // Create ImageWrapper for output vector. We also need to create said output vector.
     std::vector<detail::BaseType<T>> output(batchSize * outputSize.w * outputSize.h * detail::NumElements<T>);
@@ -75,7 +75,8 @@ std::vector<detail::BaseType<T>> GoldenWarpPerspective(std::vector<detail::BaseT
         for (int y = 0; y < outputWrap.height(); y++) {
             for (int x = 0; x < outputWrap.width(); x++) {
                 // Get transformed input point by multiplying by the given perspective transformation matrix
-                Point2D inputCoord = MatTransform((Point2D){static_cast<float>(x), static_cast<float>(y)}, invMat.value());
+                Point2D inputCoord =
+                    MatTransform((Point2D){static_cast<float>(x), static_cast<float>(y)}, invMat.value());
                 outputWrap.at(b, y, x, 0) = inputWrap.at(b, inputCoord.y, inputCoord.x, 0);
             }
         }


### PR DESCRIPTION
## Motivation

Use SaturationCast instead of RangeCast when converting the provided `float4` border value into the internal type. This aims to match with existing CV libraries.

## Test Plan

Ensure everything compiles. Ensure C++/Python tests pass.

## Test Result

Project compiles. C++/Python tests passing.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
