### PR TITLE
[Feature]: Implement Reformat operator

### DIFF
--- a/docs/supported-operators.md
+++ b/docs/supported-operators.md
@@ -16,6 +16,7 @@ See below for a list of Computer Vision operators rocCV supports.
 |Histogram|Calculates a histogram of values from a grayscale image.|U8|NHWC, HWC|Both|
 |NonMaximumSuppression|Performs non-maximum suppression on batches of bounding boxes based on a score and IoU threshold.|S16, 4S16|NW, NWC|Both|
 |Normalize|Normalizes image pixels' range using the provided shift and scale parameters.|U8, S8, U16, S16, U32, S32, F32|NHWC, HWC|Both|
+|Reformat|Converts a tensor between different memory layouts (e.g., NHWC, NCHW, HWC, CHW).|U8, S8, U16, S16, U32, S32, F32, F64|NHWC, NCHW, HWC, CHW|Both|
 |Remap|Maps pixels in an image from one projection to another projection in a new image.|U8|NHWC, HWC|Both|
 |Resize|Resizes input images using an interpolation mode for upscaling/downscaling.|U8, F32|NHWC, HWC|Both|
 |Rotate|Rotates (and optionally shifts) an input tensor by given angle in degrees counter-clockwise.|U8, S8, U16, S16, U32, S32, F32, F64|NHWC, HWC|Both|

--- a/include/core/tensor_layout.hpp
+++ b/include/core/tensor_layout.hpp
@@ -79,7 +79,9 @@ class TensorLayout {
         {TENSOR_LAYOUT_NW, {2, 0, 1, -1, -1, -1, -1, -1}}, {TENSOR_LAYOUT_NHWC, {4, 0, 2, 1, 3, -1, -1, -1}},
         {TENSOR_LAYOUT_NMC, {3, 0, -1, -1, -1, 1, 2, -1}}, {TENSOR_LAYOUT_NMD, {3, 0, -1, -1, -1, 1, 2, -1}},
         {TENSOR_LAYOUT_LNHWC, {5, 1, 3, 2, 4, -1, -1, 0}}, {TENSOR_LAYOUT_NCHW, {4, 0, 3, 2, 1, -1, -1, -1}},
-        {TENSOR_LAYOUT_N, {1, 0, -1, -1, -1, -1, -1, -1}}, {TENSOR_LAYOUT_NWC, {3, 0, 1, -1, 2, -1, -1, -1}}};
+        {TENSOR_LAYOUT_N, {1, 0, -1, -1, -1, -1, -1, -1}}, {TENSOR_LAYOUT_NWC, {3, 0, 1, -1, 2, -1, -1, -1}},
+        {TENSOR_LAYOUT_CHW, {3, -1, 2, 1, 0, -1, -1, -1}},
+    };
 
     /**
      * @brief Returns the layout enum stored in the TensorLayout object.

--- a/include/core/tensor_layout.hpp
+++ b/include/core/tensor_layout.hpp
@@ -61,6 +61,7 @@ class TensorLayout {
         {TENSOR_LAYOUT_NCHW,    "NCHW"},
         {TENSOR_LAYOUT_N,       "N"},
         {TENSOR_LAYOUT_NWC,     "NWC"},
+        {TENSOR_LAYOUT_CHW,     "CHW"},
     };
     // clang-format on
 

--- a/include/core/tensor_shape.hpp
+++ b/include/core/tensor_shape.hpp
@@ -99,9 +99,8 @@ class TensorShape {
     /**
      * @brief Permutes the tensor shape to the given layout.
      *
-     * @note This operation requires that the set of dimensions in the new layout are a subset of the dimensions in the
-     * current layout. For example, a tensor shape with layout HWC cannot be permuted to layout NCHW because NCHW has
-     * dimension N that is not present in HWC.
+     * @note If the desired layout contains dimensions that are not present in the current layout, those dimensions will
+     * be set to 1 in the permuted shape.
 
      * @param[in] layout The layout to permute the tensor shape to.
      * @return The permuted tensor shape.

--- a/include/core/util_enums.h
+++ b/include/core/util_enums.h
@@ -49,6 +49,7 @@ typedef enum eTensorLayout {
                             Width, Channels */
     TENSOR_LAYOUT_NCHW,  /* Number of Samples, Channels, Height, Width */
     TENSOR_LAYOUT_NWC,   /* Number of Samples, Width, Channels */
