### PR TITLE
Added reflect 101 border mode and updated border  C-model.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,13 @@ The full documentation for rocCV is available at [https://rocm.docs.amd.com/proj
 
 ## rocCV 0.4.0 for ROCm 7.2.0
 
+### Added
+- Reflect 101 border mode.
+
 ### Changed
 
 - `Pybind11` and `DLPack` requirements moved to git submodules.
+- Updated border C-model.
 
 ### Known issues
 

--- a/include/core/wrappers/border_wrapper.hpp
+++ b/include/core/wrappers/border_wrapper.hpp
@@ -91,21 +91,30 @@ class BorderWrapper {
         // Reflect border type implementation. (Note: This is NOT REFLECT101, pixels at the border will be duplicated as
         // is the intended behavior for this border mode.)
         if constexpr (BorderType == eBorderType::BORDER_TYPE_REFLECT) {
-            // There is a special case if we have a dimension of size 1
+            int64_t scale = imgWidth * 2;
+            int64_t val = (w % scale + scale) % scale;
+            x = (val < imgWidth) ? val : scale - 1 - val;
+
+            scale = imgHeight * 2;
+            val = (h % scale + scale) % scale;
+            y = (val < imgHeight) ? val : scale - 1 - val;
+        }
+
+        if constexpr (BorderType == eBorderType::BORDER_TYPE_REFLECT101) {
             if (imgWidth == 1) {
                 x = 0;
             } else {
-                int64_t scale = imgWidth * 2;
-                int64_t val = (w % scale + scale) % scale;
-                x = (val < imgWidth) ? val : scale - 1 - val;
+                int64_t scale = 2 * imgWidth - 2;
+                x = (w % scale + scale) % scale;
+                x = imgWidth - 1 - std::abs(imgWidth - 1 - x);
             }
 
             if (imgHeight == 1) {
                 y = 0;
             } else {
-                int64_t scale = imgHeight * 2;
-                int64_t val = (h % scale + scale) % scale;
-                y = (val < imgHeight) ? val : scale - 1 - val;
+                int64_t scale = 2 * imgHeight - 2;
+                y = (h % scale + scale) % scale;
+                y = imgHeight - 1 - std::abs(imgHeight - 1 - y);
             }
         }
 

--- a/include/operator_types.h
+++ b/include/operator_types.h
@@ -34,10 +34,11 @@ typedef enum eInterpolationType {
 } eInterpolationType;
 
 typedef enum eBorderType {
-    BORDER_TYPE_CONSTANT = 0,   ///< Uses a constant value for borders.
-    BORDER_TYPE_REPLICATE = 1,  ///< Replicates the last element for borders.
-    BORDER_TYPE_REFLECT = 2,    ///< Reflects the border elements.
-    BORDER_TYPE_WRAP = 3,       ///< Wraps the border elements.
+    BORDER_TYPE_CONSTANT = 0,       ///< Uses a constant value for borders.
+    BORDER_TYPE_REPLICATE = 1,      ///< Replicates the last element for borders.
+    BORDER_TYPE_REFLECT = 2,        ///< Reflects the border elements, including the boundary pixel
+    BORDER_TYPE_REFLECT101 = 3,     ///< Reflects the border elements, excluding the boundary pixel
+    BORDER_TYPE_WRAP = 4,           ///< Wraps the border elements.
 } eBorderType;
 
 typedef enum eRemapType {

--- a/python/src/py_enums.cpp
+++ b/python/src/py_enums.cpp
@@ -75,6 +75,7 @@ void PyEnums::Export(py::module& m) {
         .value("CONSTANT", BORDER_TYPE_CONSTANT)
         .value("REPLICATE", BORDER_TYPE_REPLICATE)
         .value("REFLECT", BORDER_TYPE_REFLECT)
+        .value("REFLECT101", BORDER_TYPE_REFLECT101)
         .value("WRAP", BORDER_TYPE_WRAP)
         .export_values();
 

--- a/src/op_bilateral_filter.cpp
+++ b/src/op_bilateral_filter.cpp
@@ -122,6 +122,7 @@ void dispatch_bilateral_filter_dtype(hipStream_t stream, const Tensor &input, co
             {eBorderType::BORDER_TYPE_REPLICATE,   dispatch_bilateral_filter_border_mode<T, eBorderType::BORDER_TYPE_REPLICATE>},
             {eBorderType::BORDER_TYPE_CONSTANT,    dispatch_bilateral_filter_border_mode<T, eBorderType::BORDER_TYPE_CONSTANT>},
             {eBorderType::BORDER_TYPE_REFLECT,     dispatch_bilateral_filter_border_mode<T, eBorderType::BORDER_TYPE_REFLECT>},
+            {eBorderType::BORDER_TYPE_REFLECT101,  dispatch_bilateral_filter_border_mode<T, eBorderType::BORDER_TYPE_REFLECT101>},
             {eBorderType::BORDER_TYPE_WRAP,        dispatch_bilateral_filter_border_mode<T, eBorderType::BORDER_TYPE_WRAP>}
         };
     // clang-format on

--- a/src/op_copy_make_border.cpp
+++ b/src/op_copy_make_border.cpp
@@ -69,6 +69,7 @@ void dispatch_copy_make_border(hipStream_t stream, const Tensor& input, const Te
         {eBorderType::BORDER_TYPE_CONSTANT,     dispatch_copy_make_border_border_mode<T, eBorderType::BORDER_TYPE_CONSTANT>},
         {eBorderType::BORDER_TYPE_REPLICATE,    dispatch_copy_make_border_border_mode<T, eBorderType::BORDER_TYPE_REPLICATE>},
         {eBorderType::BORDER_TYPE_REFLECT,      dispatch_copy_make_border_border_mode<T, eBorderType::BORDER_TYPE_REFLECT>},
+        {eBorderType::BORDER_TYPE_REFLECT101,   dispatch_copy_make_border_border_mode<T, eBorderType::BORDER_TYPE_REFLECT101>},
         {eBorderType::BORDER_TYPE_WRAP,         dispatch_copy_make_border_border_mode<T, eBorderType::BORDER_TYPE_WRAP>}
     };
     // clang-format on

--- a/src/op_remap.cpp
+++ b/src/op_remap.cpp
@@ -118,6 +118,7 @@ void dispatch_remap_dtype(hipStream_t stream, const Tensor &input, const Tensor 
             {eBorderType::BORDER_TYPE_CONSTANT,     dispatch_remap_border_mode<T, eBorderType::BORDER_TYPE_CONSTANT>},
             {eBorderType::BORDER_TYPE_REPLICATE,    dispatch_remap_border_mode<T, eBorderType::BORDER_TYPE_REPLICATE>},
             {eBorderType::BORDER_TYPE_REFLECT,      dispatch_remap_border_mode<T, eBorderType::BORDER_TYPE_REFLECT>},
+            {eBorderType::BORDER_TYPE_REFLECT101,   dispatch_remap_border_mode<T, eBorderType::BORDER_TYPE_REFLECT101>},
             {eBorderType::BORDER_TYPE_WRAP,         dispatch_remap_border_mode<T, eBorderType::BORDER_TYPE_WRAP>}
         };
     // clang-format on

--- a/src/op_warp_perspective.cpp
+++ b/src/op_warp_perspective.cpp
@@ -89,6 +89,7 @@ void dispatch_warp_perspective_dtype(hipStream_t stream, const Tensor &input, co
             {eBorderType::BORDER_TYPE_CONSTANT,     dispatch_warp_perspective_border_mode<T, eBorderType::BORDER_TYPE_CONSTANT>},
             {eBorderType::BORDER_TYPE_REPLICATE,    dispatch_warp_perspective_border_mode<T, eBorderType::BORDER_TYPE_REPLICATE>},
             {eBorderType::BORDER_TYPE_REFLECT,      dispatch_warp_perspective_border_mode<T, eBorderType::BORDER_TYPE_REFLECT>},
+            {eBorderType::BORDER_TYPE_REFLECT101,   dispatch_warp_perspective_border_mode<T, eBorderType::BORDER_TYPE_REFLECT101>},
             {eBorderType::BORDER_TYPE_WRAP,         dispatch_warp_perspective_border_mode<T, eBorderType::BORDER_TYPE_WRAP>}
         };
     // clang-format on

--- a/tests/roccv/cpp/test_border_wrapper.cpp
+++ b/tests/roccv/cpp/test_border_wrapper.cpp
@@ -40,6 +40,65 @@ namespace {
 bool IsOutOfBounds(int32_t coordinate, int32_t dimSize) { return (coordinate < 0) || (coordinate >= dimSize); }
 
 /**
+ * @brief Calculate the coordinate of certain dimension (x or y) for the border pixel.
+ * @param[in] u The coordinate of the border pixel.
+ * @param[in] dimSize The size of the image in the dimension.
+ * @param[in] borderMode The border mode to determine how the coordinate of the border pixel is mapped.
+ * @return The in-image coordinate for the border pixel.
+ */
+int64_t GetCoordOfBorderPel(int64_t u, int64_t dimSize, const eBorderType borderMode) {
+    int64_t v = u;
+    switch (borderMode) {
+        case eBorderType::BORDER_TYPE_REFLECT: {
+            if (u < 0) {
+                v = (-u - 1) % dimSize;
+            } else if (u >= dimSize) {
+                v = dimSize - (u % dimSize) - 1;
+            } else {
+                v = u;
+            }
+            break;
+        }
+
+        case eBorderType::BORDER_TYPE_REFLECT101: {
+            if (dimSize == 1) {
+                v = 0;
+            } else {
+                if (u < 0) {
+                    v = (-u) % dimSize;
+                } else if (u >= dimSize) {
+                    v = u % dimSize;
+                    v = (dimSize * 2 - 2 - v) % dimSize;
+                } else {
+                    v = u;
+                }
+            }
+            break;
+        }
+
+        case eBorderType::BORDER_TYPE_REPLICATE: {
+            if (u < 0) {
+                v = 0;
+            } else if (u >= dimSize) {
+                v = dimSize - 1;
+            } else {
+                v = u;
+            }
+            break;
+        }
+
+        case eBorderType::BORDER_TYPE_WRAP: {
+            v = ((u % dimSize) + dimSize) % dimSize;
+            break;
+        }
+
+        default: {
+            v = u;
+        }
+    }
+    return v;
+}
+/**
  * @brief Golden implementation for handling out of bounds behavior during image accesses.
  *
  * @tparam T The underlying datatype of the image. (e.g. uchar3)
@@ -60,63 +119,15 @@ BT GoldenBorderAt(ImageWrapper<T>& input, const eBorderType borderMode, T border
                   int64_t x, int64_t channel) {
     int64_t outX = x, outY = y;
 
-    switch (borderMode) {
-        case eBorderType::BORDER_TYPE_CONSTANT: {
-            // Handle constant border type boundaries. This will return a constant value if either x or y coordinates
-            // fall out of bounds.
-            if (IsOutOfBounds(x, input.width()) || IsOutOfBounds(y, input.height())) {
-                return detail::GetElement(borderValue, channel);
-            }
-
-            // Otherwise, the coordinates are within bounds. outX and outY do not need to be modified.
-            break;
+    if (borderMode == eBorderType::BORDER_TYPE_CONSTANT) {
+        // Handle constant border type boundaries. This will return a constant value if either x or y coordinates
+        // fall out of bounds.
+        if (IsOutOfBounds(x, input.width()) || IsOutOfBounds(y, input.height())) {
+            return detail::GetElement(borderValue, channel);
         }
-
-        case eBorderType::BORDER_TYPE_REFLECT: {
-            // Note, BORDER_TYPE_REFLECT also copies the border pixels. This behavior is intended, as an additional
-            // BORDER_TYPE_REFLECT101 will be implemented to handle reflections without copying the pixels on the
-            // border.
-
-            int64_t width = input.width();
-            // Handle the special case where we have a dimension of size 1.
-            if (width == 1) {
-                outX = 0;
-            } else {
-                int64_t scale = width * 2;  // The period of the reflection, used for wrapping.
-                int64_t val = (x % scale + scale) % scale;
-                outX = (val < width) ? val : scale - 1 - val;
-            }
-
-            // Identical to the logic above, just handled along the y axis instead.
-            int64_t height = input.height();
-            if (height == 1) {
-                outY = 0;
-            } else {
-                int64_t scale = height * 2;
-                int64_t val = (y % scale + scale) % scale;
-                outY = (val < height) ? val : scale - 1 - val;
-            }
-            break;
-        }
-
-        case eBorderType::BORDER_TYPE_REPLICATE: {
-            // BORDER_TYPE_REPLICATE just clamps out-of-bounds coordinates to the coordinate at the nearest border. We
-            // handle this for both the x and y axis.
-
-            outX = std::clamp<int64_t>(x, 0, input.width() - 1);
-            outY = std::clamp<int64_t>(y, 0, input.height() - 1);
-            break;
-        }
-
-        case eBorderType::BORDER_TYPE_WRAP: {
-            // Note: We cannot just do x % input.width() since a negative dividend (x) will result in a negative number.
-            int64_t width = input.width();
-            outX = ((x % width) + width) % width;
-
-            int64_t height = input.height();
-            outY = ((y % height) + height) % height;
-            break;
-        }
+    } else {
+        outX = GetCoordOfBorderPel(x, input.width(), borderMode);
+        outY = GetCoordOfBorderPel(y, input.height(), borderMode);
     }
 
     // Return the value at the modified outX, outY coordinates using the passed in ImageWrapper.
@@ -208,6 +219,9 @@ eTestStatusType test_border_wrapper(int argc, char** argv) {
     TEST_CASE((TestCorrectness<uchar3, eBorderType::BORDER_TYPE_REFLECT>(make_float4(0.5f, 1.0f, 0.0f, 1.0f), 2, {1, 1}, 9)));
     TEST_CASE((TestCorrectness<uchar4, eBorderType::BORDER_TYPE_REFLECT>(make_float4(1.0f, 1.0f, 1.0f, 0.5f), 3, {16, 83}, 9)));
 
+    TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_REFLECT101>(make_float4(1.0f, 1.0f, 1.0f, 1.0f), 1, {56, 13}, 9)));
+    TEST_CASE((TestCorrectness<uchar3, eBorderType::BORDER_TYPE_REFLECT101>(make_float4(0.5f, 1.0f, 0.0f, 1.0f), 2, {1, 1}, 9)));
+    TEST_CASE((TestCorrectness<uchar4, eBorderType::BORDER_TYPE_REFLECT101>(make_float4(1.0f, 1.0f, 1.0f, 0.5f), 3, {16, 83}, 9)));
 
     // S8 datatype tests
     TEST_CASE((TestCorrectness<char1, eBorderType::BORDER_TYPE_CONSTANT>(make_float4(1.0f, 1.0f, 1.0f, 1.0f), 1, {56, 13}, 9)));
@@ -226,6 +240,9 @@ eTestStatusType test_border_wrapper(int argc, char** argv) {
     TEST_CASE((TestCorrectness<char3, eBorderType::BORDER_TYPE_REFLECT>(make_float4(0.5f, 1.0f, 0.0f, 1.0f), 2, {1, 1}, 9)));
     TEST_CASE((TestCorrectness<char4, eBorderType::BORDER_TYPE_REFLECT>(make_float4(1.0f, 1.0f, 1.0f, 0.5f), 3, {16, 83}, 9)));
 
+    TEST_CASE((TestCorrectness<char1, eBorderType::BORDER_TYPE_REFLECT101>(make_float4(1.0f, 1.0f, 1.0f, 1.0f), 1, {56, 13}, 9)));
+    TEST_CASE((TestCorrectness<char3, eBorderType::BORDER_TYPE_REFLECT101>(make_float4(0.5f, 1.0f, 0.0f, 1.0f), 2, {1, 1}, 9)));
+    TEST_CASE((TestCorrectness<char4, eBorderType::BORDER_TYPE_REFLECT101>(make_float4(1.0f, 1.0f, 1.0f, 0.5f), 3, {16, 83}, 9)));
 
     // U16 datatype tests
     TEST_CASE((TestCorrectness<ushort1, eBorderType::BORDER_TYPE_CONSTANT>(make_float4(1.0f, 1.0f, 1.0f, 1.0f), 1, {56, 13}, 9)));
@@ -244,6 +261,9 @@ eTestStatusType test_border_wrapper(int argc, char** argv) {
     TEST_CASE((TestCorrectness<ushort3, eBorderType::BORDER_TYPE_REFLECT>(make_float4(0.5f, 1.0f, 0.0f, 1.0f), 2, {1, 1}, 9)));
     TEST_CASE((TestCorrectness<ushort4, eBorderType::BORDER_TYPE_REFLECT>(make_float4(1.0f, 1.0f, 1.0f, 0.5f), 3, {16, 83}, 9)));
 
+    TEST_CASE((TestCorrectness<ushort1, eBorderType::BORDER_TYPE_REFLECT101>(make_float4(1.0f, 1.0f, 1.0f, 1.0f), 1, {56, 13}, 9)));
+    TEST_CASE((TestCorrectness<ushort3, eBorderType::BORDER_TYPE_REFLECT101>(make_float4(0.5f, 1.0f, 0.0f, 1.0f), 2, {1, 1}, 9)));
+    TEST_CASE((TestCorrectness<ushort4, eBorderType::BORDER_TYPE_REFLECT101>(make_float4(1.0f, 1.0f, 1.0f, 0.5f), 3, {16, 83}, 9)));
 
     // S16 datatype tests
     TEST_CASE((TestCorrectness<short1, eBorderType::BORDER_TYPE_CONSTANT>(make_float4(1.0f, 1.0f, 1.0f, 1.0f), 1, {56, 13}, 9)));
@@ -262,6 +282,9 @@ eTestStatusType test_border_wrapper(int argc, char** argv) {
     TEST_CASE((TestCorrectness<short3, eBorderType::BORDER_TYPE_REFLECT>(make_float4(0.5f, 1.0f, 0.0f, 1.0f), 2, {1, 1}, 9)));
     TEST_CASE((TestCorrectness<short4, eBorderType::BORDER_TYPE_REFLECT>(make_float4(1.0f, 1.0f, 1.0f, 0.5f), 3, {16, 83}, 9)));
 
+    TEST_CASE((TestCorrectness<short1, eBorderType::BORDER_TYPE_REFLECT101>(make_float4(1.0f, 1.0f, 1.0f, 1.0f), 1, {56, 13}, 9)));
+    TEST_CASE((TestCorrectness<short3, eBorderType::BORDER_TYPE_REFLECT101>(make_float4(0.5f, 1.0f, 0.0f, 1.0f), 2, {1, 1}, 9)));
+    TEST_CASE((TestCorrectness<short4, eBorderType::BORDER_TYPE_REFLECT101>(make_float4(1.0f, 1.0f, 1.0f, 0.5f), 3, {16, 83}, 9)));
 
     // S32 datatype tests
     TEST_CASE((TestCorrectness<int1, eBorderType::BORDER_TYPE_CONSTANT>(make_float4(1.0f, 1.0f, 1.0f, 1.0f), 1, {56, 13}, 9)));
@@ -280,6 +303,9 @@ eTestStatusType test_border_wrapper(int argc, char** argv) {
     TEST_CASE((TestCorrectness<int3, eBorderType::BORDER_TYPE_REFLECT>(make_float4(0.5f, 1.0f, 0.0f, 1.0f), 2, {1, 1}, 9)));
     TEST_CASE((TestCorrectness<int4, eBorderType::BORDER_TYPE_REFLECT>(make_float4(1.0f, 1.0f, 1.0f, 0.5f), 3, {16, 83}, 9)));
 
+    TEST_CASE((TestCorrectness<int1, eBorderType::BORDER_TYPE_REFLECT101>(make_float4(1.0f, 1.0f, 1.0f, 1.0f), 1, {56, 13}, 9)));
+    TEST_CASE((TestCorrectness<int3, eBorderType::BORDER_TYPE_REFLECT101>(make_float4(0.5f, 1.0f, 0.0f, 1.0f), 2, {1, 1}, 9)));
+    TEST_CASE((TestCorrectness<int4, eBorderType::BORDER_TYPE_REFLECT101>(make_float4(1.0f, 1.0f, 1.0f, 0.5f), 3, {16, 83}, 9)));
 
     // U32 datatype tests
     TEST_CASE((TestCorrectness<uint1, eBorderType::BORDER_TYPE_CONSTANT>(make_float4(1.0f, 1.0f, 1.0f, 1.0f), 1, {56, 13}, 9)));
@@ -298,6 +324,9 @@ eTestStatusType test_border_wrapper(int argc, char** argv) {
     TEST_CASE((TestCorrectness<uint3, eBorderType::BORDER_TYPE_REFLECT>(make_float4(0.5f, 1.0f, 0.0f, 1.0f), 2, {1, 1}, 9)));
     TEST_CASE((TestCorrectness<uint4, eBorderType::BORDER_TYPE_REFLECT>(make_float4(1.0f, 1.0f, 1.0f, 0.5f), 3, {16, 83}, 9)));
 
+    TEST_CASE((TestCorrectness<uint1, eBorderType::BORDER_TYPE_REFLECT101>(make_float4(1.0f, 1.0f, 1.0f, 1.0f), 1, {56, 13}, 9)));
+    TEST_CASE((TestCorrectness<uint3, eBorderType::BORDER_TYPE_REFLECT101>(make_float4(0.5f, 1.0f, 0.0f, 1.0f), 2, {1, 1}, 9)));
+    TEST_CASE((TestCorrectness<uint4, eBorderType::BORDER_TYPE_REFLECT101>(make_float4(1.0f, 1.0f, 1.0f, 0.5f), 3, {16, 83}, 9)));
 
     // F32 datatype tests
     TEST_CASE((TestCorrectness<float1, eBorderType::BORDER_TYPE_CONSTANT>(make_float4(1.0f, 1.0f, 1.0f, 1.0f), 1, {56, 13}, 9)));
@@ -316,6 +345,9 @@ eTestStatusType test_border_wrapper(int argc, char** argv) {
     TEST_CASE((TestCorrectness<float3, eBorderType::BORDER_TYPE_REFLECT>(make_float4(0.5f, 1.0f, 0.0f, 1.0f), 2, {1, 1}, 9)));
     TEST_CASE((TestCorrectness<float4, eBorderType::BORDER_TYPE_REFLECT>(make_float4(1.0f, 1.0f, 1.0f, 0.5f), 3, {16, 83}, 9)));
 
+    TEST_CASE((TestCorrectness<float1, eBorderType::BORDER_TYPE_REFLECT101>(make_float4(1.0f, 1.0f, 1.0f, 1.0f), 1, {56, 13}, 9)));
+    TEST_CASE((TestCorrectness<float3, eBorderType::BORDER_TYPE_REFLECT101>(make_float4(0.5f, 1.0f, 0.0f, 1.0f), 2, {1, 1}, 9)));
+    TEST_CASE((TestCorrectness<float4, eBorderType::BORDER_TYPE_REFLECT101>(make_float4(1.0f, 1.0f, 1.0f, 0.5f), 3, {16, 83}, 9)));
 
     // F64 datatype tests
     TEST_CASE((TestCorrectness<double1, eBorderType::BORDER_TYPE_CONSTANT>(make_float4(1.0f, 1.0f, 1.0f, 1.0f), 1, {56, 13}, 9)));
@@ -333,6 +365,10 @@ eTestStatusType test_border_wrapper(int argc, char** argv) {
     TEST_CASE((TestCorrectness<double1, eBorderType::BORDER_TYPE_REFLECT>(make_float4(1.0f, 1.0f, 1.0f, 1.0f), 1, {56, 13}, 9)));
     TEST_CASE((TestCorrectness<double3, eBorderType::BORDER_TYPE_REFLECT>(make_float4(0.5f, 1.0f, 0.0f, 1.0f), 2, {1, 1}, 9)));
     TEST_CASE((TestCorrectness<double4, eBorderType::BORDER_TYPE_REFLECT>(make_float4(1.0f, 1.0f, 1.0f, 0.5f), 3, {16, 83}, 9)));
+
+    TEST_CASE((TestCorrectness<double1, eBorderType::BORDER_TYPE_REFLECT101>(make_float4(1.0f, 1.0f, 1.0f, 1.0f), 1, {56, 13}, 9)));
+    TEST_CASE((TestCorrectness<double3, eBorderType::BORDER_TYPE_REFLECT101>(make_float4(0.5f, 1.0f, 0.0f, 1.0f), 2, {1, 1}, 9)));
+    TEST_CASE((TestCorrectness<double4, eBorderType::BORDER_TYPE_REFLECT101>(make_float4(1.0f, 1.0f, 1.0f, 0.5f), 3, {16, 83}, 9)));
     // clang-format on
 
     TEST_CASES_END();

--- a/tests/roccv/cpp/test_op_bilateral_filter.cpp
+++ b/tests/roccv/cpp/test_op_bilateral_filter.cpp
@@ -193,7 +193,7 @@ eTestStatusType test_op_bilateral_filter(int argc, char** argv) {
     TEST_CASE((TestCorrectness<char3, BORDER_TYPE_WRAP>(5, 32, 24, FMT_RGBs8, 5, 60.0f, 5.0f, {100.0, 0.0, 100.0, 0.0},
                                                         eDeviceType::GPU)));
 
-    TEST_CASE((TestCorrectness<char4, BORDER_TYPE_REFLECT>(1, 64, 24, FMT_RGBAs8, 5, 60.0f, 3.0f,
+    TEST_CASE((TestCorrectness<char4, BORDER_TYPE_REFLECT101>(1, 64, 24, FMT_RGBAs8, 5, 60.0f, 3.0f,
                                                            {100.0, 0.0, 100.0, 0.0}, eDeviceType::GPU)));
     TEST_CASE((TestCorrectness<char4, BORDER_TYPE_CONSTANT>(5, 64, 24, FMT_RGBAs8, 5, 60.0f, 3.0f,
                                                             {100.0, 100.0, 100.0, 0.0}, eDeviceType::GPU)));
@@ -205,7 +205,7 @@ eTestStatusType test_op_bilateral_filter(int argc, char** argv) {
 
     TEST_CASE((TestCorrectness<ushort3, BORDER_TYPE_CONSTANT>(1, 20, 20, FMT_RGB16, 4, 500.0f, 3.0f,
                                                               {500.0, 600.0, 0.0, 0.0}, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<ushort3, BORDER_TYPE_REFLECT>(2, 20, 20, FMT_RGB16, 4, 500.0f, 3.0f,
+    TEST_CASE((TestCorrectness<ushort3, BORDER_TYPE_REFLECT101>(2, 20, 20, FMT_RGB16, 4, 500.0f, 3.0f,
                                                              {0.0, 0.0, 0.0, 0.0}, eDeviceType::GPU)));
 
     TEST_CASE((TestCorrectness<ushort4, BORDER_TYPE_REFLECT>(1, 20, 20, FMT_RGBA16, 4, 600.0f, 3.0f,
@@ -294,7 +294,7 @@ eTestStatusType test_op_bilateral_filter(int argc, char** argv) {
     TEST_CASE((TestCorrectness<char3, BORDER_TYPE_WRAP>(5, 32, 24, FMT_RGBs8, 5, 60.0f, 5.0f, {100.0, 0.0, 100.0, 0.0},
                                                         eDeviceType::CPU)));
 
-    TEST_CASE((TestCorrectness<char4, BORDER_TYPE_REFLECT>(1, 64, 24, FMT_RGBAs8, 5, 60.0f, 3.0f,
+    TEST_CASE((TestCorrectness<char4, BORDER_TYPE_REFLECT101>(1, 64, 24, FMT_RGBAs8, 5, 60.0f, 3.0f,
                                                            {100.0, 0.0, 100.0, 0.0}, eDeviceType::CPU)));
     TEST_CASE((TestCorrectness<char4, BORDER_TYPE_CONSTANT>(5, 64, 24, FMT_RGBAs8, 5, 60.0f, 3.0f,
                                                             {100.0, 100.0, 100.0, 0.0}, eDeviceType::CPU)));
@@ -309,7 +309,7 @@ eTestStatusType test_op_bilateral_filter(int argc, char** argv) {
     TEST_CASE((TestCorrectness<ushort3, BORDER_TYPE_REFLECT>(2, 20, 20, FMT_RGB16, 4, 500.0f, 3.0f,
                                                              {0.0, 0.0, 0.0, 0.0}, eDeviceType::CPU)));
 
-    TEST_CASE((TestCorrectness<ushort4, BORDER_TYPE_REFLECT>(1, 20, 20, FMT_RGBA16, 4, 600.0f, 3.0f,
+    TEST_CASE((TestCorrectness<ushort4, BORDER_TYPE_REFLECT101>(1, 20, 20, FMT_RGBA16, 4, 600.0f, 3.0f,
                                                              {500.0, 600.0, 0.0, 0.0}, eDeviceType::CPU)));
     TEST_CASE((TestCorrectness<ushort4, BORDER_TYPE_WRAP>(2, 20, 20, FMT_RGBA16, 4, 500.0f, 3.0f, {0.0, 0.0, 0.0, 0.0},
                                                           eDeviceType::CPU)));

--- a/tests/roccv/cpp/test_op_copy_make_border.cpp
+++ b/tests/roccv/cpp/test_op_copy_make_border.cpp
@@ -135,18 +135,21 @@ eTestStatusType test_op_copy_make_border(int argc, char** argv) {
     // U8
     TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_CONSTANT>(1, {40, 10}, {60, 20}, FMT_U8, 5, 10, make_float4(1.0f, 0.5f, 0.5f, 1.0f), eDeviceType::GPU)));
     TEST_CASE((TestCorrectness<uchar3, eBorderType::BORDER_TYPE_REFLECT>(3, {40, 10}, {80, 25}, FMT_RGB8, 0, 5, make_float4(1.0f, 0.5f, 0.5f, 1.0f), eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<uchar3, eBorderType::BORDER_TYPE_REFLECT101>(3, {40, 10}, {80, 25}, FMT_RGB8, 0, 5, make_float4(1.0f, 0.5f, 0.5f, 1.0f), eDeviceType::GPU)));
     TEST_CASE((TestCorrectness<uchar3, eBorderType::BORDER_TYPE_REPLICATE>(5, {10, 5}, {10, 25}, FMT_RGB8, 10, 0, make_float4(1.0f, 0.5f, 0.5f, 1.0f), eDeviceType::GPU)));
     TEST_CASE((TestCorrectness<uchar4, eBorderType::BORDER_TYPE_WRAP>(5, {10, 5}, {10, 25}, FMT_RGBA8, 10, 0, make_float4(1.0f, 0.5f, 0.5f, 1.0f), eDeviceType::GPU)));
 
     // S8
     TEST_CASE((TestCorrectness<char1, eBorderType::BORDER_TYPE_CONSTANT>(1, {40, 10}, {60, 20}, FMT_S8, 5, 10, make_float4(1.0f, 0.5f, 0.5f, 1.0f), eDeviceType::GPU)));
     TEST_CASE((TestCorrectness<char3, eBorderType::BORDER_TYPE_REFLECT>(3, {40, 10}, {80, 25}, FMT_RGBs8, 0, 5, make_float4(1.0f, 0.5f, 0.5f, 1.0f), eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<char3, eBorderType::BORDER_TYPE_REFLECT101>(3, {40, 10}, {80, 25}, FMT_RGBs8, 0, 5, make_float4(1.0f, 0.5f, 0.5f, 1.0f), eDeviceType::GPU)));
     TEST_CASE((TestCorrectness<char3, eBorderType::BORDER_TYPE_REPLICATE>(5, {10, 5}, {10, 25}, FMT_RGBs8, 10, 0, make_float4(1.0f, 0.5f, 0.5f, 1.0f), eDeviceType::GPU)));
     TEST_CASE((TestCorrectness<char4, eBorderType::BORDER_TYPE_WRAP>(5, {10, 5}, {10, 25}, FMT_RGBAs8, 10, 0, make_float4(1.0f, 0.5f, 0.5f, 1.0f), eDeviceType::GPU)));
 
     // U16
     TEST_CASE((TestCorrectness<ushort1, eBorderType::BORDER_TYPE_CONSTANT>(1, {40, 10}, {60, 20}, FMT_U16, 5, 10, make_float4(1.0f, 0.5f, 0.5f, 1.0f), eDeviceType::GPU)));
     TEST_CASE((TestCorrectness<ushort3, eBorderType::BORDER_TYPE_REFLECT>(3, {40, 10}, {80, 25}, FMT_RGB16, 0, 5, make_float4(1.0f, 0.5f, 0.5f, 1.0f), eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<ushort3, eBorderType::BORDER_TYPE_REFLECT101>(3, {40, 10}, {80, 25}, FMT_RGB16, 0, 5, make_float4(1.0f, 0.5f, 0.5f, 1.0f), eDeviceType::GPU)));
     TEST_CASE((TestCorrectness<ushort3, eBorderType::BORDER_TYPE_REPLICATE>(5, {10, 5}, {10, 25}, FMT_RGB16, 10, 0, make_float4(1.0f, 0.5f, 0.5f, 1.0f), eDeviceType::GPU)));
     TEST_CASE((TestCorrectness<ushort4, eBorderType::BORDER_TYPE_WRAP>(5, {10, 5}, {10, 25}, FMT_RGBA16, 10, 0, make_float4(1.0f, 0.5f, 0.5f, 1.0f), eDeviceType::GPU)));
 
@@ -156,6 +159,7 @@ eTestStatusType test_op_copy_make_border(int argc, char** argv) {
     // U32
     TEST_CASE((TestCorrectness<uint1, eBorderType::BORDER_TYPE_CONSTANT>(1, {40, 10}, {60, 20}, FMT_U32, 5, 10, make_float4(1.0f, 0.5f, 0.5f, 1.0f), eDeviceType::GPU)));
     TEST_CASE((TestCorrectness<uint3, eBorderType::BORDER_TYPE_REFLECT>(3, {40, 10}, {80, 25}, FMT_RGB32, 0, 5, make_float4(1.0f, 0.5f, 0.5f, 1.0f), eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<uint3, eBorderType::BORDER_TYPE_REFLECT101>(3, {40, 10}, {80, 25}, FMT_RGB32, 0, 5, make_float4(1.0f, 0.5f, 0.5f, 1.0f), eDeviceType::GPU)));
     TEST_CASE((TestCorrectness<uint3, eBorderType::BORDER_TYPE_REPLICATE>(5, {10, 5}, {10, 25}, FMT_RGB32, 10, 0, make_float4(1.0f, 0.5f, 0.5f, 1.0f), eDeviceType::GPU)));
     TEST_CASE((TestCorrectness<uint4, eBorderType::BORDER_TYPE_WRAP>(5, {10, 5}, {10, 25}, FMT_RGBA32, 10, 0, make_float4(1.0f, 0.5f, 0.5f, 1.0f), eDeviceType::GPU)));
 
@@ -165,12 +169,14 @@ eTestStatusType test_op_copy_make_border(int argc, char** argv) {
     // F32
     TEST_CASE((TestCorrectness<float1, eBorderType::BORDER_TYPE_CONSTANT>(1, {40, 10}, {60, 20}, FMT_F32, 5, 10, make_float4(1.0f, 0.5f, 0.5f, 1.0f), eDeviceType::GPU)));
     TEST_CASE((TestCorrectness<float3, eBorderType::BORDER_TYPE_REFLECT>(3, {40, 10}, {80, 25}, FMT_RGBf32, 0, 5, make_float4(1.0f, 0.5f, 0.5f, 1.0f), eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<float3, eBorderType::BORDER_TYPE_REFLECT101>(3, {40, 10}, {80, 25}, FMT_RGBf32, 0, 5, make_float4(1.0f, 0.5f, 0.5f, 1.0f), eDeviceType::GPU)));
     TEST_CASE((TestCorrectness<float3, eBorderType::BORDER_TYPE_REPLICATE>(5, {10, 5}, {10, 25}, FMT_RGBf32, 10, 0, make_float4(1.0f, 0.5f, 0.5f, 1.0f), eDeviceType::GPU)));
     TEST_CASE((TestCorrectness<float4, eBorderType::BORDER_TYPE_WRAP>(5, {10, 5}, {10, 25}, FMT_RGBAf32, 10, 0, make_float4(1.0f, 0.5f, 0.5f, 1.0f), eDeviceType::GPU)));
 
     // F64
     TEST_CASE((TestCorrectness<double1, eBorderType::BORDER_TYPE_CONSTANT>(1, {40, 10}, {60, 20}, FMT_F64, 5, 10, make_float4(1.0f, 0.5f, 0.5f, 1.0f), eDeviceType::GPU)));
     TEST_CASE((TestCorrectness<double3, eBorderType::BORDER_TYPE_REFLECT>(3, {40, 10}, {80, 25}, FMT_RGBf64, 0, 5, make_float4(1.0f, 0.5f, 0.5f, 1.0f), eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<double3, eBorderType::BORDER_TYPE_REFLECT101>(3, {40, 10}, {80, 25}, FMT_RGBf64, 0, 5, make_float4(1.0f, 0.5f, 0.5f, 1.0f), eDeviceType::GPU)));
     TEST_CASE((TestCorrectness<double3, eBorderType::BORDER_TYPE_REPLICATE>(5, {10, 5}, {10, 25}, FMT_RGBf64, 10, 0, make_float4(1.0f, 0.5f, 0.5f, 1.0f), eDeviceType::GPU)));
     TEST_CASE((TestCorrectness<double4, eBorderType::BORDER_TYPE_WRAP>(5, {10, 5}, {10, 25}, FMT_RGBAf64, 10, 0, make_float4(1.0f, 0.5f, 0.5f, 1.0f), eDeviceType::GPU)));
 
@@ -180,18 +186,21 @@ eTestStatusType test_op_copy_make_border(int argc, char** argv) {
     // U8
     TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_CONSTANT>(1, {40, 10}, {60, 20}, FMT_U8, 5, 10, make_float4(1.0f, 0.5f, 0.5f, 1.0f), eDeviceType::CPU)));
     TEST_CASE((TestCorrectness<uchar3, eBorderType::BORDER_TYPE_REFLECT>(3, {40, 10}, {80, 25}, FMT_RGB8, 0, 5, make_float4(1.0f, 0.5f, 0.5f, 1.0f), eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uchar3, eBorderType::BORDER_TYPE_REFLECT101>(3, {40, 10}, {80, 25}, FMT_RGB8, 0, 5, make_float4(1.0f, 0.5f, 0.5f, 1.0f), eDeviceType::CPU)));
     TEST_CASE((TestCorrectness<uchar3, eBorderType::BORDER_TYPE_REPLICATE>(5, {10, 5}, {10, 25}, FMT_RGB8, 10, 0, make_float4(1.0f, 0.5f, 0.5f, 1.0f), eDeviceType::CPU)));
     TEST_CASE((TestCorrectness<uchar4, eBorderType::BORDER_TYPE_WRAP>(5, {10, 5}, {10, 25}, FMT_RGBA8, 10, 0, make_float4(1.0f, 0.5f, 0.5f, 1.0f), eDeviceType::CPU)));
 
     // S8
     TEST_CASE((TestCorrectness<char1, eBorderType::BORDER_TYPE_CONSTANT>(1, {40, 10}, {60, 20}, FMT_S8, 5, 10, make_float4(1.0f, 0.5f, 0.5f, 1.0f), eDeviceType::CPU)));
     TEST_CASE((TestCorrectness<char3, eBorderType::BORDER_TYPE_REFLECT>(3, {40, 10}, {80, 25}, FMT_RGBs8, 0, 5, make_float4(1.0f, 0.5f, 0.5f, 1.0f), eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<char3, eBorderType::BORDER_TYPE_REFLECT101>(3, {40, 10}, {80, 25}, FMT_RGBs8, 0, 5, make_float4(1.0f, 0.5f, 0.5f, 1.0f), eDeviceType::CPU)));
     TEST_CASE((TestCorrectness<char3, eBorderType::BORDER_TYPE_REPLICATE>(5, {10, 5}, {10, 25}, FMT_RGBs8, 10, 0, make_float4(1.0f, 0.5f, 0.5f, 1.0f), eDeviceType::CPU)));
     TEST_CASE((TestCorrectness<char4, eBorderType::BORDER_TYPE_WRAP>(5, {10, 5}, {10, 25}, FMT_RGBAs8, 10, 0, make_float4(1.0f, 0.5f, 0.5f, 1.0f), eDeviceType::CPU)));
 
     // U16
     TEST_CASE((TestCorrectness<ushort1, eBorderType::BORDER_TYPE_CONSTANT>(1, {40, 10}, {60, 20}, FMT_U16, 5, 10, make_float4(1.0f, 0.5f, 0.5f, 1.0f), eDeviceType::CPU)));
     TEST_CASE((TestCorrectness<ushort3, eBorderType::BORDER_TYPE_REFLECT>(3, {40, 10}, {80, 25}, FMT_RGB16, 0, 5, make_float4(1.0f, 0.5f, 0.5f, 1.0f), eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<ushort3, eBorderType::BORDER_TYPE_REFLECT101>(3, {40, 10}, {80, 25}, FMT_RGB16, 0, 5, make_float4(1.0f, 0.5f, 0.5f, 1.0f), eDeviceType::CPU)));
     TEST_CASE((TestCorrectness<ushort3, eBorderType::BORDER_TYPE_REPLICATE>(5, {10, 5}, {10, 25}, FMT_RGB16, 10, 0, make_float4(1.0f, 0.5f, 0.5f, 1.0f), eDeviceType::CPU)));
     TEST_CASE((TestCorrectness<ushort4, eBorderType::BORDER_TYPE_WRAP>(5, {10, 5}, {10, 25}, FMT_RGBA16, 10, 0, make_float4(1.0f, 0.5f, 0.5f, 1.0f), eDeviceType::CPU)));
 
@@ -201,6 +210,7 @@ eTestStatusType test_op_copy_make_border(int argc, char** argv) {
     // U32
     TEST_CASE((TestCorrectness<uint1, eBorderType::BORDER_TYPE_CONSTANT>(1, {40, 10}, {60, 20}, FMT_U32, 5, 10, make_float4(1.0f, 0.5f, 0.5f, 1.0f), eDeviceType::CPU)));
     TEST_CASE((TestCorrectness<uint3, eBorderType::BORDER_TYPE_REFLECT>(3, {40, 10}, {80, 25}, FMT_RGB32, 0, 5, make_float4(1.0f, 0.5f, 0.5f, 1.0f), eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uint3, eBorderType::BORDER_TYPE_REFLECT101>(3, {40, 10}, {80, 25}, FMT_RGB32, 0, 5, make_float4(1.0f, 0.5f, 0.5f, 1.0f), eDeviceType::CPU)));
     TEST_CASE((TestCorrectness<uint3, eBorderType::BORDER_TYPE_REPLICATE>(5, {10, 5}, {10, 25}, FMT_RGB32, 10, 0, make_float4(1.0f, 0.5f, 0.5f, 1.0f), eDeviceType::CPU)));
     TEST_CASE((TestCorrectness<uint4, eBorderType::BORDER_TYPE_WRAP>(5, {10, 5}, {10, 25}, FMT_RGBA32, 10, 0, make_float4(1.0f, 0.5f, 0.5f, 1.0f), eDeviceType::CPU)));
 
@@ -210,12 +220,14 @@ eTestStatusType test_op_copy_make_border(int argc, char** argv) {
     // F32
     TEST_CASE((TestCorrectness<float1, eBorderType::BORDER_TYPE_CONSTANT>(1, {40, 10}, {60, 20}, FMT_F32, 5, 10, make_float4(1.0f, 0.5f, 0.5f, 1.0f), eDeviceType::CPU)));
     TEST_CASE((TestCorrectness<float3, eBorderType::BORDER_TYPE_REFLECT>(3, {40, 10}, {80, 25}, FMT_RGBf32, 0, 5, make_float4(1.0f, 0.5f, 0.5f, 1.0f), eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<float3, eBorderType::BORDER_TYPE_REFLECT101>(3, {40, 10}, {80, 25}, FMT_RGBf32, 0, 5, make_float4(1.0f, 0.5f, 0.5f, 1.0f), eDeviceType::CPU)));
     TEST_CASE((TestCorrectness<float3, eBorderType::BORDER_TYPE_REPLICATE>(5, {10, 5}, {10, 25}, FMT_RGBf32, 10, 0, make_float4(1.0f, 0.5f, 0.5f, 1.0f), eDeviceType::CPU)));
     TEST_CASE((TestCorrectness<float4, eBorderType::BORDER_TYPE_WRAP>(5, {10, 5}, {10, 25}, FMT_RGBAf32, 10, 0, make_float4(1.0f, 0.5f, 0.5f, 1.0f), eDeviceType::CPU)));
 
     // F64
     TEST_CASE((TestCorrectness<double1, eBorderType::BORDER_TYPE_CONSTANT>(1, {40, 10}, {60, 20}, FMT_F64, 5, 10, make_float4(1.0f, 0.5f, 0.5f, 1.0f), eDeviceType::CPU)));
     TEST_CASE((TestCorrectness<double3, eBorderType::BORDER_TYPE_REFLECT>(3, {40, 10}, {80, 25}, FMT_RGBf64, 0, 5, make_float4(1.0f, 0.5f, 0.5f, 1.0f), eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<double3, eBorderType::BORDER_TYPE_REFLECT101>(3, {40, 10}, {80, 25}, FMT_RGBf64, 0, 5, make_float4(1.0f, 0.5f, 0.5f, 1.0f), eDeviceType::CPU)));
     TEST_CASE((TestCorrectness<double3, eBorderType::BORDER_TYPE_REPLICATE>(5, {10, 5}, {10, 25}, FMT_RGBf64, 10, 0, make_float4(1.0f, 0.5f, 0.5f, 1.0f), eDeviceType::CPU)));
     TEST_CASE((TestCorrectness<double4, eBorderType::BORDER_TYPE_WRAP>(5, {10, 5}, {10, 25}, FMT_RGBAf64, 10, 0, make_float4(1.0f, 0.5f, 0.5f, 1.0f), eDeviceType::CPU)));
 

--- a/tests/roccv/cpp/test_op_remap.cpp
+++ b/tests/roccv/cpp/test_op_remap.cpp
@@ -186,7 +186,7 @@ eTestStatusType test_op_remap(int argc, char** argv) {
     TEST_CASE((TestCorrectness<uchar4, eBorderType::BORDER_TYPE_REPLICATE, eInterpolationType::INTERP_TYPE_NEAREST,
                                eInterpolationType::INTERP_TYPE_LINEAR>(
         1, 480, 360, FMT_RGBA8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_REFLECT, eInterpolationType::INTERP_TYPE_LINEAR,
+    TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_REFLECT101, eInterpolationType::INTERP_TYPE_LINEAR,
                                eInterpolationType::INTERP_TYPE_NEAREST>(
         5, 480, 360, FMT_U8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, eDeviceType::GPU)));
     TEST_CASE((TestCorrectness<uchar3, eBorderType::BORDER_TYPE_WRAP, eInterpolationType::INTERP_TYPE_NEAREST,
@@ -214,7 +214,7 @@ eTestStatusType test_op_remap(int argc, char** argv) {
     TEST_CASE((TestCorrectness<uchar4, eBorderType::BORDER_TYPE_REPLICATE, eInterpolationType::INTERP_TYPE_NEAREST,
                                eInterpolationType::INTERP_TYPE_LINEAR>(
         3, 480, 360, FMT_RGBA8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_REFLECT, eInterpolationType::INTERP_TYPE_LINEAR,
+    TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_REFLECT101, eInterpolationType::INTERP_TYPE_LINEAR,
                                eInterpolationType::INTERP_TYPE_NEAREST>(
         5, 480, 360, FMT_U8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, eDeviceType::CPU)));
     TEST_CASE((TestCorrectness<uchar3, eBorderType::BORDER_TYPE_WRAP, eInterpolationType::INTERP_TYPE_NEAREST,


### PR DESCRIPTION
## Motivation
This PR added the reflect 101 border mode and also updated the border C-model.

## Technical Details

- The reflect 101 border mode is added. This mode excludes the boundary pixels in border making process.
- Updated border C-model. Instead of using the same code as the kernels, the new code is based on the specification of the border modes.
- Consolidated border pixel coordinate calculation into one common function.
- Added C++ test cases for reflect 101 border mode.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