+    TENSOR_LAYOUT_CHW,   /* Channels, Height, Width */
 } eTensorLayout;
 
 typedef enum eChannelType {

--- a/include/core/wrappers/generic_tensor_wrapper.hpp
+++ b/include/core/wrappers/generic_tensor_wrapper.hpp
@@ -44,6 +44,20 @@ class GenericTensorWrapper {
         data = static_cast<unsigned char*>(tensorData.basePtr());
     }
 
+    /**
+     * @brief Constructs a generic tensor wrapper from a void pointer, shape, strides, and rank.
+     *
+     * @param data The data pointer to wrap.
+     * @param shape The shape of the tensor.
+     * @param strides The strides of the tensor.
+     * @param rank The rank of the tensor.
+     */
+    __device__ __host__ GenericTensorWrapper(void* data, const std::array<int64_t, ROCCV_TENSOR_MAX_RANK>& shape,
+                                             const std::array<int64_t, ROCCV_TENSOR_MAX_RANK>& strides, int rank)
+        : shape(shape), strides(strides), rank(rank) {
+        this->data = static_cast<unsigned char*>(data);
+    }
+
     template <typename... ARGS>
     __device__ __host__ T& at(ARGS... idx) {
         int64_t coords[] = {idx...};

--- a/include/core/wrappers/image_wrapper.hpp
+++ b/include/core/wrappers/image_wrapper.hpp
@@ -50,7 +50,8 @@ class ImageWrapper {
     ImageWrapper(const Tensor& tensor) {
         if (tensor.layout() != eTensorLayout::TENSOR_LAYOUT_NHWC &&
             tensor.layout() != eTensorLayout::TENSOR_LAYOUT_NCHW &&
-            tensor.layout() != eTensorLayout::TENSOR_LAYOUT_HWC) {
+            tensor.layout() != eTensorLayout::TENSOR_LAYOUT_HWC &&
+            tensor.layout() != eTensorLayout::TENSOR_LAYOUT_CHW) {
             throw Exception("The given tensor layout is not supported for ImageWrapper", eStatusType::NOT_IMPLEMENTED);
         }
 
@@ -61,8 +62,8 @@ class ImageWrapper {
 
         // Handle HWC layout, which doesn't have shapes/strides for the batch dimension. We set the batch shape to 1 and
         // the strides to 0.
-        int64_t num_batches = indexes.n < 0 ? 1 : tensor.shape(indexes.n);
-        int64_t batch_stride = indexes.n < 0 ? 0 : tdata.stride(indexes.n);
+        int64_t num_batches = indexes.n == -1 ? 1 : tensor.shape(indexes.n);
+        int64_t batch_stride = indexes.n == -1 ? 0 : tdata.stride(indexes.n);
 
         shape = {num_batches, tdata.shape(indexes.h), tdata.shape(indexes.w), tdata.shape(indexes.c)};
         stride = {batch_stride, tdata.stride(indexes.h), tdata.stride(indexes.w), tdata.stride(indexes.c)};

--- a/include/core/wrappers/image_wrapper.hpp
+++ b/include/core/wrappers/image_wrapper.hpp
@@ -60,8 +60,8 @@ class ImageWrapper {
         ImageShape indexes = {tensor.layout().batch_index(), tensor.layout().height_index(),
                               tensor.layout().width_index(), tensor.layout().channels_index()};
 
-        // Handle HWC layout, which doesn't have shapes/strides for the batch dimension. We set the batch shape to 1 and
-        // the strides to 0.
+        // Handle HWC/CHW layout, which doesn't have shapes/strides for the batch dimension. We set the batch shape to 1
+        // and the strides to 0.
         int64_t num_batches = indexes.n == -1 ? 1 : tensor.shape(indexes.n);
         int64_t batch_stride = indexes.n == -1 ? 0 : tdata.stride(indexes.n);
 

--- a/include/kernels/device/reformat_device.hpp
+++ b/include/kernels/device/reformat_device.hpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <hip/hip_runtime.h>
+
+#include "core/wrappers/image_wrapper.hpp"
+
+namespace Kernels::Device {
+
+/**
+ * @brief Device kernel for reformatting a tensor from one layout to another.
+ *
+ * @tparam T The datatype of the tensor.
+ * @tparam Channels The number of channels in the tensor.
+ * @param[in] input The input tensor.
+ * @param[out] output The output tensor.
+ */
+template <int Channels, typename T>
+__global__ void reformat(roccv::ImageWrapper<T> input, roccv::ImageWrapper<T> output) {
+    const int x = blockDim.x * blockIdx.x + threadIdx.x;
+    const int y = blockDim.y * blockIdx.y + threadIdx.y;
+    const int b = blockIdx.z;
+
+    if (x >= output.width() || y >= output.height()) return;
+
+#pragma unroll
+    for (int c = 0; c < Channels; c++) {
+        output.at(b, y, x, c) = input.at(b, y, x, c);
+    }
+}
+}  // namespace Kernels::Device

--- a/include/kernels/host/reformat_host.hpp
+++ b/include/kernels/host/reformat_host.hpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#pragma once
+
+#include <hip/hip_runtime.h>
+
+#include "core/wrappers/image_wrapper.hpp"
+
+namespace Kernels::Host {
+
+/**
+ * @brief Host kernel for reformatting a tensor from one layout to another.
+ *
+ * @tparam T The datatype of the tensor.
+ * @tparam Channels The number of channels in the tensor.
+ * @param[in] input The input tensor.
+ * @param[out] output The output tensor.
+ */
+template <int Channels, typename T>
+void reformat(roccv::ImageWrapper<T> input, roccv::ImageWrapper<T> output) {
+#pragma omp parallel for
+    for (int b = 0; b < output.batches(); b++) {
+        for (int y = 0; y < output.height(); y++) {
+            for (int x = 0; x < output.width(); x++) {
+#pragma unroll
+                for (int c = 0; c < Channels; c++) {
+                    output.at(b, y, x, c) = input.at(b, y, x, c);
+                }
+            }
+        }
+    }
+}
+}  // namespace Kernels::Host

--- a/include/op_reformat.hpp
+++ b/include/op_reformat.hpp
@@ -71,7 +71,9 @@ class Reformat final : public IOperator {
      * @param[in] stream The HIP stream to run this operation on.
      * @param[in] input The input tensor to reformat.
      * @param[out] output The output tensor to store the result.
+     * @param[in] device The device to run this operation on. Default is GPU.
      */
-    void operator()(hipStream_t stream, const Tensor& input, const Tensor& output);
+    void operator()(hipStream_t stream, const Tensor& input, const Tensor& output,
+                    const eDeviceType device = eDeviceType::GPU) const;
 };
 }  // namespace roccv

--- a/include/op_reformat.hpp
+++ b/include/op_reformat.hpp
@@ -20,6 +20,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
+#pragma once
+
 #include "core/tensor.hpp"
 #include "i_operator.hpp"
 

--- a/include/op_reformat.hpp
+++ b/include/op_reformat.hpp
@@ -1,0 +1,77 @@
+/**
+Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#include "core/tensor.hpp"
+#include "i_operator.hpp"
+
+namespace roccv {
+class Reformat final : public IOperator {
+   public:
+    /**
+     * @brief Constructs a Reformat object.
+     *
+     */
+    explicit Reformat() {}
+
+    /**
+     * @brief Destroys a Reformat object.
+     *
+     */
+    ~Reformat() {}
+
+    /**
+     * @brief Executes the Reformat operation on the given HIP stream.
+     *
+     * Reformat changes the layout of the input tensor to that of the output tensor by rearranging memory. Supported
+     * layout conversions include:
+     * - NHWC to NCHW (and vice versa)
+     *
+     * Limitations:
+     *
+     * Input:
+     *       Supported TensorLayout(s): [NHWC, NCHW, HWC]
+     *                        Channels: [1, 3, 4]
+     *       Supported DataType(s):     [U8, S8, U16, S16, U32, S32, F32, F64]
+     *
+     * Output:
+     *       Supported TensorLayout(s): [NHWC, NCHW, HWC]
+     *                        Channels: [1, 3, 4]
+     *       Supported DataType(s):     [U8, S8, U16, S16, U32, S32, F32, F64]
+     *
+     * Input/Output dependency:
+     *
+     *       Property      |  Input == Output
+     *      -------------- | -------------
+     *       TensorLayout  | No
+     *       DataType      | Yes
+     *       Channels      | Yes
+     *       Width         | Yes
+     *       Height        | Yes
+     *       Batch Size    | Yes
+     *
+     * @param[in] stream The HIP stream to run this operation on.
+     * @param[in] input The input tensor to reformat.
+     * @param[out] output The output tensor to store the result.
+     */
+    void operator()(hipStream_t stream, const Tensor& input, const Tensor& output);
+};
+}  // namespace roccv

--- a/include/op_reformat.hpp
+++ b/include/op_reformat.hpp
@@ -41,19 +41,24 @@ class Reformat final : public IOperator {
     /**
      * @brief Executes the Reformat operation on the given HIP stream.
      *
-     * Reformat changes the layout of the input tensor to that of the output tensor by rearranging memory. Supported
-     * layout conversions include:
-     * - NHWC to NCHW (and vice versa)
+     * Reformat changes the layout of the input tensor to that of the output tensor by rearranging memory. All
+     * combinations of supported input and output layouts are supported. Note that reformatting to the same layout is
+     * essentially a tensor copy.
+     *
+     * Although reformating from HWC to NHWC, or CHW to NCHW is supported, it is not recommended as it will result in a
+     * direct copy of the data without any rearrangement. To do these conversions, it is recommended to use the
+     * `Tensor::reshape()` method instead, as these will create zero-copy views pointing to the same data and is
+     * typically more efficient in most use cases.
      *
      * Limitations:
      *
      * Input:
-     *       Supported TensorLayout(s): [NHWC, NCHW, HWC]
+     *       Supported TensorLayout(s): [NHWC, NCHW, HWC, CHW]
      *                        Channels: [1, 3, 4]
      *       Supported DataType(s):     [U8, S8, U16, S16, U32, S32, F32, F64]
      *
      * Output:
-     *       Supported TensorLayout(s): [NHWC, NCHW, HWC]
+     *       Supported TensorLayout(s): [NHWC, NCHW, HWC, CHW]
      *                        Channels: [1, 3, 4]
      *       Supported DataType(s):     [U8, S8, U16, S16, U32, S32, F32, F64]
      *

--- a/python/include/operators/py_op_reformat.hpp
+++ b/python/include/operators/py_op_reformat.hpp
@@ -40,8 +40,28 @@ class PyOpReformat {
      */
     static void Export(py::module& m);
 
+    /**
+     * @brief Defines the python wrapper for `roccv::Reformat`. Executes the Reformat operation and returns the result
+     * as a new tensor.
+     *
+     * @param[in] input The input tensor to reformat.
+     * @param[in] outLayout The layout to reformat the input tensor to.
+     * @param[in] stream The HIP stream to run this operation on.
+     * @param[in] device The device to run the operation on.
+     * @return The result tensor.
+     */
     static PyTensor Execute(PyTensor& input, eTensorLayout outLayout,
                             std::optional<std::reference_wrapper<PyStream>> stream, eDeviceType device);
+
+    /**
+     * @brief Defines the python wrapper for `roccv::Reformat`. Executes the Reformat operation and stores the result in
+     * the output tensor.
+     *
+     * @param[out] output The output tensor to store the result.
+     * @param[in] input The input tensor to reformat.
+     * @param[in] stream The HIP stream to run this operation on.
+     * @param[in] device The device to run the operation on.
+     */
     static void ExecuteInto(PyTensor& output, PyTensor& input, std::optional<std::reference_wrapper<PyStream>> stream,
                             eDeviceType device);
 };

--- a/python/include/operators/py_op_reformat.hpp
+++ b/python/include/operators/py_op_reformat.hpp
@@ -1,0 +1,47 @@
+/**
+Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+#include <op_reformat.hpp>
+
+#include "py_stream.hpp"
+#include "py_tensor.hpp"
+
+namespace py = pybind11;
+
+class PyOpReformat {
+   public:
+    /**
+     * @brief Exports the Reformat operator to a Python module.
+     *
+     * @param[in] m The Python module to export the operator to.
+     */
+    static void Export(py::module& m);
+
+    static PyTensor Execute(PyTensor& input, eTensorLayout outLayout,
+                            std::optional<std::reference_wrapper<PyStream>> stream, eDeviceType device);
+    static void ExecuteInto(PyTensor& output, PyTensor& input, std::optional<std::reference_wrapper<PyStream>> stream,
+                            eDeviceType device);
+};

--- a/python/src/main.cpp
+++ b/python/src/main.cpp
@@ -25,16 +25,17 @@ THE SOFTWARE.
 
 #include "operators/py_op_bilateral_filter.hpp"
 #include "operators/py_op_bnd_box.hpp"
+#include "operators/py_op_center_crop.hpp"
 #include "operators/py_op_composite.hpp"
 #include "operators/py_op_copy_make_border.hpp"
 #include "operators/py_op_custom_crop.hpp"
-#include "operators/py_op_center_crop.hpp"
 #include "operators/py_op_cvt_color.hpp"
 #include "operators/py_op_flip.hpp"
 #include "operators/py_op_gamma_contrast.hpp"
 #include "operators/py_op_histogram.hpp"
 #include "operators/py_op_non_max_suppression.hpp"
 #include "operators/py_op_normalize.hpp"
+#include "operators/py_op_reformat.hpp"
 #include "operators/py_op_remap.hpp"
 #include "operators/py_op_resize.hpp"
 #include "operators/py_op_rotate.hpp"
@@ -76,4 +77,5 @@ PYBIND11_MODULE(rocpycv, m) {
     PyOpCopyMakeBorder::Export(m);
     PyOpCenterCrop::Export(m);
     PyOpHistogram::Export(m);
+    PyOpReformat::Export(m);
 }

--- a/python/src/main.cpp
+++ b/python/src/main.cpp
@@ -49,7 +49,7 @@ THE SOFTWARE.
 #include "py_structs.hpp"
 #include "py_tensor.hpp"
 
-PYBIND11_MODULE(_rocpycv, m) {
+PYBIND11_MODULE(rocpycv, m) {
     m.doc() = R"pbdoc(
         Python API reference
         -----------------------

--- a/python/src/main.cpp
+++ b/python/src/main.cpp
@@ -48,7 +48,7 @@ THE SOFTWARE.
 #include "py_structs.hpp"
 #include "py_tensor.hpp"
 
-PYBIND11_MODULE(rocpycv, m) {
+PYBIND11_MODULE(_rocpycv, m) {
     m.doc() = R"pbdoc(
         Python API reference
         -----------------------

--- a/python/src/operators/py_op_reformat.cpp
+++ b/python/src/operators/py_op_reformat.cpp
@@ -1,0 +1,68 @@
+/**
+Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#include "operators/py_op_reformat.hpp"
+
+void PyOpReformat::ExecuteInto(PyTensor& output, PyTensor& input,
+                               std::optional<std::reference_wrapper<PyStream>> stream, eDeviceType device) {
+    hipStream_t hipStream = stream.has_value() ? stream.value().get().getStream() : nullptr;
+
+    roccv::Reformat op;
+    op(hipStream, *input.getTensor(), *output.getTensor(), device);
+}
+
+void PyOpReformat::Export(py::module& m) {
+    using namespace py::literals;
+
+    m.def("reformat", &PyOpReformat::Execute, "input"_a, "out_layout"_a, "stream"_a = nullptr,
+          "device"_a = eDeviceType::GPU, R"pbdoc(
+            Executes the Reformat operation and returns the result as a new tensor.
+
+            See also:
+                Refer to the rocCV C++ API reference for more information on this operation.
+
+            Args:
+                input (rocpycv.Tensor): Input tensor to reformat.
+                out_layout (rocpycv.eTensorLayout): The layout to reformat the input tensor to.
+                stream (rocpycv.Stream, optional): HIP stream to run this operation on.
+                device (rocpycv.Device, optional): The device to run this operation on. Defaults to GPU.
+
+            Returns:
+                rocpycv.Tensor: The reformatted tensor.
+        )pbdoc")
+        .def("reformat_into", &PyOpReformat::ExecuteInto, "output"_a, "input"_a, "stream"_a = nullptr,
+             "device"_a = eDeviceType::GPU, R"pbdoc(
+            Executes the Reformat operation on the given HIP stream.
+
+            See also:
+                Refer to the rocCV C++ API reference for more information on this operation.
+
+            Args:
+                output (rocpycv.Tensor): Output tensor to store the result.
+                input (rocpycv.Tensor): Input tensor to reformat.
+                stream (rocpycv.Stream, optional): HIP stream to run this operation on.
+                device (rocpycv.Device, optional): The device to run this operation on. Defaults to GPU.
+
+            Returns:
+                None
+        )pbdoc");
+}

--- a/python/src/operators/py_op_reformat.cpp
+++ b/python/src/operators/py_op_reformat.cpp
@@ -30,6 +30,17 @@ void PyOpReformat::ExecuteInto(PyTensor& output, PyTensor& input,
     op(hipStream, *input.getTensor(), *output.getTensor(), device);
 }
 
+PyTensor PyOpReformat::Execute(PyTensor& input, eTensorLayout outLayout,
+                               std::optional<std::reference_wrapper<PyStream>> stream, eDeviceType device) {
+    // TODO: Construct output tensor with the correct layout.
+    hipStream_t hipStream = stream.has_value() ? stream.value().get().getStream() : nullptr;
+    auto outputTensor = std::make_shared<roccv::Tensor>(input.getTensor()->shape(), input.getTensor()->dtype(), device);
+
+    roccv::Reformat op;
+    op(hipStream, *input.getTensor(), *outputTensor, device);
+    return PyTensor(outputTensor);
+}
+
 void PyOpReformat::Export(py::module& m) {
     using namespace py::literals;
 

--- a/python/src/operators/py_op_reformat.cpp
+++ b/python/src/operators/py_op_reformat.cpp
@@ -34,7 +34,9 @@ PyTensor PyOpReformat::Execute(PyTensor& input, eTensorLayout outLayout,
                                std::optional<std::reference_wrapper<PyStream>> stream, eDeviceType device) {
     // TODO: Construct output tensor with the correct layout.
     hipStream_t hipStream = stream.has_value() ? stream.value().get().getStream() : nullptr;
-    auto outputTensor = std::make_shared<roccv::Tensor>(input.getTensor()->shape(), input.getTensor()->dtype(), device);
+    roccv::TensorShape inputShape = input.getTensor()->shape();
+    roccv::TensorShape outputShape = inputShape.permute(roccv::TensorLayout(outLayout));
+    auto outputTensor = std::make_shared<roccv::Tensor>(outputShape, input.getTensor()->dtype(), device);
 
     roccv::Reformat op;
     op(hipStream, *input.getTensor(), *outputTensor, device);

--- a/python/src/py_enums.cpp
+++ b/python/src/py_enums.cpp
@@ -35,6 +35,7 @@ void PyEnums::Export(py::module& m) {
         .value("N", TENSOR_LAYOUT_N)
         .value("NCHW", TENSOR_LAYOUT_NCHW)
         .value("NWC", TENSOR_LAYOUT_NWC)
+        .value("CHW", TENSOR_LAYOUT_CHW)
         .export_values();
 
     // eDataType Bindings
@@ -106,7 +107,7 @@ void PyEnums::Export(py::module& m) {
         .value("COLOR_RGB2GRAY", COLOR_RGB2GRAY)
         .value("COLOR_BGR2GRAY", COLOR_BGR2GRAY)
         .export_values();
-        
+
     // eRemapType Enum Bindings
     py::enum_<eRemapType>(m, "eRemapType")
         .value("REMAP_ABSOLUTE", REMAP_ABSOLUTE)

--- a/src/core/tensor_shape.cpp
+++ b/src/core/tensor_shape.cpp
@@ -154,7 +154,13 @@ const std::array<int64_t, ROCCV_TENSOR_MAX_RANK> &TensorShape::shape() const { r
 TensorShape TensorShape::permute(const TensorLayout &layout) const {
     std::vector<int64_t> permutedShape(layout.rank());
     for (int32_t i = 0; i < layout.rank(); i++) {
-        permutedShape[i] = operator[](layout.dimAt(i));
+        std::string_view dim = layout.dimAt(i);
+        int32_t index = m_layout.indexOf(dim);
+        if (index == -1) {
+            permutedShape[i] = 1;
+        } else {
+            permutedShape[i] = operator[](index);
+        }
     }
     return TensorShape(layout, permutedShape);
 }

--- a/src/op_reformat.cpp
+++ b/src/op_reformat.cpp
@@ -83,8 +83,8 @@ void Reformat::operator()(hipStream_t stream, const Tensor& input, const Tensor&
     CHECK_TENSOR_DEVICE(output, device);
     CHECK_TENSOR_DATATYPES(input, eDataType::DATA_TYPE_U8, eDataType::DATA_TYPE_S8, eDataType::DATA_TYPE_U16, eDataType::DATA_TYPE_S16, eDataType::DATA_TYPE_U32, eDataType::DATA_TYPE_S32, eDataType::DATA_TYPE_F32, eDataType::DATA_TYPE_F64);
     CHECK_TENSOR_DATATYPES(output, eDataType::DATA_TYPE_U8, eDataType::DATA_TYPE_S8, eDataType::DATA_TYPE_U16, eDataType::DATA_TYPE_S16, eDataType::DATA_TYPE_U32, eDataType::DATA_TYPE_S32, eDataType::DATA_TYPE_F32, eDataType::DATA_TYPE_F64);
-    CHECK_TENSOR_LAYOUT(input, eTensorLayout::TENSOR_LAYOUT_NHWC, eTensorLayout::TENSOR_LAYOUT_NCHW, eTensorLayout::TENSOR_LAYOUT_HWC);
-    CHECK_TENSOR_LAYOUT(output, eTensorLayout::TENSOR_LAYOUT_NHWC, eTensorLayout::TENSOR_LAYOUT_NCHW, eTensorLayout::TENSOR_LAYOUT_HWC);
+    CHECK_TENSOR_LAYOUT(input, eTensorLayout::TENSOR_LAYOUT_NHWC, eTensorLayout::TENSOR_LAYOUT_NCHW, eTensorLayout::TENSOR_LAYOUT_HWC, eTensorLayout::TENSOR_LAYOUT_CHW);
+    CHECK_TENSOR_LAYOUT(output, eTensorLayout::TENSOR_LAYOUT_NHWC, eTensorLayout::TENSOR_LAYOUT_NCHW, eTensorLayout::TENSOR_LAYOUT_HWC, eTensorLayout::TENSOR_LAYOUT_CHW);
     CHECK_TENSOR_CHANNELS(input, 1, 3, 4);
     CHECK_TENSOR_CHANNELS(output, 1, 3, 4);
 

--- a/src/op_reformat.cpp
+++ b/src/op_reformat.cpp
@@ -93,12 +93,10 @@ void Reformat::operator()(hipStream_t stream, const Tensor& input, const Tensor&
     CHECK_TENSOR_CHANNELS(output, 1, 3, 4);
 
     CHECK_TENSOR_COMPARISON(input.dtype() == output.dtype());
-    CHECK_TENSOR_COMPARISON(input.layout() != output.layout());
 
-    if (input.layout().batch_index() != -1 && output.layout().batch_index() != -1) {
-        CHECK_TENSOR_COMPARISON(input.shape(input.layout().batch_index()) ==
-                                output.shape(output.layout().batch_index()));
-    }
+    int inputBatchSize = input.layout().batch_index() != -1 ? input.shape(input.layout().batch_index()) : 1;
+    int outputBatchSize = output.layout().batch_index() != -1 ? output.shape(output.layout().batch_index()) : 1;
+    CHECK_TENSOR_COMPARISON(inputBatchSize == outputBatchSize);
 
     CHECK_TENSOR_COMPARISON(input.shape(input.layout().channels_index()) ==
                             output.shape(output.layout().channels_index()));

--- a/src/op_reformat.cpp
+++ b/src/op_reformat.cpp
@@ -76,40 +76,35 @@ void DispatchReformatType(hipStream_t stream, const Tensor& input, const Tensor&
 
 void Reformat::operator()(hipStream_t stream, const Tensor& input, const Tensor& output,
                           const eDeviceType device) const {
+    // clang-format off
+
     // Validate the input and output tensors
     CHECK_TENSOR_DEVICE(input, device);
     CHECK_TENSOR_DEVICE(output, device);
-    CHECK_TENSOR_DATATYPES(input, eDataType::DATA_TYPE_U8, eDataType::DATA_TYPE_S8, eDataType::DATA_TYPE_U16,
-                           eDataType::DATA_TYPE_S16, eDataType::DATA_TYPE_U32, eDataType::DATA_TYPE_S32,
-                           eDataType::DATA_TYPE_F32, eDataType::DATA_TYPE_F64);
-    CHECK_TENSOR_DATATYPES(output, eDataType::DATA_TYPE_U8, eDataType::DATA_TYPE_S8, eDataType::DATA_TYPE_U16,
-                           eDataType::DATA_TYPE_S16, eDataType::DATA_TYPE_U32, eDataType::DATA_TYPE_S32,
-                           eDataType::DATA_TYPE_F32, eDataType::DATA_TYPE_F64);
-    CHECK_TENSOR_LAYOUT(input, eTensorLayout::TENSOR_LAYOUT_NHWC, eTensorLayout::TENSOR_LAYOUT_NCHW,
-                        eTensorLayout::TENSOR_LAYOUT_HWC);
-    CHECK_TENSOR_LAYOUT(output, eTensorLayout::TENSOR_LAYOUT_NHWC, eTensorLayout::TENSOR_LAYOUT_NCHW,
-                        eTensorLayout::TENSOR_LAYOUT_HWC);
+    CHECK_TENSOR_DATATYPES(input, eDataType::DATA_TYPE_U8, eDataType::DATA_TYPE_S8, eDataType::DATA_TYPE_U16, eDataType::DATA_TYPE_S16, eDataType::DATA_TYPE_U32, eDataType::DATA_TYPE_S32, eDataType::DATA_TYPE_F32, eDataType::DATA_TYPE_F64);
+    CHECK_TENSOR_DATATYPES(output, eDataType::DATA_TYPE_U8, eDataType::DATA_TYPE_S8, eDataType::DATA_TYPE_U16, eDataType::DATA_TYPE_S16, eDataType::DATA_TYPE_U32, eDataType::DATA_TYPE_S32, eDataType::DATA_TYPE_F32, eDataType::DATA_TYPE_F64);
+    CHECK_TENSOR_LAYOUT(input, eTensorLayout::TENSOR_LAYOUT_NHWC, eTensorLayout::TENSOR_LAYOUT_NCHW, eTensorLayout::TENSOR_LAYOUT_HWC);
+    CHECK_TENSOR_LAYOUT(output, eTensorLayout::TENSOR_LAYOUT_NHWC, eTensorLayout::TENSOR_LAYOUT_NCHW, eTensorLayout::TENSOR_LAYOUT_HWC);
     CHECK_TENSOR_CHANNELS(input, 1, 3, 4);
     CHECK_TENSOR_CHANNELS(output, 1, 3, 4);
 
     CHECK_TENSOR_COMPARISON(input.dtype() == output.dtype());
 
-    int inputBatchSize = input.layout().batch_index() != -1 ? input.shape(input.layout().batch_index()) : 1;
-    int outputBatchSize = output.layout().batch_index() != -1 ? output.shape(output.layout().batch_index()) : 1;
+    // Validate the input and output shapes
+    const int inputBatchSize = input.layout().batch_index() != -1 ? input.shape(input.layout().batch_index()) : 1;
+    const int outputBatchSize = output.layout().batch_index() != -1 ? output.shape(output.layout().batch_index()) : 1;
+    
     CHECK_TENSOR_COMPARISON(inputBatchSize == outputBatchSize);
-
-    CHECK_TENSOR_COMPARISON(input.shape(input.layout().channels_index()) ==
-                            output.shape(output.layout().channels_index()));
+    CHECK_TENSOR_COMPARISON(input.shape(input.layout().channels_index()) == output.shape(output.layout().channels_index()));
     CHECK_TENSOR_COMPARISON(input.shape(input.layout().width_index()) == output.shape(output.layout().width_index()));
     CHECK_TENSOR_COMPARISON(input.shape(input.layout().height_index()) == output.shape(output.layout().height_index()));
 
     // Select kernel dispatcher based on the input and output datatypes.
-    // clang-format off
     static const std::unordered_map<eDataType, std::function<void(hipStream_t stream, const Tensor& input, const Tensor& output,
                                                      const eDeviceType device)>>
         funcs = {
-            {eDataType::DATA_TYPE_U8, DispatchReformatType<unsigned char>},
-            {eDataType::DATA_TYPE_S8, DispatchReformatType<signed char>},
+            {eDataType::DATA_TYPE_U8,  DispatchReformatType<unsigned char>},
+            {eDataType::DATA_TYPE_S8,  DispatchReformatType<signed char>},
             {eDataType::DATA_TYPE_U16, DispatchReformatType<unsigned short>},
             {eDataType::DATA_TYPE_S16, DispatchReformatType<signed short>},
             {eDataType::DATA_TYPE_U32, DispatchReformatType<unsigned int>},

--- a/src/op_reformat.cpp
+++ b/src/op_reformat.cpp
@@ -70,7 +70,7 @@ void DispatchReformatType(hipStream_t stream, const Tensor& input, const Tensor&
     };
     // clang-format on
 
-    auto func = funcs.at(input.shape(input.layout().channels_index()) - 1);
+    auto func = funcs.at(input.shape("C") - 1);
     if (func == nullptr) {
         throw Exception("Unsupported channel count for Reformat operation.", eStatusType::INVALID_OPERATION);
     }
@@ -95,14 +95,17 @@ void Reformat::operator()(hipStream_t stream, const Tensor& input, const Tensor&
 
     CHECK_TENSOR_COMPARISON(input.dtype() == output.dtype());
 
+    const TensorShape inputShape = input.shape();
+    const TensorShape outputShape = output.shape();
+
     // Validate the input and output shapes
-    const int inputBatchSize = input.layout().batch_index() != -1 ? input.shape(input.layout().batch_index()) : 1;
-    const int outputBatchSize = output.layout().batch_index() != -1 ? output.shape(output.layout().batch_index()) : 1;
+    const int inputBatchSize = inputShape.containsDim("N") ? inputShape["N"] : 1;
+    const int outputBatchSize = outputShape.containsDim("N") ? outputShape["N"] : 1;
     
     CHECK_TENSOR_COMPARISON(inputBatchSize == outputBatchSize);
-    CHECK_TENSOR_COMPARISON(input.shape(input.layout().channels_index()) == output.shape(output.layout().channels_index()));
-    CHECK_TENSOR_COMPARISON(input.shape(input.layout().width_index()) == output.shape(output.layout().width_index()));
-    CHECK_TENSOR_COMPARISON(input.shape(input.layout().height_index()) == output.shape(output.layout().height_index()));
+    CHECK_TENSOR_COMPARISON(inputShape["C"] == outputShape["C"]);
+    CHECK_TENSOR_COMPARISON(inputShape["W"] == outputShape["W"]);
+    CHECK_TENSOR_COMPARISON(inputShape["H"] == outputShape["H"]);
 
     // Select kernel dispatcher based on the input and output datatypes.
     static const std::unordered_map<eDataType, std::function<void(hipStream_t stream, const Tensor& input, const Tensor& output,

--- a/src/op_reformat.cpp
+++ b/src/op_reformat.cpp
@@ -28,6 +28,7 @@ THE SOFTWARE.
 #include "common/validation_helpers.hpp"
 #include "core/wrappers/image_wrapper.hpp"
 #include "kernels/device/reformat_device.hpp"
+#include "kernels/host/reformat_host.hpp"
 
 namespace roccv {
 
@@ -47,7 +48,7 @@ void DispatchReformatChannels(hipStream_t stream, const Tensor& input, const Ten
         }
 
         case eDeviceType::CPU: {
-            throw Exception("Reformat is not supported on CPU", eStatusType::NOT_IMPLEMENTED);
+            Kernels::Host::reformat<Channels, T>(inputWrap, outputWrap);
             break;
         }
     }
@@ -84,8 +85,10 @@ void Reformat::operator()(hipStream_t stream, const Tensor& input, const Tensor&
     CHECK_TENSOR_DATATYPES(output, eDataType::DATA_TYPE_U8, eDataType::DATA_TYPE_S8, eDataType::DATA_TYPE_U16,
                            eDataType::DATA_TYPE_S16, eDataType::DATA_TYPE_U32, eDataType::DATA_TYPE_S32,
                            eDataType::DATA_TYPE_F32, eDataType::DATA_TYPE_F64);
-    CHECK_TENSOR_LAYOUT(input, eTensorLayout::TENSOR_LAYOUT_NHWC, eTensorLayout::TENSOR_LAYOUT_NCHW);
-    CHECK_TENSOR_LAYOUT(output, eTensorLayout::TENSOR_LAYOUT_NHWC, eTensorLayout::TENSOR_LAYOUT_NCHW);
+    CHECK_TENSOR_LAYOUT(input, eTensorLayout::TENSOR_LAYOUT_NHWC, eTensorLayout::TENSOR_LAYOUT_NCHW,
+                        eTensorLayout::TENSOR_LAYOUT_HWC);
+    CHECK_TENSOR_LAYOUT(output, eTensorLayout::TENSOR_LAYOUT_NHWC, eTensorLayout::TENSOR_LAYOUT_NCHW,
+                        eTensorLayout::TENSOR_LAYOUT_HWC);
     CHECK_TENSOR_CHANNELS(input, 1, 3, 4);
     CHECK_TENSOR_CHANNELS(output, 1, 3, 4);
 

--- a/src/op_reformat.cpp
+++ b/src/op_reformat.cpp
@@ -1,0 +1,120 @@
+/**
+Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#include "op_reformat.hpp"
+
+#include <functional>
+#include <unordered_map>
+
+#include "common/validation_helpers.hpp"
+#include "core/wrappers/image_wrapper.hpp"
+#include "kernels/device/reformat_device.hpp"
+
+namespace roccv {
+
+namespace {
+template <int Channels, typename T>
+void DispatchReformatChannels(hipStream_t stream, const Tensor& input, const Tensor& output, const eDeviceType device) {
+    ImageWrapper<T> inputWrap(input);
+    ImageWrapper<T> outputWrap(output);
+
+    switch (device) {
+        case eDeviceType::GPU: {
+            dim3 block(64, 16);
+            dim3 grid((outputWrap.width() + block.x - 1) / block.x, (outputWrap.height() + block.y - 1) / block.y,
+                      outputWrap.batches());
+            Kernels::Device::reformat<Channels, T><<<grid, block, 0, stream>>>(inputWrap, outputWrap);
+            break;
+        }
+
+        case eDeviceType::CPU: {
+            throw Exception("Reformat is not supported on CPU", eStatusType::NOT_IMPLEMENTED);
+            break;
+        }
+    }
+}
+
+template <typename T>
+void DispatchReformatType(hipStream_t stream, const Tensor& input, const Tensor& output, const eDeviceType device) {
+    // clang-format off
+    static const std::array<std::function<void(hipStream_t stream, const Tensor& input, const Tensor& output, const eDeviceType device)>, 4> funcs = {
+        DispatchReformatChannels<1, T>,
+        nullptr,    // Not supported
+        DispatchReformatChannels<3, T>,
+        DispatchReformatChannels<4, T>,
+    };
+    // clang-format on
+
+    auto func = funcs.at(input.shape(input.layout().channels_index()) - 1);
+    if (func == nullptr) {
+        throw Exception("Not mapped to a defined function.", eStatusType::INVALID_OPERATION);
+    }
+
+    func(stream, input, output, device);
+}
+}  // namespace
+
+void Reformat::operator()(hipStream_t stream, const Tensor& input, const Tensor& output,
+                          const eDeviceType device) const {
+    // Validate the input and output tensors
+    CHECK_TENSOR_DEVICE(input, device);
+    CHECK_TENSOR_DEVICE(output, device);
+    CHECK_TENSOR_DATATYPES(input, eDataType::DATA_TYPE_U8, eDataType::DATA_TYPE_S8, eDataType::DATA_TYPE_U16,
+                           eDataType::DATA_TYPE_S16, eDataType::DATA_TYPE_U32, eDataType::DATA_TYPE_S32,
+                           eDataType::DATA_TYPE_F32, eDataType::DATA_TYPE_F64);
+    CHECK_TENSOR_DATATYPES(output, eDataType::DATA_TYPE_U8, eDataType::DATA_TYPE_S8, eDataType::DATA_TYPE_U16,
+                           eDataType::DATA_TYPE_S16, eDataType::DATA_TYPE_U32, eDataType::DATA_TYPE_S32,
+                           eDataType::DATA_TYPE_F32, eDataType::DATA_TYPE_F64);
+    CHECK_TENSOR_LAYOUT(input, eTensorLayout::TENSOR_LAYOUT_NHWC, eTensorLayout::TENSOR_LAYOUT_NCHW);
+    CHECK_TENSOR_LAYOUT(output, eTensorLayout::TENSOR_LAYOUT_NHWC, eTensorLayout::TENSOR_LAYOUT_NCHW);
+    CHECK_TENSOR_CHANNELS(input, 1, 3, 4);
+    CHECK_TENSOR_CHANNELS(output, 1, 3, 4);
+
+    CHECK_TENSOR_COMPARISON(input.shape() == output.shape());
+    CHECK_TENSOR_COMPARISON(input.dtype() == output.dtype());
+    CHECK_TENSOR_COMPARISON(input.layout() != output.layout());
+
+    // Select kernel dispatcher based on the input and output datatypes.
+    // clang-format off
+    static const std::unordered_map<eDataType, std::function<void(hipStream_t stream, const Tensor& input, const Tensor& output,
+                                                     const eDeviceType device)>>
+        funcs = {
+            {eDataType::DATA_TYPE_U8, DispatchReformatType<unsigned char>},
+            {eDataType::DATA_TYPE_S8, DispatchReformatType<signed char>},
+            {eDataType::DATA_TYPE_U16, DispatchReformatType<unsigned short>},
+            {eDataType::DATA_TYPE_S16, DispatchReformatType<signed short>},
+            {eDataType::DATA_TYPE_U32, DispatchReformatType<unsigned int>},
+            {eDataType::DATA_TYPE_S32, DispatchReformatType<signed int>},
+            {eDataType::DATA_TYPE_F32, DispatchReformatType<float>},
+            {eDataType::DATA_TYPE_F64, DispatchReformatType<double>},
+        };
+    // clang-format on
+
+    auto func = funcs.at(input.dtype().etype());
+
+    if (func == nullptr) {
+        throw Exception("Not mapped to a defined function.", eStatusType::INVALID_OPERATION);
+    }
+
+    func(stream, input, output, device);
+}
+}  // namespace roccv

--- a/src/op_reformat.cpp
+++ b/src/op_reformat.cpp
@@ -51,6 +51,11 @@ void DispatchReformatChannels(hipStream_t stream, const Tensor& input, const Ten
             Kernels::Host::reformat<Channels, T>(inputWrap, outputWrap);
             break;
         }
+
+        default: {
+            throw Exception("Unsupported device type for Reformat operation.", eStatusType::INVALID_OPERATION);
+            break;
+        }
     }
 }
 
@@ -67,7 +72,7 @@ void DispatchReformatType(hipStream_t stream, const Tensor& input, const Tensor&
 
     auto func = funcs.at(input.shape(input.layout().channels_index()) - 1);
     if (func == nullptr) {
-        throw Exception("Not mapped to a defined function.", eStatusType::INVALID_OPERATION);
+        throw Exception("Unsupported channel count for Reformat operation.", eStatusType::INVALID_OPERATION);
     }
 
     func(stream, input, output, device);
@@ -117,7 +122,7 @@ void Reformat::operator()(hipStream_t stream, const Tensor& input, const Tensor&
     auto func = funcs.at(input.dtype().etype());
 
     if (func == nullptr) {
-        throw Exception("Not mapped to a defined function.", eStatusType::INVALID_OPERATION);
+        throw Exception("Unsupported datatype for Reformat operation.", eStatusType::INVALID_OPERATION);
     }
 
     func(stream, input, output, device);

--- a/src/op_reformat.cpp
+++ b/src/op_reformat.cpp
@@ -95,7 +95,7 @@ void Reformat::operator()(hipStream_t stream, const Tensor& input, const Tensor&
     CHECK_TENSOR_COMPARISON(input.dtype() == output.dtype());
     CHECK_TENSOR_COMPARISON(input.layout() != output.layout());
 
-    if (input.layout().batch_index() != -1) {
+    if (input.layout().batch_index() != -1 && output.layout().batch_index() != -1) {
         CHECK_TENSOR_COMPARISON(input.shape(input.layout().batch_index()) ==
                                 output.shape(output.layout().batch_index()));
     }

--- a/src/op_reformat.cpp
+++ b/src/op_reformat.cpp
@@ -92,9 +92,18 @@ void Reformat::operator()(hipStream_t stream, const Tensor& input, const Tensor&
     CHECK_TENSOR_CHANNELS(input, 1, 3, 4);
     CHECK_TENSOR_CHANNELS(output, 1, 3, 4);
 
-    CHECK_TENSOR_COMPARISON(input.shape() == output.shape());
     CHECK_TENSOR_COMPARISON(input.dtype() == output.dtype());
     CHECK_TENSOR_COMPARISON(input.layout() != output.layout());
+
+    if (input.layout().batch_index() != -1) {
+        CHECK_TENSOR_COMPARISON(input.shape(input.layout().batch_index()) ==
+                                output.shape(output.layout().batch_index()));
+    }
+
+    CHECK_TENSOR_COMPARISON(input.shape(input.layout().channels_index()) ==
+                            output.shape(output.layout().channels_index()));
+    CHECK_TENSOR_COMPARISON(input.shape(input.layout().width_index()) == output.shape(output.layout().width_index()));
+    CHECK_TENSOR_COMPARISON(input.shape(input.layout().height_index()) == output.shape(output.layout().height_index()));
 
     // Select kernel dispatcher based on the input and output datatypes.
     // clang-format off

--- a/tests/roccv/cpp/include/test_helpers.hpp
+++ b/tests/roccv/cpp/include/test_helpers.hpp
@@ -34,6 +34,8 @@ THE SOFTWARE.
 #include <random>
 #include <span>
 
+#include "core/tensor_layout.hpp"
+
 namespace roccv {
 namespace tests {
 
@@ -470,6 +472,23 @@ void CopyTensorIntoVector(std::vector<T>& dst, const Tensor& src) {
             break;
         }
     }
+}
+/**
+ * @brief Computes the strides for a tensor with a given shape and data type.
+ *
+ * @param shape The shape of the tensor.
+ * @param dtype The data type of the tensor.
+ * @param rank The rank of the tensor.
+ * @return The strides for the tensor.
+ */
+std::array<int64_t, ROCCV_TENSOR_MAX_RANK> ComputePackedStrides(const std::array<int64_t, ROCCV_TENSOR_MAX_RANK>& shape,
+                                                                const DataType& dtype, int rank) {
+    std::array<int64_t, ROCCV_TENSOR_MAX_RANK> strides;
+    strides[rank - 1] = dtype.size();
+    for (int i = rank - 2; i >= 0; i--) {
+        strides[i] = strides[i + 1] * shape[i + 1];
+    }
+    return strides;
 }
 
 }  // namespace tests

--- a/tests/roccv/cpp/src/tests/core/tensor/test_tensor_shape.cpp
+++ b/tests/roccv/cpp/src/tests/core/tensor/test_tensor_shape.cpp
@@ -55,12 +55,6 @@ void TestNegativeTensorShape() {
     {
         EXPECT_EXCEPTION(TensorShape shape({1, 2, 3}, "NWCX"), eStatusType::INVALID_VALUE);
     }
-
-    // Test permute operation with invalid layout
-    {
-        TensorShape shape({1, 2, 3}, "HWC");
-        EXPECT_EXCEPTION(shape.permute(TensorLayout(TENSOR_LAYOUT_NCHW)), eStatusType::OUT_OF_BOUNDS);
-    }
 }
 
 /**

--- a/tests/roccv/cpp/src/tests/operators/test_op_reformat.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_reformat.cpp
@@ -210,13 +210,6 @@ static void TestNegativeReformat() {
         EXPECT_EXCEPTION(op(nullptr, invalidTensor, validGPUTensor, eDeviceType::GPU),
                          eStatusType::INVALID_COMBINATION);
     }
-
-    // Test identical input and output layouts (not supported)
-    {
-        Reformat op;
-        EXPECT_EXCEPTION(op(nullptr, validGPUTensor, validGPUTensor, eDeviceType::GPU),
-                         eStatusType::INVALID_COMBINATION);
-    }
 }
 
 }  // namespace

--- a/tests/roccv/cpp/src/tests/operators/test_op_reformat.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_reformat.cpp
@@ -24,6 +24,7 @@ THE SOFTWARE.
 #include <core/tensor.hpp>
 #include <core/wrappers/generic_tensor_wrapper.hpp>
 
+#include "op_reformat.hpp"
 #include "test_helpers.hpp"
 
 using namespace roccv;
@@ -112,9 +113,69 @@ static std::vector<T> GoldenReformat(std::vector<T>& input, int32_t batchSize, i
 
     return outputData;
 }
+
+/**
+ * @brief Tests correctness of the Reformat operator, comparing it against a generated golden result.
+ *
+ * @tparam T The datatype of the tensor.
+ * @param[in] batchSize The batch size of the tensor.
+ * @param[in] width The width of the tensor.
+ * @param[in] height The height of the tensor.
+ * @param[in] channels The channels of the tensor.
+ * @param[in] inLayout The input layout of the tensor.
+ * @param[in] outLayout The output layout of the tensor.
+ * @param[in] dtype The datatype of the tensor.
+ * @param[in] device The device to run the roccv::Reformat operator on.
+ * @throws std::runtime_error on test failure.
+ */
+template <typename T>
+static void TestCorrectness(int batchSize, int width, int height, int channels, const TensorLayout& inLayout,
+                            const TensorLayout& outLayout, const DataType& dtype, eDeviceType device) {
+    // Create input and output tensors based on test parameters
+    std::array<int64_t, ROCCV_TENSOR_MAX_RANK> inputShapeData =
+        GetShapeFromLayout(inLayout, batchSize, width, height, channels);
+    std::array<int64_t, ROCCV_TENSOR_MAX_RANK> outputShapeData =
+        GetShapeFromLayout(outLayout, batchSize, width, height, channels);
+
+    TensorShape inputShape(inputShapeData, inLayout.rank(), inLayout.elayout());
+    TensorShape outputShape(outputShapeData, outLayout.rank(), outLayout.elayout());
+
+    Tensor input(inputShape, dtype, device);
+    Tensor output(outputShape, dtype, device);
+
+    // Create a vector and fill it with random data.
+    std::vector<T> inputData(input.shape().size());
+    FillVector(inputData);
+
+    CopyVectorIntoTensor(input, inputData);
+
+    // Obtain golden results
+    std::vector<T> goldenOutput =
+        GoldenReformat<T>(inputData, batchSize, width, height, channels, dtype, inLayout, outLayout);
+
+    // Call roccv::Reformat operator to obtain actual results
+    hipStream_t stream;
+    HIP_VALIDATE_NO_ERRORS(hipStreamCreate(&stream));
+
+    Reformat op;
+    op(stream, input, output, device);
+    HIP_VALIDATE_NO_ERRORS(hipStreamSynchronize(stream));
+    HIP_VALIDATE_NO_ERRORS(hipStreamDestroy(stream));
+
+    // Copy actual results into host allocated vector
+    std::vector<T> actualOutput(output.shape().size());
+    CopyTensorIntoVector(actualOutput, output);
+
+    // Compare actual results with golden results
+    CompareVectors(actualOutput, goldenOutput);
+}
+
 }  // namespace
 
 int main(int argc, char** argv) {
     TEST_CASES_BEGIN();
+    TEST_CASE(TestCorrectness<unsigned char>(1, 1024, 1024, 3, TensorLayout(eTensorLayout::TENSOR_LAYOUT_NHWC),
+                                             TensorLayout(eTensorLayout::TENSOR_LAYOUT_NCHW),
+                                             DataType(eDataType::DATA_TYPE_U8), eDeviceType::GPU));
     TEST_CASES_END();
 }

--- a/tests/roccv/cpp/src/tests/operators/test_op_reformat.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_reformat.cpp
@@ -46,7 +46,10 @@ namespace {
 static std::array<int64_t, ROCCV_TENSOR_MAX_RANK> GetShapeFromLayout(const TensorLayout& layout, int32_t batchSize,
                                                                      int32_t width, int32_t height, int32_t channels) {
     std::array<int64_t, ROCCV_TENSOR_MAX_RANK> shape;
-    shape[layout.batch_index()] = batchSize;
+    if (layout.batch_index() != -1) {
+        shape[layout.batch_index()] = batchSize;
+    }
+
     shape[layout.height_index()] = height;
     shape[layout.width_index()] = width;
     shape[layout.channels_index()] = channels;
@@ -100,6 +103,30 @@ static std::vector<T> GoldenReformat(std::vector<T>& input, int32_t batchSize, i
                              outLayout.elayout() == eTensorLayout::TENSOR_LAYOUT_NHWC) {
                         // NCHW to NHWC
                         outputWrapper.at(b, y, x, c) = inputWrapper.at(b, c, y, x);
+                    }
+
+                    else if (inLayout.elayout() == eTensorLayout::TENSOR_LAYOUT_HWC &&
+                             outLayout.elayout() == eTensorLayout::TENSOR_LAYOUT_NHWC) {
+                        // HWC to NHWC
+                        outputWrapper.at(b, y, x, c) = inputWrapper.at(y, x, c);
+                    }
+
+                    else if (inLayout.elayout() == eTensorLayout::TENSOR_LAYOUT_NHWC &&
+                             outLayout.elayout() == eTensorLayout::TENSOR_LAYOUT_HWC) {
+                        // NHWC to HWC
+                        outputWrapper.at(y, x, c) = inputWrapper.at(b, y, x, c);
+                    }
+
+                    else if (inLayout.elayout() == eTensorLayout::TENSOR_LAYOUT_NCHW &&
+                             outLayout.elayout() == eTensorLayout::TENSOR_LAYOUT_HWC) {
+                        // NCHW to HWC
+                        outputWrapper.at(y, x, c) = inputWrapper.at(b, c, y, x);
+                    }
+
+                    else if (inLayout.elayout() == eTensorLayout::TENSOR_LAYOUT_HWC &&
+                             outLayout.elayout() == eTensorLayout::TENSOR_LAYOUT_NCHW) {
+                        // HWC to NCHW
+                        outputWrapper.at(b, c, y, x) = inputWrapper.at(y, x, c);
                     }
 
                     else {
@@ -170,12 +197,74 @@ static void TestCorrectness(int batchSize, int width, int height, int channels, 
     CompareVectors(actualOutput, goldenOutput);
 }
 
+static void TestNegativeReformat() {
+    TensorShape validLayoutShape(TensorLayout(eTensorLayout::TENSOR_LAYOUT_NHWC), {1, 1, 1, 1});
+    Tensor validGPUTensor(validLayoutShape, DataType(eDataType::DATA_TYPE_U8), eDeviceType::GPU);
+    Tensor validCPUTensor(validLayoutShape, DataType(eDataType::DATA_TYPE_U8), eDeviceType::CPU);
+
+    // Test unsupported layout
+    {
+        TensorShape invalidLayoutShape(TensorLayout(eTensorLayout::TENSOR_LAYOUT_NC), {1, 1});
+        Tensor invalidTensor(invalidLayoutShape, DataType(eDataType::DATA_TYPE_U8), eDeviceType::GPU);
+        Reformat op;
+        EXPECT_EXCEPTION(op(nullptr, invalidTensor, validGPUTensor, eDeviceType::GPU),
+                         eStatusType::INVALID_COMBINATION);
+    }
+
+    // Test identical input and output layouts (not supported)
+    {
+        Reformat op;
+        EXPECT_EXCEPTION(op(nullptr, validGPUTensor, validGPUTensor, eDeviceType::GPU),
+                         eStatusType::INVALID_COMBINATION);
+    }
+}
+
 }  // namespace
 
 int main(int argc, char** argv) {
     TEST_CASES_BEGIN();
-    TEST_CASE(TestCorrectness<unsigned char>(1, 1024, 1024, 3, TensorLayout(eTensorLayout::TENSOR_LAYOUT_NHWC),
-                                             TensorLayout(eTensorLayout::TENSOR_LAYOUT_NCHW),
-                                             DataType(eDataType::DATA_TYPE_U8), eDeviceType::GPU));
+
+    // clang-format off
+
+    // GPU Tests - NHWC to NCHW
+    TEST_CASE(TestCorrectness<unsigned char >(1, 32, 24, 3, TensorLayout(eTensorLayout::TENSOR_LAYOUT_NHWC), TensorLayout(eTensorLayout::TENSOR_LAYOUT_NCHW), DataType(eDataType::DATA_TYPE_U8 ),  eDeviceType::GPU));
+    TEST_CASE(TestCorrectness<unsigned short>(3, 64, 48, 4, TensorLayout(eTensorLayout::TENSOR_LAYOUT_NHWC), TensorLayout(eTensorLayout::TENSOR_LAYOUT_NCHW), DataType(eDataType::DATA_TYPE_U16),  eDeviceType::GPU));
+    TEST_CASE(TestCorrectness<float         >(7, 16,  8, 1, TensorLayout(eTensorLayout::TENSOR_LAYOUT_NHWC), TensorLayout(eTensorLayout::TENSOR_LAYOUT_NCHW), DataType(eDataType::DATA_TYPE_F32),  eDeviceType::GPU));
+
+    // GPU Tests - NCHW to NHWC
+    TEST_CASE(TestCorrectness<unsigned char >(1, 32, 24, 3, TensorLayout(eTensorLayout::TENSOR_LAYOUT_NCHW), TensorLayout(eTensorLayout::TENSOR_LAYOUT_NHWC), DataType(eDataType::DATA_TYPE_U8 ),  eDeviceType::GPU));
+    TEST_CASE(TestCorrectness<unsigned short>(3, 64, 48, 4, TensorLayout(eTensorLayout::TENSOR_LAYOUT_NCHW), TensorLayout(eTensorLayout::TENSOR_LAYOUT_NHWC), DataType(eDataType::DATA_TYPE_U16),  eDeviceType::GPU));
+    TEST_CASE(TestCorrectness<float         >(7, 16,  8, 1, TensorLayout(eTensorLayout::TENSOR_LAYOUT_NCHW), TensorLayout(eTensorLayout::TENSOR_LAYOUT_NHWC), DataType(eDataType::DATA_TYPE_F32),  eDeviceType::GPU));
+
+    // GPU Tests - HWC to NHWC
+    TEST_CASE(TestCorrectness<unsigned char >(1, 32, 24, 3, TensorLayout(eTensorLayout::TENSOR_LAYOUT_HWC), TensorLayout(eTensorLayout::TENSOR_LAYOUT_NHWC), DataType(eDataType::DATA_TYPE_U8 ),  eDeviceType::GPU));
+    TEST_CASE(TestCorrectness<unsigned short>(1, 64, 48, 4, TensorLayout(eTensorLayout::TENSOR_LAYOUT_HWC), TensorLayout(eTensorLayout::TENSOR_LAYOUT_NHWC), DataType(eDataType::DATA_TYPE_U16),  eDeviceType::GPU));
+    TEST_CASE(TestCorrectness<float         >(1, 16,  8, 1, TensorLayout(eTensorLayout::TENSOR_LAYOUT_HWC), TensorLayout(eTensorLayout::TENSOR_LAYOUT_NHWC), DataType(eDataType::DATA_TYPE_F32),  eDeviceType::GPU));
+
+    // GPU Tests - NHWC to HWC
+    TEST_CASE(TestCorrectness<unsigned char >(1, 32, 24, 3, TensorLayout(eTensorLayout::TENSOR_LAYOUT_NHWC), TensorLayout(eTensorLayout::TENSOR_LAYOUT_HWC), DataType(eDataType::DATA_TYPE_U8 ),  eDeviceType::GPU));
+    TEST_CASE(TestCorrectness<unsigned short>(1, 64, 48, 4, TensorLayout(eTensorLayout::TENSOR_LAYOUT_NHWC), TensorLayout(eTensorLayout::TENSOR_LAYOUT_HWC), DataType(eDataType::DATA_TYPE_U16),  eDeviceType::GPU));
+    TEST_CASE(TestCorrectness<float         >(1, 16,  8, 1, TensorLayout(eTensorLayout::TENSOR_LAYOUT_NHWC), TensorLayout(eTensorLayout::TENSOR_LAYOUT_HWC), DataType(eDataType::DATA_TYPE_F32),  eDeviceType::GPU));
+
+    // GPU Tests - HWC to NCHW
+    TEST_CASE(TestCorrectness<unsigned char >(1, 32, 24, 3, TensorLayout(eTensorLayout::TENSOR_LAYOUT_HWC), TensorLayout(eTensorLayout::TENSOR_LAYOUT_NCHW), DataType(eDataType::DATA_TYPE_U8 ),  eDeviceType::GPU));
+    TEST_CASE(TestCorrectness<unsigned short>(1, 64, 48, 4, TensorLayout(eTensorLayout::TENSOR_LAYOUT_HWC), TensorLayout(eTensorLayout::TENSOR_LAYOUT_NCHW), DataType(eDataType::DATA_TYPE_U16),  eDeviceType::GPU));
+    TEST_CASE(TestCorrectness<float         >(1, 16,  8, 1, TensorLayout(eTensorLayout::TENSOR_LAYOUT_HWC), TensorLayout(eTensorLayout::TENSOR_LAYOUT_NCHW), DataType(eDataType::DATA_TYPE_F32),  eDeviceType::GPU));
+    
+    // CPU Tests - NHWC to NCHW
+    TEST_CASE(TestCorrectness<unsigned char >(1, 32, 24, 3, TensorLayout(eTensorLayout::TENSOR_LAYOUT_NHWC), TensorLayout(eTensorLayout::TENSOR_LAYOUT_NCHW), DataType(eDataType::DATA_TYPE_U8 ),  eDeviceType::CPU));
+    TEST_CASE(TestCorrectness<signed  short >(3, 64, 48, 4, TensorLayout(eTensorLayout::TENSOR_LAYOUT_NHWC), TensorLayout(eTensorLayout::TENSOR_LAYOUT_NCHW), DataType(eDataType::DATA_TYPE_S16),  eDeviceType::CPU));
+    TEST_CASE(TestCorrectness<double        >(7, 16,  8, 1, TensorLayout(eTensorLayout::TENSOR_LAYOUT_NHWC), TensorLayout(eTensorLayout::TENSOR_LAYOUT_NCHW), DataType(eDataType::DATA_TYPE_F64),  eDeviceType::CPU));
+
+    // CPU Tests - NCHW to NHWC
+    TEST_CASE(TestCorrectness<unsigned char >(1, 32, 24, 3, TensorLayout(eTensorLayout::TENSOR_LAYOUT_NCHW), TensorLayout(eTensorLayout::TENSOR_LAYOUT_NHWC), DataType(eDataType::DATA_TYPE_U8 ),  eDeviceType::CPU));
+    TEST_CASE(TestCorrectness<signed  short >(3, 64, 48, 4, TensorLayout(eTensorLayout::TENSOR_LAYOUT_NCHW), TensorLayout(eTensorLayout::TENSOR_LAYOUT_NHWC), DataType(eDataType::DATA_TYPE_S16),  eDeviceType::CPU));
+    TEST_CASE(TestCorrectness<double        >(7, 16,  8, 1, TensorLayout(eTensorLayout::TENSOR_LAYOUT_NCHW), TensorLayout(eTensorLayout::TENSOR_LAYOUT_NHWC), DataType(eDataType::DATA_TYPE_F64),  eDeviceType::CPU));
+
+    // clang-format on
+
+    // Negative Tests
+    TEST_CASE(TestNegativeReformat());
+
     TEST_CASES_END();
 }

--- a/tests/roccv/cpp/src/tests/operators/test_op_reformat.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_reformat.cpp
@@ -1,0 +1,120 @@
+/**
+Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#include <core/detail/type_traits.hpp>
+#include <core/tensor.hpp>
+#include <core/wrappers/generic_tensor_wrapper.hpp>
+
+#include "test_helpers.hpp"
+
+using namespace roccv;
+using namespace roccv::tests;
+using namespace roccv::detail;
+
+namespace {
+
+/**
+ * @brief Calculates the shape of a tensor from a layout, batch size, width, height, and channels.
+ *
+ * @param[in] layout The layout of the tensor.
+ * @param[in] batchSize The batch size of the tensor.
+ * @param[in] width The width of the tensor.
+ * @param[in] height The height of the tensor.
+ * @param[in] channels The channels of the tensor.
+ * @return The shape of the tensor.
+ */
+static std::array<int64_t, ROCCV_TENSOR_MAX_RANK> GetShapeFromLayout(const TensorLayout& layout, int32_t batchSize,
+                                                                     int32_t width, int32_t height, int32_t channels) {
+    std::array<int64_t, ROCCV_TENSOR_MAX_RANK> shape;
+    shape[layout.batch_index()] = batchSize;
+    shape[layout.height_index()] = height;
+    shape[layout.width_index()] = width;
+    shape[layout.channels_index()] = channels;
+    return shape;
+}
+
+/**
+ * @brief Golden model for reformatting a tensor from one layout to another.
+ *
+ * @tparam T The datatype of the tensor.
+ * @param[in] input The input tensor data.
+ * @param[in] batchSize The batch size of the tensor.
+ * @param[in] width The width of the tensor.
+ * @param[in] height The height of the tensor.
+ * @param[in] channels The channels of the tensor.
+ * @param[in] dtype The datatype of the tensor.
+ * @param[in] inLayout The input layout of the tensor.
+ * @param[in] outLayout The output layout of the tensor.
+ * @return The output tensor data.
+ */
+template <typename T>
+static std::vector<T> GoldenReformat(std::vector<T>& input, int32_t batchSize, int32_t width, int32_t height,
+                                     int32_t channels, const DataType& dtype, const TensorLayout& inLayout,
+                                     const TensorLayout& outLayout) {
+    // Calculate the shape and strides for the input and output tensors.
+    std::array<int64_t, ROCCV_TENSOR_MAX_RANK> inShape =
+        GetShapeFromLayout(inLayout, batchSize, width, height, channels);
+    std::array<int64_t, ROCCV_TENSOR_MAX_RANK> inStrides = ComputePackedStrides(inShape, dtype, inLayout.rank());
+    std::array<int64_t, ROCCV_TENSOR_MAX_RANK> outShape =
+        GetShapeFromLayout(outLayout, batchSize, width, height, channels);
+    std::array<int64_t, ROCCV_TENSOR_MAX_RANK> outStrides = ComputePackedStrides(outShape, dtype, outLayout.rank());
+
+    // Create the output data and wrappers.
+    std::vector<T> outputData(batchSize * width * height * channels);
+    GenericTensorWrapper<T> outputWrapper(outputData.data(), outShape, outStrides, outLayout.rank());
+    GenericTensorWrapper<T> inputWrapper(input.data(), inShape, inStrides, inLayout.rank());
+
+    // TODO: Support HWC <-> CHW conversions.
+
+    for (int32_t b = 0; b < batchSize; b++) {
+        for (int32_t y = 0; y < height; y++) {
+            for (int32_t x = 0; x < width; x++) {
+                for (int32_t c = 0; c < channels; c++) {
+                    if (inLayout.elayout() == eTensorLayout::TENSOR_LAYOUT_NHWC &&
+                        outLayout.elayout() == eTensorLayout::TENSOR_LAYOUT_NCHW) {
+                        // NHWC to NCHW
+                        outputWrapper.at(b, c, y, x) = inputWrapper.at(b, y, x, c);
+                    }
+
+                    else if (inLayout.elayout() == eTensorLayout::TENSOR_LAYOUT_NCHW &&
+                             outLayout.elayout() == eTensorLayout::TENSOR_LAYOUT_NHWC) {
+                        // NCHW to NHWC
+                        outputWrapper.at(b, y, x, c) = inputWrapper.at(b, c, y, x);
+                    }
+
+                    else {
+                        throw Exception("Invalid layout conversion requested in GoldenReformat",
+                                        eStatusType::INVALID_VALUE);
+                    }
+                }
+            }
+        }
+    }
+
+    return outputData;
+}
+}  // namespace
+
+int main(int argc, char** argv) {
+    TEST_CASES_BEGIN();
+    TEST_CASES_END();
+}

--- a/tests/roccv/cpp/src/tests/operators/test_op_reformat.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_reformat.cpp
@@ -57,6 +57,35 @@ static std::array<int64_t, ROCCV_TENSOR_MAX_RANK> GetShapeFromLayout(const Tenso
 }
 
 /**
+ * @brief Gets an element from a generic tensor wrapper based on a layout.
+ *
+ * @tparam T The datatype of the tensor.
+ * @param[in] wrapper The generic tensor wrapper.
+ * @param[in] layout The layout of the tensor.
+ * @param[in] batchIndex The batch index of the element.
+ * @param[in] heightIndex The height index of the element.
+ * @param[in] widthIndex The width index of the element.
+ * @param[in] channelsIndex The channels index of the element.
+ * @return The element from the generic tensor wrapper based on the layout.
+ */
+template <typename T>
+static T& GetElement(GenericTensorWrapper<T>& wrapper, const TensorLayout& layout, int32_t batchIndex,
+                     int32_t heightIndex, int32_t widthIndex, int32_t channelsIndex) {
+    switch (layout.elayout()) {
+        case eTensorLayout::TENSOR_LAYOUT_NHWC:
+            return wrapper.at(batchIndex, heightIndex, widthIndex, channelsIndex);
+        case eTensorLayout::TENSOR_LAYOUT_NCHW:
+            return wrapper.at(batchIndex, channelsIndex, heightIndex, widthIndex);
+        case eTensorLayout::TENSOR_LAYOUT_HWC:
+            return wrapper.at(heightIndex, widthIndex, channelsIndex);
+        case eTensorLayout::TENSOR_LAYOUT_CHW:
+            return wrapper.at(channelsIndex, heightIndex, widthIndex);
+        default:
+            throw Exception("Unsupported layout for Reformat", eStatusType::INVALID_VALUE);
+    }
+}
+
+/**
  * @brief Golden model for reformatting a tensor from one layout to another.
  *
  * @tparam T The datatype of the tensor.
@@ -87,52 +116,11 @@ static std::vector<T> GoldenReformat(std::vector<T>& input, int32_t batchSize, i
     GenericTensorWrapper<T> outputWrapper(outputData.data(), outShape, outStrides, outLayout.rank());
     GenericTensorWrapper<T> inputWrapper(input.data(), inShape, inStrides, inLayout.rank());
 
-    // TODO: Support HWC <-> CHW conversions.
-
     for (int32_t b = 0; b < batchSize; b++) {
         for (int32_t y = 0; y < height; y++) {
             for (int32_t x = 0; x < width; x++) {
                 for (int32_t c = 0; c < channels; c++) {
-                    if (inLayout.elayout() == eTensorLayout::TENSOR_LAYOUT_NHWC &&
-                        outLayout.elayout() == eTensorLayout::TENSOR_LAYOUT_NCHW) {
-                        // NHWC to NCHW
-                        outputWrapper.at(b, c, y, x) = inputWrapper.at(b, y, x, c);
-                    }
-
-                    else if (inLayout.elayout() == eTensorLayout::TENSOR_LAYOUT_NCHW &&
-                             outLayout.elayout() == eTensorLayout::TENSOR_LAYOUT_NHWC) {
-                        // NCHW to NHWC
-                        outputWrapper.at(b, y, x, c) = inputWrapper.at(b, c, y, x);
-                    }
-
-                    else if (inLayout.elayout() == eTensorLayout::TENSOR_LAYOUT_HWC &&
-                             outLayout.elayout() == eTensorLayout::TENSOR_LAYOUT_NHWC) {
-                        // HWC to NHWC
-                        outputWrapper.at(b, y, x, c) = inputWrapper.at(y, x, c);
-                    }
-
-                    else if (inLayout.elayout() == eTensorLayout::TENSOR_LAYOUT_NHWC &&
-                             outLayout.elayout() == eTensorLayout::TENSOR_LAYOUT_HWC) {
-                        // NHWC to HWC
-                        outputWrapper.at(y, x, c) = inputWrapper.at(b, y, x, c);
-                    }
-
-                    else if (inLayout.elayout() == eTensorLayout::TENSOR_LAYOUT_NCHW &&
-                             outLayout.elayout() == eTensorLayout::TENSOR_LAYOUT_HWC) {
-                        // NCHW to HWC
-                        outputWrapper.at(y, x, c) = inputWrapper.at(b, c, y, x);
-                    }
-
-                    else if (inLayout.elayout() == eTensorLayout::TENSOR_LAYOUT_HWC &&
-                             outLayout.elayout() == eTensorLayout::TENSOR_LAYOUT_NCHW) {
-                        // HWC to NCHW
-                        outputWrapper.at(b, c, y, x) = inputWrapper.at(y, x, c);
-                    }
-
-                    else {
-                        throw Exception("Invalid layout conversion requested in GoldenReformat",
-                                        eStatusType::INVALID_VALUE);
-                    }
+                    GetElement(outputWrapper, outLayout, b, y, x, c) = GetElement(inputWrapper, inLayout, b, y, x, c);
                 }
             }
         }

--- a/tests/roccv/cpp/src/tests/operators/test_op_reformat.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_reformat.cpp
@@ -232,6 +232,16 @@ int main(int argc, char** argv) {
     TEST_CASE(TestCorrectness<unsigned short>(1, 64, 48, 4, TensorLayout(eTensorLayout::TENSOR_LAYOUT_HWC), TensorLayout(eTensorLayout::TENSOR_LAYOUT_NCHW), DataType(eDataType::DATA_TYPE_U16),  eDeviceType::GPU));
     TEST_CASE(TestCorrectness<float         >(1, 16,  8, 1, TensorLayout(eTensorLayout::TENSOR_LAYOUT_HWC), TensorLayout(eTensorLayout::TENSOR_LAYOUT_NCHW), DataType(eDataType::DATA_TYPE_F32),  eDeviceType::GPU));
     
+    // GPU Tests - CHW to NHWC
+    TEST_CASE(TestCorrectness<unsigned char >(1, 32, 24, 3, TensorLayout(eTensorLayout::TENSOR_LAYOUT_CHW), TensorLayout(eTensorLayout::TENSOR_LAYOUT_NHWC), DataType(eDataType::DATA_TYPE_U8 ),  eDeviceType::GPU));
+    TEST_CASE(TestCorrectness<unsigned short>(1, 64, 48, 4, TensorLayout(eTensorLayout::TENSOR_LAYOUT_CHW), TensorLayout(eTensorLayout::TENSOR_LAYOUT_NHWC), DataType(eDataType::DATA_TYPE_U16),  eDeviceType::GPU));
+    TEST_CASE(TestCorrectness<float         >(1, 16,  8, 1, TensorLayout(eTensorLayout::TENSOR_LAYOUT_CHW), TensorLayout(eTensorLayout::TENSOR_LAYOUT_NHWC), DataType(eDataType::DATA_TYPE_F32),  eDeviceType::GPU));
+
+    // GPU Tests - NHWC to CHW
+    TEST_CASE(TestCorrectness<unsigned char >(1, 32, 24, 3, TensorLayout(eTensorLayout::TENSOR_LAYOUT_NHWC), TensorLayout(eTensorLayout::TENSOR_LAYOUT_CHW), DataType(eDataType::DATA_TYPE_U8 ),  eDeviceType::GPU));
+    TEST_CASE(TestCorrectness<unsigned short>(1, 64, 48, 4, TensorLayout(eTensorLayout::TENSOR_LAYOUT_NHWC), TensorLayout(eTensorLayout::TENSOR_LAYOUT_CHW), DataType(eDataType::DATA_TYPE_U16),  eDeviceType::GPU));
+    TEST_CASE(TestCorrectness<float         >(1, 16,  8, 1, TensorLayout(eTensorLayout::TENSOR_LAYOUT_NHWC), TensorLayout(eTensorLayout::TENSOR_LAYOUT_CHW), DataType(eDataType::DATA_TYPE_F32),  eDeviceType::GPU));
+
     // CPU Tests - NHWC to NCHW
     TEST_CASE(TestCorrectness<unsigned char >(1, 32, 24, 3, TensorLayout(eTensorLayout::TENSOR_LAYOUT_NHWC), TensorLayout(eTensorLayout::TENSOR_LAYOUT_NCHW), DataType(eDataType::DATA_TYPE_U8 ),  eDeviceType::CPU));
     TEST_CASE(TestCorrectness<signed  short >(3, 64, 48, 4, TensorLayout(eTensorLayout::TENSOR_LAYOUT_NHWC), TensorLayout(eTensorLayout::TENSOR_LAYOUT_NCHW), DataType(eDataType::DATA_TYPE_S16),  eDeviceType::CPU));

--- a/tests/roccv/python/test_op_reformat.py
+++ b/tests/roccv/python/test_op_reformat.py
@@ -1,0 +1,44 @@
+# ##############################################################################
+# Copyright (c)  - 2026 Advanced Micro Devices, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# ##############################################################################
+
+import rocpycv
+import pytest
+
+from test_helpers import generate_tensor, compare_tensors
+
+@pytest.mark.parametrize("device", [rocpycv.eDeviceType.GPU, rocpycv.eDeviceType.CPU])
+@pytest.mark.parametrize("dtype", [rocpycv.eDataType.U8, rocpycv.eDataType.S8, rocpycv.eDataType.U16, rocpycv.eDataType.S16, rocpycv.eDataType.U32, rocpycv.eDataType.S32, rocpycv.eDataType.F32])
+@pytest.mark.parametrize("channels", [1, 3, 4])
+@pytest.mark.parametrize("inLayout,outLayout", [
+    (rocpycv.eTensorLayout.NHWC, rocpycv.eTensorLayout.NCHW),
+    (rocpycv.eTensorLayout.NCHW, rocpycv.eTensorLayout.NHWC),
+    (rocpycv.eTensorLayout.HWC, rocpycv.eTensorLayout.NHWC),
+    (rocpycv.eTensorLayout.CHW, rocpycv.eTensorLayout.NCHW),
+])
+@pytest.mark.parametrize("samples,height,width", [
+    (1, 45, 23),
+    (3, 67, 85),
+    (7, 25, 95)
+])
+def test_op_reformat(samples, height, width, channels, device, dtype):
+    pass

--- a/tests/roccv/python/test_op_reformat.py
+++ b/tests/roccv/python/test_op_reformat.py
@@ -24,7 +24,19 @@
 import rocpycv
 import pytest
 
-from test_helpers import generate_tensor, compare_tensors
+from test_helpers import compare_tensors, generate_tensor_generic
+
+def create_tensor_shape(layout: rocpycv.eTensorLayout, samples: int, channels: int, height: int, width: int) -> list[int]:
+    if layout == rocpycv.eTensorLayout.NHWC:
+        return [samples, height, width, channels]
+    elif layout == rocpycv.eTensorLayout.NCHW:
+        return [samples, channels, height, width]
+    elif layout == rocpycv.eTensorLayout.HWC:
+        return [height, width, channels]
+    elif layout == rocpycv.eTensorLayout.CHW:
+        return [channels, height, width]
+    else:
+        raise ValueError(f"Unsupported layout: {layout}")
 
 @pytest.mark.parametrize("device", [rocpycv.eDeviceType.GPU, rocpycv.eDeviceType.CPU])
 @pytest.mark.parametrize("dtype", [rocpycv.eDataType.U8, rocpycv.eDataType.S8, rocpycv.eDataType.U16, rocpycv.eDataType.S16, rocpycv.eDataType.U32, rocpycv.eDataType.S32, rocpycv.eDataType.F32])
@@ -36,9 +48,17 @@ from test_helpers import generate_tensor, compare_tensors
     (rocpycv.eTensorLayout.CHW, rocpycv.eTensorLayout.NCHW),
 ])
 @pytest.mark.parametrize("samples,height,width", [
-    (1, 45, 23),
-    (3, 67, 85),
-    (7, 25, 95)
+    (1, 45, 23)
 ])
-def test_op_reformat(samples, height, width, channels, device, dtype):
-    pass
+def test_op_reformat(samples, height, width, channels, inLayout, outLayout, device, dtype):
+    input_shape = create_tensor_shape(inLayout, samples, channels, height, width)
+    output_shape = create_tensor_shape(outLayout, samples, channels, height, width)
+    input_tensor = generate_tensor_generic(input_shape, inLayout, dtype, device)
+    output_golden = rocpycv.Tensor(output_shape, outLayout, dtype, device)
+
+    stream = rocpycv.Stream()
+    rocpycv.reformat_into(input_tensor, output_golden, stream, device)
+    output_tensor = rocpycv.reformat(input_tensor, outLayout, stream, device)
+    stream.synchronize()
+
+    compare_tensors(output_tensor, output_golden)


### PR DESCRIPTION
## Technical Details

* Implements Reformat operator (for NHWC -> NCHW) layout conversions.
* Implements python bindings for the Reformat operator.
* Adds golden implementation for Reformat + C++ and Python tests.
* Minor change to `TensorShape::permute()`, which adds a size of 1 for dimensions which don't exist in the input layout. This change has been documented in the header's docstrings.

## Test Plan

* Ensure C++ Reformat operators (on both CPU and GPU) matches the golden model.

## Test Result

* All tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
