### PR TITLE
[Benchmarking]: Add benchmark warmups and memory throughput calculations

### DIFF
--- a/benchmarks/config.json
+++ b/benchmarks/config.json
@@ -4,31 +4,36 @@
             "samples": 1,
             "height": 1080,
             "width": 1920,
-            "runs": 10
+            "runs": 10,
+            "warmup_runs": 5
         },
         {
             "samples": 16,
             "height": 1080,
             "width": 1920,
-            "runs": 10
+            "runs": 10,
+            "warmup_runs": 5
         },
         {
             "samples": 32,
             "height": 1080,
             "width": 1920,
-            "runs": 10
+            "runs": 10,
+            "warmup_runs": 5
         },
         {
             "samples": 64,
             "height": 1080,
             "width": 1920,
-            "runs": 10
+            "runs": 10,
+            "warmup_runs": 5
         },
         {
             "samples": 128,
             "height": 1080,
             "width": 1920,
-            "runs": 10
+            "runs": 10,
+            "warmup_runs": 5
         }
     ]
 }

--- a/benchmarks/config.json
+++ b/benchmarks/config.json
@@ -4,25 +4,31 @@
             "samples": 1,
             "height": 1080,
             "width": 1920,
-            "runs": 5
+            "runs": 10
         },
         {
             "samples": 16,
             "height": 1080,
             "width": 1920,
-            "runs": 5
+            "runs": 10
         },
         {
             "samples": 32,
             "height": 1080,
             "width": 1920,
-            "runs": 5
+            "runs": 10
         },
         {
             "samples": 64,
             "height": 1080,
             "width": 1920,
-            "runs": 5
+            "runs": 10
+        },
+        {
+            "samples": 128,
+            "height": 1080,
+            "width": 1920,
+            "runs": 10
         }
     ]
 }

--- a/benchmarks/generate_graphs.py
+++ b/benchmarks/generate_graphs.py
@@ -106,7 +106,7 @@ if __name__ == "__main__":
     for category in data["results"]:
         benchmarks_in_category = data["results"][category]
 
-        fig, ax = plt.subplots(1, 2, dpi=200, figsize=(10, 6))
+        fig, ax = plt.subplots(1, 3, dpi=200, figsize=(15, 6))
 
         # Setup execution time axis
         ex_time_ax = ax[0]
@@ -122,6 +122,13 @@ if __name__ == "__main__":
         fps_ax.set_title("Frames per Second")
         fps_ax.set_yscale('log')
 
+        # Setup throughput axis
+        throughput_ax = ax[2]
+        throughput_ax.set_ylabel("Throughput (GB/s) [Log Scale]\n(Higher is better)")
+        throughput_ax.set_xlabel("Batch Size")
+        throughput_ax.set_title("Total Memory Throughput")
+        throughput_ax.set_yscale('log')
+
         # Gather data and plot results
         benchmark_names = []
         execution_time_data = []
@@ -129,19 +136,22 @@ if __name__ == "__main__":
         image_height = data["results"][category][0]["height"][0]
         image_width = data["results"][category][0]["width"][0]
         fps_data = []
+        throughput_data = []
 
         for benchmark in benchmarks_in_category:
             benchmark_names.append(benchmark["name"])
             execution_time_data.append(benchmark["execution_time"])
             fps_data.append([1000 / (benchmark["execution_time"][i] / samples[i])
                             for i in range(len(benchmark["execution_time"]))])
+            throughput_data.append([(samples[i] * image_width * image_height * 3) / (benchmark["execution_time"][i] / 1000.0) / 1e9 for i in range(len(benchmark["execution_time"]))])
 
         plot_annotated_bars(ex_time_ax, samples, execution_time_data, benchmark_names)
         plot_annotated_bars(fps_ax, samples, fps_data, benchmark_names)
+        plot_annotated_bars(throughput_ax, samples, throughput_data, benchmark_names)
 
         ex_time_ax.legend()
         fps_ax.legend()
-
+        throughput_ax.legend()
         # Set bottom text for entire figure
         fig.subplots_adjust(bottom=0.2)  # Adjust bottom to make space for footnote
         fig.text(0.5, 0.04, graph_footnote, wrap=True, ha='center', fontsize=8, alpha=0.7)  # Centered footnote

--- a/benchmarks/generate_graphs.py
+++ b/benchmarks/generate_graphs.py
@@ -149,12 +149,13 @@ if __name__ == "__main__":
         plot_annotated_bars(fps_ax, samples, fps_data, benchmark_names)
         plot_annotated_bars(throughput_ax, samples, throughput_data, benchmark_names)
 
-        ex_time_ax.legend()
-        fps_ax.legend()
-        throughput_ax.legend()
+        
+        handles, labels = ex_time_ax.get_legend_handles_labels()
+        fig.legend(handles, labels, loc='lower center', ncol=len(labels), bbox_to_anchor=(0.5, 0.10))
+
         # Set bottom text for entire figure
-        fig.subplots_adjust(bottom=0.2, wspace=0.35)
-        fig.text(0.5, 0.04, graph_footnote, wrap=True, ha='center', fontsize=8, alpha=0.7)  # Centered footnote
+        fig.subplots_adjust(bottom=0.25, wspace=0.35)
+        fig.text(0.5, 0.02, graph_footnote, wrap=True, ha='center', fontsize=8, alpha=0.7)
         fig.suptitle(f"{category} Benchmarks (Batches of {image_width}x{image_height} 8-bit Images)")
 
         output_filename = os.path.join(args.output_dir, f"bench_{category}.png")

--- a/benchmarks/generate_graphs.py
+++ b/benchmarks/generate_graphs.py
@@ -143,7 +143,7 @@ if __name__ == "__main__":
             execution_time_data.append(benchmark["execution_time"])
             fps_data.append([1000 / (benchmark["execution_time"][i] / samples[i])
                             for i in range(len(benchmark["execution_time"]))])
-            throughput_data.append([(benchmark["input_memory_bytes"][i] + benchmark["output_memory_bytes"][i]) / (benchmark["execution_time"][i] / 1000.0) / 1e9 for i in range(len(benchmark["execution_time"]))])
+            throughput_data.append([(benchmark["read_memory_bytes"][i] + benchmark["written_memory_bytes"][i]) / (benchmark["execution_time"][i] / 1000.0) / 1e9 for i in range(len(benchmark["execution_time"]))])
 
         plot_annotated_bars(ex_time_ax, samples, execution_time_data, benchmark_names)
         plot_annotated_bars(fps_ax, samples, fps_data, benchmark_names)

--- a/benchmarks/generate_graphs.py
+++ b/benchmarks/generate_graphs.py
@@ -143,7 +143,7 @@ if __name__ == "__main__":
             execution_time_data.append(benchmark["execution_time"])
             fps_data.append([1000 / (benchmark["execution_time"][i] / samples[i])
                             for i in range(len(benchmark["execution_time"]))])
-            throughput_data.append([(samples[i] * image_width * image_height * 3) / (benchmark["execution_time"][i] / 1000.0) / 1e9 for i in range(len(benchmark["execution_time"]))])
+            throughput_data.append([(benchmark["input_memory_bytes"][i] + benchmark["output_memory_bytes"][i]) / (benchmark["execution_time"][i] / 1000.0) / 1e9 for i in range(len(benchmark["execution_time"]))])
 
         plot_annotated_bars(ex_time_ax, samples, execution_time_data, benchmark_names)
         plot_annotated_bars(fps_ax, samples, fps_data, benchmark_names)
@@ -153,7 +153,7 @@ if __name__ == "__main__":
         fps_ax.legend()
         throughput_ax.legend()
         # Set bottom text for entire figure
-        fig.subplots_adjust(bottom=0.2)  # Adjust bottom to make space for footnote
+        fig.subplots_adjust(bottom=0.2, wspace=0.35)
         fig.text(0.5, 0.04, graph_footnote, wrap=True, ha='center', fontsize=8, alpha=0.7)  # Centered footnote
         fig.suptitle(f"{category} Benchmarks (Batches of {image_width}x{image_height} 8-bit Images)")
 

--- a/benchmarks/roccvbench/include/roccvbench/structs.hpp
+++ b/benchmarks/roccvbench/include/roccvbench/structs.hpp
@@ -42,7 +42,7 @@ struct BenchmarkResults {
  *
  */
 struct BenchmarkConfig {
-    int samples, width, height, runs;
+    int samples, width, height, runs, warmupRuns;
 };
 
 /**

--- a/benchmarks/roccvbench/include/roccvbench/structs.hpp
+++ b/benchmarks/roccvbench/include/roccvbench/structs.hpp
@@ -21,7 +21,9 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstddef>
+#include <functional>
+#include <string>
 
 namespace roccvbench {
 
@@ -30,7 +32,9 @@ namespace roccvbench {
  *
  */
 struct BenchmarkResults {
-    double executionTime;
+    double executionTime = 0.0;
+    size_t inputMemoryBytes = 0;
+    size_t outputMemoryBytes = 0;
 };
 
 /**

--- a/benchmarks/roccvbench/include/roccvbench/structs.hpp
+++ b/benchmarks/roccvbench/include/roccvbench/structs.hpp
@@ -33,8 +33,8 @@ namespace roccvbench {
  */
 struct BenchmarkResults {
     double executionTime = 0.0;
-    size_t inputMemoryBytes = 0;
-    size_t outputMemoryBytes = 0;
+    size_t readMemoryBytes = 0;
+    size_t writtenMemoryBytes = 0;
 };
 
 /**

--- a/benchmarks/roccvbench/include/roccvbench/utils.hpp
+++ b/benchmarks/roccvbench/include/roccvbench/utils.hpp
@@ -22,7 +22,6 @@
 #pragma once
 
 #include <chrono>
-#include <core/tensor.hpp>
 #include <random>
 #include <vector>
 

--- a/benchmarks/roccvbench/include/roccvbench/utils.hpp
+++ b/benchmarks/roccvbench/include/roccvbench/utils.hpp
@@ -60,10 +60,6 @@ std::vector<T> RandVector(size_t size) {
     return result;
 }
 
-static void RegisterMemoryUsage(const roccv::Tensor& tensor, size_t& memoryUsage) {
-    memoryUsage += tensor.shape().size() * tensor.dtype().size();
-}
-
 /**
  * @brief Records the execution time in milliseconds of a block of code <code> by running it <numRuns> times and taking
  * the mean of the results. The resulting mean is written to <executionTime>.

--- a/benchmarks/roccvbench/include/roccvbench/utils.hpp
+++ b/benchmarks/roccvbench/include/roccvbench/utils.hpp
@@ -27,6 +27,8 @@
 
 namespace roccvbench {
 
+static constexpr int NUM_WARMUP_RUNS = 5;
+
 /**
  * @brief Generates a one-dimensional vector of the given size and type.
  *
@@ -62,16 +64,20 @@ std::vector<T> RandVector(size_t size) {
  * the mean of the results. The resulting mean is written to <executionTime>.
  *
  */
-#define ROCCV_BENCH_RECORD_BLOCK(code, executionTime, numRuns)                                              \
-    {                                                                                                       \
-        double totalExecutionTime = 0.0;                                                                    \
-        for (int i = 0; i < numRuns; i++) {                                                                 \
-            auto blockStart = std::chrono::high_resolution_clock::now();                                    \
-            code;                                                                                           \
-            auto blockEnd = std::chrono::high_resolution_clock::now();                                      \
-            totalExecutionTime += std::chrono::duration<double, std::milli>(blockEnd - blockStart).count(); \
-        }                                                                                                   \
-        executionTime = totalExecutionTime / numRuns;                                                       \
+#define ROCCV_BENCH_RECORD_BLOCK(code, executionTime, numRuns)                                                  \
+    {                                                                                                           \
+        double totalExecutionTime = 0.0;                                                                        \
+        int numValidRuns = 0;                                                                                   \
+        for (int i = 0; i < numRuns; i++) {                                                                     \
+            auto blockStart = std::chrono::high_resolution_clock::now();                                        \
+            code;                                                                                               \
+            auto blockEnd = std::chrono::high_resolution_clock::now();                                          \
+            if (i >= roccvbench::NUM_WARMUP_RUNS) {                                                             \
+                totalExecutionTime += std::chrono::duration<double, std::milli>(blockEnd - blockStart).count(); \
+                numValidRuns++;                                                                                 \
+            }                                                                                                   \
+        }                                                                                                       \
+        executionTime = totalExecutionTime / numValidRuns;                                                      \
     }
 
 }  // namespace roccvbench

--- a/benchmarks/roccvbench/include/roccvbench/utils.hpp
+++ b/benchmarks/roccvbench/include/roccvbench/utils.hpp
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <chrono>
+#include <core/tensor.hpp>
 #include <random>
 #include <vector>
 
@@ -57,6 +58,10 @@ std::vector<T> RandVector(size_t size) {
     }
 
     return result;
+}
+
+static void RegisterMemoryUsage(const roccv::Tensor& tensor, size_t& memoryUsage) {
+    memoryUsage += tensor.shape().size() * tensor.dtype().size();
 }
 
 /**

--- a/benchmarks/roccvbench/include/roccvbench/utils.hpp
+++ b/benchmarks/roccvbench/include/roccvbench/utils.hpp
@@ -28,8 +28,6 @@
 
 namespace roccvbench {
 
-static constexpr int NUM_WARMUP_RUNS = 5;
-
 /**
  * @brief Generates a one-dimensional vector of the given size and type.
  *
@@ -65,15 +63,15 @@ std::vector<T> RandVector(size_t size) {
  * the mean of the results. The resulting mean is written to <executionTime>.
  *
  */
-#define ROCCV_BENCH_RECORD_BLOCK(code, executionTime, numRuns)                                                  \
+#define ROCCV_BENCH_RECORD_BLOCK(code, executionTime, numRuns, warmupRuns)                                      \
     {                                                                                                           \
         double totalExecutionTime = 0.0;                                                                        \
         int numValidRuns = 0;                                                                                   \
-        for (int i = 0; i < numRuns; i++) {                                                                     \
+        for (int i = 0; i < numRuns + warmupRuns; i++) {                                                        \
             auto blockStart = std::chrono::high_resolution_clock::now();                                        \
             code;                                                                                               \
             auto blockEnd = std::chrono::high_resolution_clock::now();                                          \
-            if (i >= roccvbench::NUM_WARMUP_RUNS) {                                                             \
+            if (i >= warmupRuns) {                                                                              \
                 totalExecutionTime += std::chrono::duration<double, std::milli>(blockEnd - blockStart).count(); \
                 numValidRuns++;                                                                                 \
             }                                                                                                   \

--- a/benchmarks/src/main.cpp
+++ b/benchmarks/src/main.cpp
@@ -312,6 +312,8 @@ int main(int argc, char** argv) {
                     runResultsJson["runs"].push_back(config.runs);
                     runResultsJson["execution_time"].push_back(result.executionTime);
                     runResultsJson["samples"].push_back(config.samples);
+                    runResultsJson["input_memory_bytes"].push_back(result.inputMemoryBytes);
+                    runResultsJson["output_memory_bytes"].push_back(result.outputMemoryBytes);
                 }
                 std::cout << std::endl;
 

--- a/benchmarks/src/main.cpp
+++ b/benchmarks/src/main.cpp
@@ -83,7 +83,7 @@ std::vector<roccvbench::BenchmarkConfig> loadConfig(const std::string& filepath)
         config.height = benchParams["height"];
         config.width = benchParams["width"];
         config.runs = benchParams["runs"];
-
+        config.warmupRuns = benchParams["warmup_runs"];
         result.push_back(config);
     }
 
@@ -303,7 +303,8 @@ int main(int argc, char** argv) {
                 // Iterate through each benchmark configuration
                 for (auto config : configs) {
                     std::cout << "\tConfig [samples=" << config.samples << ", height=" << config.height
-                              << ", width=" << config.width << ", runs=" << config.runs << "]" << std::endl;
+                              << ", width=" << config.width << ", runs=" << config.runs
+                              << ", warmupRuns=" << config.warmupRuns << "]" << std::endl;
                     auto result = benchmark.func(config);
 
                     // Write run results to output JSON

--- a/benchmarks/src/main.cpp
+++ b/benchmarks/src/main.cpp
@@ -313,8 +313,8 @@ int main(int argc, char** argv) {
                     runResultsJson["runs"].push_back(config.runs);
                     runResultsJson["execution_time"].push_back(result.executionTime);
                     runResultsJson["samples"].push_back(config.samples);
-                    runResultsJson["input_memory_bytes"].push_back(result.inputMemoryBytes);
-                    runResultsJson["output_memory_bytes"].push_back(result.outputMemoryBytes);
+                    runResultsJson["read_memory_bytes"].push_back(result.readMemoryBytes);
+                    runResultsJson["written_memory_bytes"].push_back(result.writtenMemoryBytes);
                 }
                 std::cout << std::endl;
 

--- a/benchmarks/src/main.cpp
+++ b/benchmarks/src/main.cpp
@@ -79,11 +79,11 @@ std::vector<roccvbench::BenchmarkConfig> loadConfig(const std::string& filepath)
 
     for (auto benchParams : data["params"]) {
         roccvbench::BenchmarkConfig config;
-        config.samples = benchParams["samples"];
-        config.height = benchParams["height"];
-        config.width = benchParams["width"];
-        config.runs = benchParams["runs"];
-        config.warmupRuns = benchParams["warmup_runs"];
+        config.samples = benchParams.value("samples", 1);
+        config.height = benchParams.value("height", 1080);
+        config.width = benchParams.value("width", 1920);
+        config.runs = benchParams.value("runs", 5);
+        config.warmupRuns = benchParams.value("warmup_runs", 5);
         result.push_back(config);
     }
 

--- a/benchmarks/src/opencv/bench_composite.cpp
+++ b/benchmarks/src/opencv/bench_composite.cpp
@@ -32,18 +32,18 @@ BENCHMARK(Composite, OpenCV) {
     std::vector<cv::Mat> foregrounds = GenerateMats<uint8_t>(config.samples, config.width, config.height, CV_8UC3);
     std::vector<cv::Mat> weights1 = GenerateMats<float>(config.samples, config.width, config.height, CV_32F);
     std::vector<cv::Mat> weights2 = GenerateMats<float>(config.samples, config.width, config.height, CV_32F);
-    cv::Mat outputMat(config.height, config.width, CV_8UC3);
+    std::vector<cv::Mat> outputs = CreateOutputMats(config.samples, config.width, config.height, CV_8UC3);
 
     RegisterMemoryUsage(backgrounds, results.inputMemoryBytes);
     RegisterMemoryUsage(foregrounds, results.inputMemoryBytes);
     RegisterMemoryUsage(weights1, results.inputMemoryBytes);
     RegisterMemoryUsage(weights2, results.inputMemoryBytes);
-    RegisterMemoryUsage(outputMat, results.outputMemoryBytes);
+    RegisterMemoryUsage(outputs, results.outputMemoryBytes);
 
     ROCCV_BENCH_RECORD_BLOCK(
         {
             for (size_t i = 0; i < backgrounds.size(); i++) {
-                cv::blendLinear(backgrounds[i], foregrounds[i], weights1[i], weights2[i], outputMat);
+                cv::blendLinear(backgrounds[i], foregrounds[i], weights1[i], weights2[i], outputs[i]);
             }
         },
         results.executionTime, config.runs);

--- a/benchmarks/src/opencv/bench_composite.cpp
+++ b/benchmarks/src/opencv/bench_composite.cpp
@@ -46,6 +46,6 @@ BENCHMARK(Composite, OpenCV) {
                 cv::blendLinear(backgrounds[i], foregrounds[i], weights1[i], weights2[i], outputs[i]);
             }
         },
-        results.executionTime, config.runs);
+        results.executionTime, config.runs, config.warmupRuns);
     return results;
 }

--- a/benchmarks/src/opencv/bench_composite.cpp
+++ b/benchmarks/src/opencv/bench_composite.cpp
@@ -34,11 +34,11 @@ BENCHMARK(Composite, OpenCV) {
     std::vector<cv::Mat> weights2 = GenerateMats<float>(config.samples, config.width, config.height, CV_32F);
     std::vector<cv::Mat> outputs = CreateOutputMats(config.samples, config.width, config.height, CV_8UC3);
 
-    RegisterMemoryUsage(backgrounds, results.inputMemoryBytes);
-    RegisterMemoryUsage(foregrounds, results.inputMemoryBytes);
-    RegisterMemoryUsage(weights1, results.inputMemoryBytes);
-    RegisterMemoryUsage(weights2, results.inputMemoryBytes);
-    RegisterMemoryUsage(outputs, results.outputMemoryBytes);
+    RegisterMemoryUsage(backgrounds, results.readMemoryBytes);
+    RegisterMemoryUsage(foregrounds, results.readMemoryBytes);
+    RegisterMemoryUsage(weights1, results.readMemoryBytes);
+    RegisterMemoryUsage(weights2, results.readMemoryBytes);
+    RegisterMemoryUsage(outputs, results.writtenMemoryBytes);
 
     ROCCV_BENCH_RECORD_BLOCK(
         {

--- a/benchmarks/src/opencv/bench_composite.cpp
+++ b/benchmarks/src/opencv/bench_composite.cpp
@@ -34,6 +34,12 @@ BENCHMARK(Composite, OpenCV) {
     std::vector<cv::Mat> weights2 = GenerateMats<float>(config.samples, config.width, config.height, CV_32F);
     cv::Mat outputMat(config.height, config.width, CV_8UC3);
 
+    RegisterMemoryUsage(backgrounds, results.inputMemoryBytes);
+    RegisterMemoryUsage(foregrounds, results.inputMemoryBytes);
+    RegisterMemoryUsage(weights1, results.inputMemoryBytes);
+    RegisterMemoryUsage(weights2, results.inputMemoryBytes);
+    RegisterMemoryUsage(outputMat, results.outputMemoryBytes);
+
     ROCCV_BENCH_RECORD_BLOCK(
         {
             for (size_t i = 0; i < backgrounds.size(); i++) {

--- a/benchmarks/src/opencv/bench_copy_make_border.cpp
+++ b/benchmarks/src/opencv/bench_copy_make_border.cpp
@@ -45,7 +45,7 @@ BENCHMARK(CopyMakeBorder, OpenCV_Constant) {
                 cv::copyMakeBorder(mats[i], outputs[i], top, bottom, left, right, CV_HAL_BORDER_CONSTANT, 0);
             }
         },
-        results.executionTime, config.runs);
+        results.executionTime, config.runs, config.warmupRuns);
 
     return results;
 }

--- a/benchmarks/src/opencv/bench_copy_make_border.cpp
+++ b/benchmarks/src/opencv/bench_copy_make_border.cpp
@@ -33,12 +33,13 @@ BENCHMARK(CopyMakeBorder, OpenCV_Constant) {
     const int right = 9;
 
     std::vector<cv::Mat> mats = GenerateMats<uint8_t>(config.samples, config.width, config.height, CV_8UC3);
-    cv::Mat outMat(config.height + top + bottom, config.width + left + right, CV_8UC3);
+    std::vector<cv::Mat> outputs =
+        CreateOutputMats(config.samples, config.width + left + right, config.height + top + bottom, CV_8UC3);
 
     ROCCV_BENCH_RECORD_BLOCK(
         {
             for (const auto& mat : mats) {
-                cv::copyMakeBorder(mat, outMat, top, bottom, left, right, CV_HAL_BORDER_CONSTANT, 0);
+                cv::copyMakeBorder(mat, outputs[i], top, bottom, left, right, CV_HAL_BORDER_CONSTANT, 0);
             }
         },
         results.executionTime, config.runs);

--- a/benchmarks/src/opencv/bench_copy_make_border.cpp
+++ b/benchmarks/src/opencv/bench_copy_make_border.cpp
@@ -41,8 +41,8 @@ BENCHMARK(CopyMakeBorder, OpenCV_Constant) {
 
     ROCCV_BENCH_RECORD_BLOCK(
         {
-            for (const auto& mat : mats) {
-                cv::copyMakeBorder(mat, outputs[i], top, bottom, left, right, CV_HAL_BORDER_CONSTANT, 0);
+            for (size_t i = 0; i < mats.size(); i++) {
+                cv::copyMakeBorder(mats[i], outputs[i], top, bottom, left, right, CV_HAL_BORDER_CONSTANT, 0);
             }
         },
         results.executionTime, config.runs);

--- a/benchmarks/src/opencv/bench_copy_make_border.cpp
+++ b/benchmarks/src/opencv/bench_copy_make_border.cpp
@@ -36,6 +36,9 @@ BENCHMARK(CopyMakeBorder, OpenCV_Constant) {
     std::vector<cv::Mat> outputs =
         CreateOutputMats(config.samples, config.width + left + right, config.height + top + bottom, CV_8UC3);
 
+    RegisterMemoryUsage(mats, results.inputMemoryBytes);
+    RegisterMemoryUsage(outputs, results.outputMemoryBytes);
+
     ROCCV_BENCH_RECORD_BLOCK(
         {
             for (const auto& mat : mats) {

--- a/benchmarks/src/opencv/bench_copy_make_border.cpp
+++ b/benchmarks/src/opencv/bench_copy_make_border.cpp
@@ -36,8 +36,8 @@ BENCHMARK(CopyMakeBorder, OpenCV_Constant) {
     std::vector<cv::Mat> outputs =
         CreateOutputMats(config.samples, config.width + left + right, config.height + top + bottom, CV_8UC3);
 
-    RegisterMemoryUsage(mats, results.inputMemoryBytes);
-    RegisterMemoryUsage(outputs, results.outputMemoryBytes);
+    RegisterMemoryUsage(mats, results.readMemoryBytes);
+    RegisterMemoryUsage(outputs, results.writtenMemoryBytes);
 
     ROCCV_BENCH_RECORD_BLOCK(
         {

--- a/benchmarks/src/opencv/bench_cvt_color.cpp
+++ b/benchmarks/src/opencv/bench_cvt_color.cpp
@@ -31,6 +31,9 @@ BENCHMARK(CvtColor, OpenCV) {
     std::vector<cv::Mat> mats = GenerateMats<uint8_t>(config.samples, config.width, config.height, CV_8UC3);
     std::vector<cv::Mat> outputs = CreateOutputMats(config.samples, config.width, config.height, CV_8UC1);
 
+    RegisterMemoryUsage(mats, results.inputMemoryBytes);
+    RegisterMemoryUsage(outputs, results.outputMemoryBytes);
+
     ROCCV_BENCH_RECORD_BLOCK(
         {
             for (size_t i = 0; i < mats.size(); i++) {

--- a/benchmarks/src/opencv/bench_cvt_color.cpp
+++ b/benchmarks/src/opencv/bench_cvt_color.cpp
@@ -29,12 +29,12 @@ BENCHMARK(CvtColor, OpenCV) {
     roccvbench::BenchmarkResults results;
 
     std::vector<cv::Mat> mats = GenerateMats<uint8_t>(config.samples, config.width, config.height, CV_8UC3);
-    cv::Mat outputMat(config.height, config.width, CV_8UC1);
+    std::vector<cv::Mat> outputs = CreateOutputMats(config.samples, config.width, config.height, CV_8UC1);
 
     ROCCV_BENCH_RECORD_BLOCK(
         {
             for (size_t i = 0; i < mats.size(); i++) {
-                cv::cvtColor(mats[i], outputMat, cv::COLOR_RGB2GRAY);
+                cv::cvtColor(mats[i], outputs[i], cv::COLOR_RGB2GRAY);
             }
         },
         results.executionTime, config.runs);

--- a/benchmarks/src/opencv/bench_cvt_color.cpp
+++ b/benchmarks/src/opencv/bench_cvt_color.cpp
@@ -40,6 +40,6 @@ BENCHMARK(CvtColor, OpenCV) {
                 cv::cvtColor(mats[i], outputs[i], cv::COLOR_RGB2GRAY);
             }
         },
-        results.executionTime, config.runs);
+        results.executionTime, config.runs, config.warmupRuns);
     return results;
 }

--- a/benchmarks/src/opencv/bench_cvt_color.cpp
+++ b/benchmarks/src/opencv/bench_cvt_color.cpp
@@ -31,8 +31,8 @@ BENCHMARK(CvtColor, OpenCV) {
     std::vector<cv::Mat> mats = GenerateMats<uint8_t>(config.samples, config.width, config.height, CV_8UC3);
     std::vector<cv::Mat> outputs = CreateOutputMats(config.samples, config.width, config.height, CV_8UC1);
 
-    RegisterMemoryUsage(mats, results.inputMemoryBytes);
-    RegisterMemoryUsage(outputs, results.outputMemoryBytes);
+    RegisterMemoryUsage(mats, results.readMemoryBytes);
+    RegisterMemoryUsage(outputs, results.writtenMemoryBytes);
 
     ROCCV_BENCH_RECORD_BLOCK(
         {

--- a/benchmarks/src/opencv/bench_flip.cpp
+++ b/benchmarks/src/opencv/bench_flip.cpp
@@ -31,8 +31,8 @@ BENCHMARK(Flip, OpenCV) {
     std::vector<cv::Mat> mats = GenerateMats<uint8_t>(config.samples, config.width, config.height, CV_8UC3);
     std::vector<cv::Mat> outputs = CreateOutputMats(config.samples, config.width, config.height, CV_8UC3);
 
-    RegisterMemoryUsage(mats, results.inputMemoryBytes);
-    RegisterMemoryUsage(outputs, results.outputMemoryBytes);
+    RegisterMemoryUsage(mats, results.readMemoryBytes);
+    RegisterMemoryUsage(outputs, results.writtenMemoryBytes);
 
     ROCCV_BENCH_RECORD_BLOCK(
         {

--- a/benchmarks/src/opencv/bench_flip.cpp
+++ b/benchmarks/src/opencv/bench_flip.cpp
@@ -29,12 +29,12 @@ BENCHMARK(Flip, OpenCV) {
     roccvbench::BenchmarkResults results;
 
     std::vector<cv::Mat> mats = GenerateMats<uint8_t>(config.samples, config.width, config.height, CV_8UC3);
-    cv::Mat outputMat(config.height, config.width, CV_8UC3);
+    std::vector<cv::Mat> outputs = CreateOutputMats(config.samples, config.width, config.height, CV_8UC3);
 
     ROCCV_BENCH_RECORD_BLOCK(
         {
             for (size_t i = 0; i < mats.size(); i++) {
-                cv::flip(mats[i], outputMat, -1);
+                cv::flip(mats[i], outputs[i], -1);
             }
         },
         results.executionTime, config.runs);

--- a/benchmarks/src/opencv/bench_flip.cpp
+++ b/benchmarks/src/opencv/bench_flip.cpp
@@ -40,6 +40,6 @@ BENCHMARK(Flip, OpenCV) {
                 cv::flip(mats[i], outputs[i], -1);
             }
         },
-        results.executionTime, config.runs);
+        results.executionTime, config.runs, config.warmupRuns);
     return results;
 }

--- a/benchmarks/src/opencv/bench_flip.cpp
+++ b/benchmarks/src/opencv/bench_flip.cpp
@@ -31,6 +31,9 @@ BENCHMARK(Flip, OpenCV) {
     std::vector<cv::Mat> mats = GenerateMats<uint8_t>(config.samples, config.width, config.height, CV_8UC3);
     std::vector<cv::Mat> outputs = CreateOutputMats(config.samples, config.width, config.height, CV_8UC3);
 
+    RegisterMemoryUsage(mats, results.inputMemoryBytes);
+    RegisterMemoryUsage(outputs, results.outputMemoryBytes);
+
     ROCCV_BENCH_RECORD_BLOCK(
         {
             for (size_t i = 0; i < mats.size(); i++) {

--- a/benchmarks/src/opencv/bench_rotate.cpp
+++ b/benchmarks/src/opencv/bench_rotate.cpp
@@ -30,6 +30,9 @@ BENCHMARK(Rotate, OpenCV) {
     std::vector<cv::Mat> mats = GenerateMats<uint8_t>(config.samples, config.width, config.height, CV_8UC3);
     std::vector<cv::Mat> outputs = CreateOutputMats(config.samples, config.width, config.height, CV_8UC3);
 
+    RegisterMemoryUsage(mats, results.inputMemoryBytes);
+    RegisterMemoryUsage(outputs, results.outputMemoryBytes);
+
     ROCCV_BENCH_RECORD_BLOCK(
         {
             for (const auto& mat : mats) {

--- a/benchmarks/src/opencv/bench_rotate.cpp
+++ b/benchmarks/src/opencv/bench_rotate.cpp
@@ -28,13 +28,12 @@ BENCHMARK(Rotate, OpenCV) {
     roccvbench::BenchmarkResults results;
 
     std::vector<cv::Mat> mats = GenerateMats<uint8_t>(config.samples, config.width, config.height, CV_8UC3);
-
-    cv::Mat outMat(config.height, config.width, CV_8UC3);
+    std::vector<cv::Mat> outputs = CreateOutputMats(config.samples, config.width, config.height, CV_8UC3);
 
     ROCCV_BENCH_RECORD_BLOCK(
         {
             for (const auto& mat : mats) {
-                cv::rotate(mat, outMat, cv::ROTATE_180);
+                cv::rotate(mat, outputs[i], cv::ROTATE_180);
             }
         },
         results.executionTime, config.runs);

--- a/benchmarks/src/opencv/bench_rotate.cpp
+++ b/benchmarks/src/opencv/bench_rotate.cpp
@@ -30,8 +30,8 @@ BENCHMARK(Rotate, OpenCV) {
     std::vector<cv::Mat> mats = GenerateMats<uint8_t>(config.samples, config.width, config.height, CV_8UC3);
     std::vector<cv::Mat> outputs = CreateOutputMats(config.samples, config.width, config.height, CV_8UC3);
 
-    RegisterMemoryUsage(mats, results.inputMemoryBytes);
-    RegisterMemoryUsage(outputs, results.outputMemoryBytes);
+    RegisterMemoryUsage(mats, results.readMemoryBytes);
+    RegisterMemoryUsage(outputs, results.writtenMemoryBytes);
 
     ROCCV_BENCH_RECORD_BLOCK(
         {

--- a/benchmarks/src/opencv/bench_rotate.cpp
+++ b/benchmarks/src/opencv/bench_rotate.cpp
@@ -35,8 +35,8 @@ BENCHMARK(Rotate, OpenCV) {
 
     ROCCV_BENCH_RECORD_BLOCK(
         {
-            for (const auto& mat : mats) {
-                cv::rotate(mat, outputs[i], cv::ROTATE_180);
+            for (size_t i = 0; i < mats.size(); i++) {
+                cv::rotate(mats[i], outputs[i], cv::ROTATE_180);
             }
         },
         results.executionTime, config.runs);

--- a/benchmarks/src/opencv/bench_rotate.cpp
+++ b/benchmarks/src/opencv/bench_rotate.cpp
@@ -39,7 +39,7 @@ BENCHMARK(Rotate, OpenCV) {
                 cv::rotate(mats[i], outputs[i], cv::ROTATE_180);
             }
         },
-        results.executionTime, config.runs);
+        results.executionTime, config.runs, config.warmupRuns);
 
     return results;
 }

--- a/benchmarks/src/opencv/bench_warp_affine.cpp
+++ b/benchmarks/src/opencv/bench_warp_affine.cpp
@@ -34,6 +34,10 @@ BENCHMARK(WarpAffine, OpenCV) {
     std::vector<float> affineMatData = {1, 0, 0, 1, -1, 120};
     cv::Mat affineMat(2, 3, CV_32F, affineMatData.data());
 
+    RegisterMemoryUsage(mats, results.inputMemoryBytes);
+    RegisterMemoryUsage(affineMat, results.inputMemoryBytes);
+    RegisterMemoryUsage(outputs, results.outputMemoryBytes);
+
     ROCCV_BENCH_RECORD_BLOCK(
         {
             for (const auto& mat : mats) {

--- a/benchmarks/src/opencv/bench_warp_affine.cpp
+++ b/benchmarks/src/opencv/bench_warp_affine.cpp
@@ -40,8 +40,9 @@ BENCHMARK(WarpAffine, OpenCV) {
 
     ROCCV_BENCH_RECORD_BLOCK(
         {
-            for (const auto& mat : mats) {
-                cv::warpAffine(mat, outputs[i], affineMat, outputs[i].size(), cv::INTER_LINEAR, cv::BORDER_CONSTANT, 0);
+            for (size_t i = 0; i < mats.size(); i++) {
+                cv::warpAffine(mats[i], outputs[i], affineMat, outputs[i].size(), cv::INTER_LINEAR, cv::BORDER_CONSTANT,
+                               0);
             }
         },
         results.executionTime, config.runs);

--- a/benchmarks/src/opencv/bench_warp_affine.cpp
+++ b/benchmarks/src/opencv/bench_warp_affine.cpp
@@ -29,7 +29,7 @@ BENCHMARK(WarpAffine, OpenCV) {
     roccvbench::BenchmarkResults results;
 
     std::vector<cv::Mat> mats = GenerateMats<uint8_t>(config.samples, config.width, config.height, CV_8UC3);
-    cv::Mat outputMat(config.height, config.width, CV_8UC3);
+    std::vector<cv::Mat> outputs = CreateOutputMats(config.samples, config.width, config.height, CV_8UC3);
 
     std::vector<float> affineMatData = {1, 0, 0, 1, -1, 120};
     cv::Mat affineMat(2, 3, CV_32F, affineMatData.data());
@@ -37,7 +37,7 @@ BENCHMARK(WarpAffine, OpenCV) {
     ROCCV_BENCH_RECORD_BLOCK(
         {
             for (const auto& mat : mats) {
-                cv::warpAffine(mat, outputMat, affineMat, outputMat.size(), cv::INTER_LINEAR, cv::BORDER_CONSTANT, 0);
+                cv::warpAffine(mat, outputs[i], affineMat, outputs[i].size(), cv::INTER_LINEAR, cv::BORDER_CONSTANT, 0);
             }
         },
         results.executionTime, config.runs);

--- a/benchmarks/src/opencv/bench_warp_affine.cpp
+++ b/benchmarks/src/opencv/bench_warp_affine.cpp
@@ -45,6 +45,6 @@ BENCHMARK(WarpAffine, OpenCV) {
                                0);
             }
         },
-        results.executionTime, config.runs);
+        results.executionTime, config.runs, config.warmupRuns);
     return results;
 }

--- a/benchmarks/src/opencv/bench_warp_affine.cpp
+++ b/benchmarks/src/opencv/bench_warp_affine.cpp
@@ -34,9 +34,9 @@ BENCHMARK(WarpAffine, OpenCV) {
     std::vector<float> affineMatData = {1, 0, 0, 1, -1, 120};
     cv::Mat affineMat(2, 3, CV_32F, affineMatData.data());
 
-    RegisterMemoryUsage(mats, results.inputMemoryBytes);
-    RegisterMemoryUsage(affineMat, results.inputMemoryBytes);
-    RegisterMemoryUsage(outputs, results.outputMemoryBytes);
+    RegisterMemoryUsage(mats, results.readMemoryBytes);
+    RegisterMemoryUsage(affineMat, results.readMemoryBytes);
+    RegisterMemoryUsage(outputs, results.writtenMemoryBytes);
 
     ROCCV_BENCH_RECORD_BLOCK(
         {

--- a/benchmarks/src/opencv/bench_warp_perspective.cpp
+++ b/benchmarks/src/opencv/bench_warp_perspective.cpp
@@ -34,6 +34,10 @@ BENCHMARK(WarpPerspective, OpenCV) {
     std::vector<float> transformData = {1, 0, 0, 0, 1, 0, -0.001, 0, 1};
     cv::Mat transform(3, 3, CV_32F, transformData.data());
 
+    RegisterMemoryUsage(mats, results.inputMemoryBytes);
+    RegisterMemoryUsage(transform, results.inputMemoryBytes);
+    RegisterMemoryUsage(outputs, results.outputMemoryBytes);
+
     ROCCV_BENCH_RECORD_BLOCK(
         {
             for (const auto& mat : mats) {

--- a/benchmarks/src/opencv/bench_warp_perspective.cpp
+++ b/benchmarks/src/opencv/bench_warp_perspective.cpp
@@ -29,7 +29,7 @@ BENCHMARK(WarpPerspective, OpenCV) {
     roccvbench::BenchmarkResults results;
 
     std::vector<cv::Mat> mats = GenerateMats<uint8_t>(config.samples, config.width, config.height, CV_8UC3);
-    cv::Mat outputMat(config.height, config.width, CV_8UC3);
+    std::vector<cv::Mat> outputs = CreateOutputMats(config.samples, config.width, config.height, CV_8UC3);
 
     std::vector<float> transformData = {1, 0, 0, 0, 1, 0, -0.001, 0, 1};
     cv::Mat transform(3, 3, CV_32F, transformData.data());
@@ -37,8 +37,8 @@ BENCHMARK(WarpPerspective, OpenCV) {
     ROCCV_BENCH_RECORD_BLOCK(
         {
             for (const auto& mat : mats) {
-                cv::warpPerspective(mat, outputMat, transform, outputMat.size(), cv::INTER_LINEAR, cv::BORDER_CONSTANT,
-                                    0);
+                cv::warpPerspective(mat, outputs[i], transform, outputs[i].size(), cv::INTER_LINEAR,
+                                    cv::BORDER_CONSTANT, 0);
             }
         },
         results.executionTime, config.runs);

--- a/benchmarks/src/opencv/bench_warp_perspective.cpp
+++ b/benchmarks/src/opencv/bench_warp_perspective.cpp
@@ -34,9 +34,9 @@ BENCHMARK(WarpPerspective, OpenCV) {
     std::vector<float> transformData = {1, 0, 0, 0, 1, 0, -0.001, 0, 1};
     cv::Mat transform(3, 3, CV_32F, transformData.data());
 
-    RegisterMemoryUsage(mats, results.inputMemoryBytes);
-    RegisterMemoryUsage(transform, results.inputMemoryBytes);
-    RegisterMemoryUsage(outputs, results.outputMemoryBytes);
+    RegisterMemoryUsage(mats, results.readMemoryBytes);
+    RegisterMemoryUsage(transform, results.readMemoryBytes);
+    RegisterMemoryUsage(outputs, results.writtenMemoryBytes);
 
     ROCCV_BENCH_RECORD_BLOCK(
         {

--- a/benchmarks/src/opencv/bench_warp_perspective.cpp
+++ b/benchmarks/src/opencv/bench_warp_perspective.cpp
@@ -40,8 +40,8 @@ BENCHMARK(WarpPerspective, OpenCV) {
 
     ROCCV_BENCH_RECORD_BLOCK(
         {
-            for (const auto& mat : mats) {
-                cv::warpPerspective(mat, outputs[i], transform, outputs[i].size(), cv::INTER_LINEAR,
+            for (size_t i = 0; i < mats.size(); i++) {
+                cv::warpPerspective(mats[i], outputs[i], transform, outputs[i].size(), cv::INTER_LINEAR,
                                     cv::BORDER_CONSTANT, 0);
             }
         },

--- a/benchmarks/src/opencv/bench_warp_perspective.cpp
+++ b/benchmarks/src/opencv/bench_warp_perspective.cpp
@@ -45,6 +45,6 @@ BENCHMARK(WarpPerspective, OpenCV) {
                                     cv::BORDER_CONSTANT, 0);
             }
         },
-        results.executionTime, config.runs);
+        results.executionTime, config.runs, config.warmupRuns);
     return results;
 }

--- a/benchmarks/src/opencv/opencv_bench_helpers.hpp
+++ b/benchmarks/src/opencv/opencv_bench_helpers.hpp
@@ -61,3 +61,25 @@ std::vector<cv::Mat> GenerateMats(int samples, int width, int height, int dataty
     }
     return batch;
 }
+
+/**
+ * @brief Registers the memory usage of a cv::Mat.
+ *
+ * @param mat The cv::Mat to register the memory usage of.
+ * @param memoryUsage The memory usage to register.
+ */
+inline void RegisterMemoryUsage(const cv::Mat& mat, size_t& memoryUsage) {
+    memoryUsage += mat.total() * mat.elemSize();
+}
+
+/**
+ * @brief Registers the memory usage of a list of cv::Mat.
+ *
+ * @param mats The list of cv::Mat to register the memory usage of.
+ * @param memoryUsage The memory usage to register.
+ */
+inline void RegisterMemoryUsage(const std::vector<cv::Mat>& mats, size_t& memoryUsage) {
+    for (const auto& mat : mats) {
+        RegisterMemoryUsage(mat, memoryUsage);
+    }
+}

--- a/benchmarks/src/opencv/opencv_bench_helpers.hpp
+++ b/benchmarks/src/opencv/opencv_bench_helpers.hpp
@@ -34,12 +34,30 @@
  * @return A cv::Mat with randomly generated data.
  */
 template <typename T>
-cv::Mat GenerateMat(int width, int height, int datatype) {
+inline cv::Mat GenerateMat(int width, int height, int datatype) {
     const size_t vecSize = width * height * CV_MAT_CN(datatype);
     std::vector<T> data = roccvbench::RandVector<T>(vecSize);
 
     cv::Mat mat(height, width, datatype, data.data());
     return mat.clone();
+}
+
+/**
+ * @brief Creates a list of empty cv::Mat's to be used as output matrices.
+ *
+ * @param samples Number of images in the batch.
+ * @param width Image width.
+ * @param height Image height.
+ * @param datatype OpenCV datatype for the image. (e.g. CV_U8C3)
+ * @return A list of cv::Mat.
+ */
+inline std::vector<cv::Mat> CreateOutputMats(int samples, int width, int height, int datatype) {
+    std::vector<cv::Mat> mats;
+    mats.reserve(samples);
+    for (int i = 0; i < samples; i++) {
+        mats.push_back(cv::Mat(height, width, datatype));
+    }
+    return mats;
 }
 
 /**
@@ -53,7 +71,7 @@ cv::Mat GenerateMat(int width, int height, int datatype) {
  * @return A list of cv::Mat with randomly generated data.
  */
 template <typename T>
-std::vector<cv::Mat> GenerateMats(int samples, int width, int height, int datatype) {
+inline std::vector<cv::Mat> GenerateMats(int samples, int width, int height, int datatype) {
     std::vector<cv::Mat> batch;
     batch.reserve(samples);
     for (int i = 0; i < samples; i++) {

--- a/benchmarks/src/roccv/bench_bilateral_filter.cpp
+++ b/benchmarks/src/roccv/bench_bilateral_filter.cpp
@@ -54,7 +54,7 @@ BENCHMARK(BilateralFilter, GPU) {
                make_float4(1.0f, 0.0f, 1.0f, 1.0f));
             HIP_VALIDATE_NO_ERRORS(hipStreamSynchronize(stream))
         },
-        results.executionTime, config.runs);
+        results.executionTime, config.runs, config.warmupRuns);
 
     HIP_VALIDATE_NO_ERRORS(hipStreamDestroy(stream));
 
@@ -80,7 +80,7 @@ BENCHMARK(BilateralFilter, CPU) {
             op(nullptr, input, output, 30, 75, 75, eBorderType::BORDER_TYPE_CONSTANT,
                make_float4(1.0f, 0.0f, 1.0f, 1.0f), eDeviceType::CPU);
         },
-        results.executionTime, config.runs);
+        results.executionTime, config.runs, config.warmupRuns);
 
     return results;
 }

--- a/benchmarks/src/roccv/bench_bilateral_filter.cpp
+++ b/benchmarks/src/roccv/bench_bilateral_filter.cpp
@@ -39,8 +39,8 @@ BENCHMARK(BilateralFilter, GPU) {
     Tensor input(reqs);
     Tensor output(reqs);
 
-    roccvbench::RegisterMemoryUsage(input, results.inputMemoryBytes);
-    roccvbench::RegisterMemoryUsage(output, results.outputMemoryBytes);
+    RegisterMemoryUsage(input, results.inputMemoryBytes);
+    RegisterMemoryUsage(output, results.outputMemoryBytes);
 
     FillTensor(input);
 
@@ -69,8 +69,8 @@ BENCHMARK(BilateralFilter, CPU) {
     Tensor input(reqs);
     Tensor output(reqs);
 
-    roccvbench::RegisterMemoryUsage(input, results.inputMemoryBytes);
-    roccvbench::RegisterMemoryUsage(output, results.outputMemoryBytes);
+    RegisterMemoryUsage(input, results.inputMemoryBytes);
+    RegisterMemoryUsage(output, results.outputMemoryBytes);
 
     FillTensor(input);
 

--- a/benchmarks/src/roccv/bench_bilateral_filter.cpp
+++ b/benchmarks/src/roccv/bench_bilateral_filter.cpp
@@ -39,8 +39,8 @@ BENCHMARK(BilateralFilter, GPU) {
     Tensor input(reqs);
     Tensor output(reqs);
 
-    RegisterMemoryUsage(input, results.inputMemoryBytes);
-    RegisterMemoryUsage(output, results.outputMemoryBytes);
+    RegisterMemoryUsage(input, results.readMemoryBytes);
+    RegisterMemoryUsage(output, results.writtenMemoryBytes);
 
     FillTensor(input);
 
@@ -69,8 +69,8 @@ BENCHMARK(BilateralFilter, CPU) {
     Tensor input(reqs);
     Tensor output(reqs);
 
-    RegisterMemoryUsage(input, results.inputMemoryBytes);
-    RegisterMemoryUsage(output, results.outputMemoryBytes);
+    RegisterMemoryUsage(input, results.readMemoryBytes);
+    RegisterMemoryUsage(output, results.writtenMemoryBytes);
 
     FillTensor(input);
 

--- a/benchmarks/src/roccv/bench_bilateral_filter.cpp
+++ b/benchmarks/src/roccv/bench_bilateral_filter.cpp
@@ -33,12 +33,14 @@ using namespace roccv;
 
 BENCHMARK(BilateralFilter, GPU) {
     roccvbench::BenchmarkResults results;
-    results.executionTime = 0.0f;
 
     Tensor::Requirements reqs =
         Tensor::CalcRequirements(config.samples, (Size2D){config.width, config.height}, FMT_RGB8);
     Tensor input(reqs);
     Tensor output(reqs);
+
+    roccvbench::RegisterMemoryUsage(input, results.inputMemoryBytes);
+    roccvbench::RegisterMemoryUsage(output, results.outputMemoryBytes);
 
     FillTensor(input);
 
@@ -61,12 +63,14 @@ BENCHMARK(BilateralFilter, GPU) {
 
 BENCHMARK(BilateralFilter, CPU) {
     roccvbench::BenchmarkResults results;
-    results.executionTime = 0.0f;
 
     Tensor::Requirements reqs =
         Tensor::CalcRequirements(config.samples, (Size2D){config.width, config.height}, FMT_RGB8, eDeviceType::CPU);
     Tensor input(reqs);
     Tensor output(reqs);
+
+    roccvbench::RegisterMemoryUsage(input, results.inputMemoryBytes);
+    roccvbench::RegisterMemoryUsage(output, results.outputMemoryBytes);
 
     FillTensor(input);
 

--- a/benchmarks/src/roccv/bench_composite.cpp
+++ b/benchmarks/src/roccv/bench_composite.cpp
@@ -45,10 +45,10 @@ BENCHMARK(Composite, GPU) {
     Tensor mask(maskReqs);
     Tensor output(reqs);
 
-    roccvbench::RegisterMemoryUsage(background, results.inputMemoryBytes);
-    roccvbench::RegisterMemoryUsage(foreground, results.inputMemoryBytes);
-    roccvbench::RegisterMemoryUsage(mask, results.inputMemoryBytes);
-    roccvbench::RegisterMemoryUsage(output, results.outputMemoryBytes);
+    RegisterMemoryUsage(background, results.inputMemoryBytes);
+    RegisterMemoryUsage(foreground, results.inputMemoryBytes);
+    RegisterMemoryUsage(mask, results.inputMemoryBytes);
+    RegisterMemoryUsage(output, results.outputMemoryBytes);
 
     FillTensor(background);
     FillTensor(foreground);
@@ -86,10 +86,10 @@ BENCHMARK(Composite, CPU) {
     Tensor mask(maskReqs);
     Tensor output(reqs);
 
-    roccvbench::RegisterMemoryUsage(background, results.inputMemoryBytes);
-    roccvbench::RegisterMemoryUsage(foreground, results.inputMemoryBytes);
-    roccvbench::RegisterMemoryUsage(mask, results.inputMemoryBytes);
-    roccvbench::RegisterMemoryUsage(output, results.outputMemoryBytes);
+    RegisterMemoryUsage(background, results.inputMemoryBytes);
+    RegisterMemoryUsage(foreground, results.inputMemoryBytes);
+    RegisterMemoryUsage(mask, results.inputMemoryBytes);
+    RegisterMemoryUsage(output, results.outputMemoryBytes);
 
     FillTensor(background);
     FillTensor(foreground);

--- a/benchmarks/src/roccv/bench_composite.cpp
+++ b/benchmarks/src/roccv/bench_composite.cpp
@@ -64,7 +64,7 @@ BENCHMARK(Composite, GPU) {
             op(stream, foreground, background, mask, output);
             HIP_VALIDATE_NO_ERRORS(hipStreamSynchronize(stream))
         },
-        results.executionTime, config.runs);
+        results.executionTime, config.runs, config.warmupRuns);
 
     HIP_VALIDATE_NO_ERRORS(hipStreamDestroy(stream));
 
@@ -97,7 +97,8 @@ BENCHMARK(Composite, CPU) {
 
     Composite op;
     ROCCV_BENCH_RECORD_BLOCK(
-        { op(nullptr, foreground, background, mask, output, eDeviceType::CPU); }, results.executionTime, config.runs);
+        { op(nullptr, foreground, background, mask, output, eDeviceType::CPU); }, results.executionTime, config.runs,
+        config.warmupRuns);
 
     return results;
 }

--- a/benchmarks/src/roccv/bench_composite.cpp
+++ b/benchmarks/src/roccv/bench_composite.cpp
@@ -34,7 +34,6 @@ using namespace roccv;
 
 BENCHMARK(Composite, GPU) {
     roccvbench::BenchmarkResults results;
-    results.executionTime = 0.0f;
 
     Tensor::Requirements reqs = Tensor::CalcRequirements(
         config.samples, (Size2D){static_cast<int>(config.width), static_cast<int>(config.height)}, FMT_RGB8);
@@ -45,6 +44,11 @@ BENCHMARK(Composite, GPU) {
     Tensor foreground(reqs);
     Tensor mask(maskReqs);
     Tensor output(reqs);
+
+    roccvbench::RegisterMemoryUsage(background, results.inputMemoryBytes);
+    roccvbench::RegisterMemoryUsage(foreground, results.inputMemoryBytes);
+    roccvbench::RegisterMemoryUsage(mask, results.inputMemoryBytes);
+    roccvbench::RegisterMemoryUsage(output, results.outputMemoryBytes);
 
     FillTensor(background);
     FillTensor(foreground);
@@ -69,7 +73,6 @@ BENCHMARK(Composite, GPU) {
 
 BENCHMARK(Composite, CPU) {
     roccvbench::BenchmarkResults results;
-    results.executionTime = 0.0f;
 
     Tensor::Requirements reqs = Tensor::CalcRequirements(
         config.samples, (Size2D){static_cast<int>(config.width), static_cast<int>(config.height)}, FMT_RGB8,
@@ -82,6 +85,11 @@ BENCHMARK(Composite, CPU) {
     Tensor foreground(reqs);
     Tensor mask(maskReqs);
     Tensor output(reqs);
+
+    roccvbench::RegisterMemoryUsage(background, results.inputMemoryBytes);
+    roccvbench::RegisterMemoryUsage(foreground, results.inputMemoryBytes);
+    roccvbench::RegisterMemoryUsage(mask, results.inputMemoryBytes);
+    roccvbench::RegisterMemoryUsage(output, results.outputMemoryBytes);
 
     FillTensor(background);
     FillTensor(foreground);

--- a/benchmarks/src/roccv/bench_composite.cpp
+++ b/benchmarks/src/roccv/bench_composite.cpp
@@ -45,10 +45,10 @@ BENCHMARK(Composite, GPU) {
     Tensor mask(maskReqs);
     Tensor output(reqs);
 
-    RegisterMemoryUsage(background, results.inputMemoryBytes);
-    RegisterMemoryUsage(foreground, results.inputMemoryBytes);
-    RegisterMemoryUsage(mask, results.inputMemoryBytes);
-    RegisterMemoryUsage(output, results.outputMemoryBytes);
+    RegisterMemoryUsage(background, results.readMemoryBytes);
+    RegisterMemoryUsage(foreground, results.readMemoryBytes);
+    RegisterMemoryUsage(mask, results.readMemoryBytes);
+    RegisterMemoryUsage(output, results.writtenMemoryBytes);
 
     FillTensor(background);
     FillTensor(foreground);
@@ -86,10 +86,10 @@ BENCHMARK(Composite, CPU) {
     Tensor mask(maskReqs);
     Tensor output(reqs);
 
-    RegisterMemoryUsage(background, results.inputMemoryBytes);
-    RegisterMemoryUsage(foreground, results.inputMemoryBytes);
-    RegisterMemoryUsage(mask, results.inputMemoryBytes);
-    RegisterMemoryUsage(output, results.outputMemoryBytes);
+    RegisterMemoryUsage(background, results.readMemoryBytes);
+    RegisterMemoryUsage(foreground, results.readMemoryBytes);
+    RegisterMemoryUsage(mask, results.readMemoryBytes);
+    RegisterMemoryUsage(output, results.writtenMemoryBytes);
 
     FillTensor(background);
     FillTensor(foreground);

--- a/benchmarks/src/roccv/bench_copy_make_border.cpp
+++ b/benchmarks/src/roccv/bench_copy_make_border.cpp
@@ -60,7 +60,7 @@ BENCHMARK(CopyMakeBorder, GPU_Constant) {
             op(stream, input, output, top, left, borderType, borderVal);
             HIP_VALIDATE_NO_ERRORS(hipStreamSynchronize(stream))
         },
-        results.executionTime, config.runs);
+        results.executionTime, config.runs, config.warmupRuns);
 
     HIP_VALIDATE_NO_ERRORS(hipStreamDestroy(stream));
 
@@ -90,7 +90,7 @@ BENCHMARK(CopyMakeBorder, CPU_Constant) {
     CopyMakeBorder op;
     ROCCV_BENCH_RECORD_BLOCK(
         { op(nullptr, input, output, top, left, borderType, borderVal, eDeviceType::CPU); }, results.executionTime,
-        config.runs);
+        config.runs, config.warmupRuns);
 
     return results;
 }
@@ -125,7 +125,7 @@ BENCHMARK(CopyMakeBorder, GPU_Reflect) {
             op(stream, input, output, top, left, borderType, borderVal);
             HIP_VALIDATE_NO_ERRORS(hipStreamSynchronize(stream))
         },
-        results.executionTime, config.runs);
+        results.executionTime, config.runs, config.warmupRuns);
 
     HIP_VALIDATE_NO_ERRORS(hipStreamDestroy(stream));
 
@@ -156,7 +156,7 @@ BENCHMARK(CopyMakeBorder, CPU_Reflect) {
     CopyMakeBorder op;
     ROCCV_BENCH_RECORD_BLOCK(
         { op(nullptr, input, output, top, left, borderType, borderVal, eDeviceType::CPU); }, results.executionTime,
-        config.runs);
+        config.runs, config.warmupRuns);
 
     return results;
 }

--- a/benchmarks/src/roccv/bench_copy_make_border.cpp
+++ b/benchmarks/src/roccv/bench_copy_make_border.cpp
@@ -110,6 +110,9 @@ BENCHMARK(CopyMakeBorder, GPU_Reflect) {
     Tensor input(inReqs);
     Tensor output(outReqs);
 
+    RegisterMemoryUsage(input, results.inputMemoryBytes);
+    RegisterMemoryUsage(output, results.outputMemoryBytes);
+
     FillTensor(input);
 
     CopyMakeBorder op;
@@ -144,6 +147,9 @@ BENCHMARK(CopyMakeBorder, CPU_Reflect) {
         config.samples, {config.width + left * 2, config.height + top * 2}, FMT_RGB8, eDeviceType::CPU);
     Tensor input(inReqs);
     Tensor output(outReqs);
+
+    RegisterMemoryUsage(input, results.inputMemoryBytes);
+    RegisterMemoryUsage(output, results.outputMemoryBytes);
 
     FillTensor(input);
 

--- a/benchmarks/src/roccv/bench_copy_make_border.cpp
+++ b/benchmarks/src/roccv/bench_copy_make_border.cpp
@@ -45,8 +45,8 @@ BENCHMARK(CopyMakeBorder, GPU_Constant) {
     Tensor input(inReqs);
     Tensor output(outReqs);
 
-    roccvbench::RegisterMemoryUsage(input, results.inputMemoryBytes);
-    roccvbench::RegisterMemoryUsage(output, results.outputMemoryBytes);
+    RegisterMemoryUsage(input, results.inputMemoryBytes);
+    RegisterMemoryUsage(output, results.outputMemoryBytes);
 
     FillTensor(input);
 
@@ -82,8 +82,8 @@ BENCHMARK(CopyMakeBorder, CPU_Constant) {
     Tensor input(inReqs);
     Tensor output(outReqs);
 
-    roccvbench::RegisterMemoryUsage(input, results.inputMemoryBytes);
-    roccvbench::RegisterMemoryUsage(output, results.outputMemoryBytes);
+    RegisterMemoryUsage(input, results.inputMemoryBytes);
+    RegisterMemoryUsage(output, results.outputMemoryBytes);
 
     FillTensor(input);
 

--- a/benchmarks/src/roccv/bench_copy_make_border.cpp
+++ b/benchmarks/src/roccv/bench_copy_make_border.cpp
@@ -45,8 +45,8 @@ BENCHMARK(CopyMakeBorder, GPU_Constant) {
     Tensor input(inReqs);
     Tensor output(outReqs);
 
-    RegisterMemoryUsage(input, results.inputMemoryBytes);
-    RegisterMemoryUsage(output, results.outputMemoryBytes);
+    RegisterMemoryUsage(input, results.readMemoryBytes);
+    RegisterMemoryUsage(output, results.writtenMemoryBytes);
 
     FillTensor(input);
 
@@ -82,8 +82,8 @@ BENCHMARK(CopyMakeBorder, CPU_Constant) {
     Tensor input(inReqs);
     Tensor output(outReqs);
 
-    RegisterMemoryUsage(input, results.inputMemoryBytes);
-    RegisterMemoryUsage(output, results.outputMemoryBytes);
+    RegisterMemoryUsage(input, results.readMemoryBytes);
+    RegisterMemoryUsage(output, results.writtenMemoryBytes);
 
     FillTensor(input);
 
@@ -110,8 +110,8 @@ BENCHMARK(CopyMakeBorder, GPU_Reflect) {
     Tensor input(inReqs);
     Tensor output(outReqs);
 
-    RegisterMemoryUsage(input, results.inputMemoryBytes);
-    RegisterMemoryUsage(output, results.outputMemoryBytes);
+    RegisterMemoryUsage(input, results.readMemoryBytes);
+    RegisterMemoryUsage(output, results.writtenMemoryBytes);
 
     FillTensor(input);
 
@@ -148,8 +148,8 @@ BENCHMARK(CopyMakeBorder, CPU_Reflect) {
     Tensor input(inReqs);
     Tensor output(outReqs);
 
-    RegisterMemoryUsage(input, results.inputMemoryBytes);
-    RegisterMemoryUsage(output, results.outputMemoryBytes);
+    RegisterMemoryUsage(input, results.readMemoryBytes);
+    RegisterMemoryUsage(output, results.writtenMemoryBytes);
 
     FillTensor(input);
 

--- a/benchmarks/src/roccv/bench_copy_make_border.cpp
+++ b/benchmarks/src/roccv/bench_copy_make_border.cpp
@@ -33,7 +33,6 @@ using namespace roccv;
 
 BENCHMARK(CopyMakeBorder, GPU_Constant) {
     roccvbench::BenchmarkResults results;
-    results.executionTime = 0.0f;
 
     const int top = 9;
     const int left = 9;
@@ -45,6 +44,9 @@ BENCHMARK(CopyMakeBorder, GPU_Constant) {
         Tensor::CalcRequirements(config.samples, {config.width + left * 2, config.height + top * 2}, FMT_RGB8);
     Tensor input(inReqs);
     Tensor output(outReqs);
+
+    roccvbench::RegisterMemoryUsage(input, results.inputMemoryBytes);
+    roccvbench::RegisterMemoryUsage(output, results.outputMemoryBytes);
 
     FillTensor(input);
 
@@ -67,7 +69,6 @@ BENCHMARK(CopyMakeBorder, GPU_Constant) {
 
 BENCHMARK(CopyMakeBorder, CPU_Constant) {
     roccvbench::BenchmarkResults results;
-    results.executionTime = 0.0f;
 
     const int top = 9;
     const int left = 9;
@@ -80,6 +81,9 @@ BENCHMARK(CopyMakeBorder, CPU_Constant) {
         config.samples, {config.width + left * 2, config.height + top * 2}, FMT_RGB8, eDeviceType::CPU);
     Tensor input(inReqs);
     Tensor output(outReqs);
+
+    roccvbench::RegisterMemoryUsage(input, results.inputMemoryBytes);
+    roccvbench::RegisterMemoryUsage(output, results.outputMemoryBytes);
 
     FillTensor(input);
 

--- a/benchmarks/src/roccv/bench_custom_crop.cpp
+++ b/benchmarks/src/roccv/bench_custom_crop.cpp
@@ -43,8 +43,8 @@ BENCHMARK(CustomCrop, GPU) {
                               {config.samples, cropRect.height, cropRect.width, 3}),
                   input.dtype());
 
-    RegisterMemoryUsage(input, results.inputMemoryBytes);
-    RegisterMemoryUsage(output, results.outputMemoryBytes);
+    RegisterMemoryUsage(input, results.readMemoryBytes);
+    RegisterMemoryUsage(output, results.writtenMemoryBytes);
 
     FillTensor(input);
 
@@ -77,8 +77,8 @@ BENCHMARK(CustomCrop, CPU) {
                               {config.samples, cropRect.height, cropRect.width, 3}),
                   input.dtype(), eDeviceType::CPU);
 
-    RegisterMemoryUsage(input, results.inputMemoryBytes);
-    RegisterMemoryUsage(output, results.outputMemoryBytes);
+    RegisterMemoryUsage(input, results.readMemoryBytes);
+    RegisterMemoryUsage(output, results.writtenMemoryBytes);
 
     FillTensor(input);
 

--- a/benchmarks/src/roccv/bench_custom_crop.cpp
+++ b/benchmarks/src/roccv/bench_custom_crop.cpp
@@ -32,7 +32,6 @@ using namespace roccv;
 
 BENCHMARK(CustomCrop, GPU) {
     roccvbench::BenchmarkResults results;
-    results.executionTime = 0.0f;
 
     TensorRequirements reqs = Tensor::CalcRequirements(
         TensorShape(TensorLayout(TENSOR_LAYOUT_NHWC), {config.samples, config.height, config.width, 3}),
@@ -43,6 +42,9 @@ BENCHMARK(CustomCrop, GPU) {
     Tensor output(TensorShape(TensorLayout(eTensorLayout::TENSOR_LAYOUT_NHWC),
                               {config.samples, cropRect.height, cropRect.width, 3}),
                   input.dtype());
+
+    roccvbench::RegisterMemoryUsage(input, results.inputMemoryBytes);
+    roccvbench::RegisterMemoryUsage(output, results.outputMemoryBytes);
 
     FillTensor(input);
 
@@ -64,7 +66,6 @@ BENCHMARK(CustomCrop, GPU) {
 
 BENCHMARK(CustomCrop, CPU) {
     roccvbench::BenchmarkResults results;
-    results.executionTime = 0.0f;
 
     TensorRequirements reqs = Tensor::CalcRequirements(
         TensorShape(TensorLayout(TENSOR_LAYOUT_NHWC), {config.samples, config.height, config.width, 3}),
@@ -75,6 +76,9 @@ BENCHMARK(CustomCrop, CPU) {
     Tensor output(TensorShape(TensorLayout(eTensorLayout::TENSOR_LAYOUT_NHWC),
                               {config.samples, cropRect.height, cropRect.width, 3}),
                   input.dtype(), eDeviceType::CPU);
+
+    roccvbench::RegisterMemoryUsage(input, results.inputMemoryBytes);
+    roccvbench::RegisterMemoryUsage(output, results.outputMemoryBytes);
 
     FillTensor(input);
 

--- a/benchmarks/src/roccv/bench_custom_crop.cpp
+++ b/benchmarks/src/roccv/bench_custom_crop.cpp
@@ -57,7 +57,7 @@ BENCHMARK(CustomCrop, GPU) {
             op(stream, input, output, cropRect);
             HIP_VALIDATE_NO_ERRORS(hipStreamSynchronize(stream))
         },
-        results.executionTime, config.runs);
+        results.executionTime, config.runs, config.warmupRuns);
 
     HIP_VALIDATE_NO_ERRORS(hipStreamDestroy(stream));
 
@@ -84,7 +84,8 @@ BENCHMARK(CustomCrop, CPU) {
 
     CustomCrop op;
     ROCCV_BENCH_RECORD_BLOCK(
-        { op(nullptr, input, output, cropRect, eDeviceType::CPU); }, results.executionTime, config.runs);
+        { op(nullptr, input, output, cropRect, eDeviceType::CPU); }, results.executionTime, config.runs,
+        config.warmupRuns);
 
     return results;
 }

--- a/benchmarks/src/roccv/bench_custom_crop.cpp
+++ b/benchmarks/src/roccv/bench_custom_crop.cpp
@@ -43,8 +43,8 @@ BENCHMARK(CustomCrop, GPU) {
                               {config.samples, cropRect.height, cropRect.width, 3}),
                   input.dtype());
 
-    roccvbench::RegisterMemoryUsage(input, results.inputMemoryBytes);
-    roccvbench::RegisterMemoryUsage(output, results.outputMemoryBytes);
+    RegisterMemoryUsage(input, results.inputMemoryBytes);
+    RegisterMemoryUsage(output, results.outputMemoryBytes);
 
     FillTensor(input);
 
@@ -77,8 +77,8 @@ BENCHMARK(CustomCrop, CPU) {
                               {config.samples, cropRect.height, cropRect.width, 3}),
                   input.dtype(), eDeviceType::CPU);
 
-    roccvbench::RegisterMemoryUsage(input, results.inputMemoryBytes);
-    roccvbench::RegisterMemoryUsage(output, results.outputMemoryBytes);
+    RegisterMemoryUsage(input, results.inputMemoryBytes);
+    RegisterMemoryUsage(output, results.outputMemoryBytes);
 
     FillTensor(input);
 

--- a/benchmarks/src/roccv/bench_cvt_color.cpp
+++ b/benchmarks/src/roccv/bench_cvt_color.cpp
@@ -41,8 +41,8 @@ BENCHMARK(CvtColor, GPU) {
     Tensor input(inReqs);
     Tensor output(outReqs);
 
-    RegisterMemoryUsage(input, results.inputMemoryBytes);
-    RegisterMemoryUsage(output, results.outputMemoryBytes);
+    RegisterMemoryUsage(input, results.readMemoryBytes);
+    RegisterMemoryUsage(output, results.writtenMemoryBytes);
 
     FillTensor(input);
 
@@ -72,8 +72,8 @@ BENCHMARK(CvtColor, CPU) {
     Tensor input(inReqs);
     Tensor output(outReqs);
 
-    RegisterMemoryUsage(input, results.inputMemoryBytes);
-    RegisterMemoryUsage(output, results.outputMemoryBytes);
+    RegisterMemoryUsage(input, results.readMemoryBytes);
+    RegisterMemoryUsage(output, results.writtenMemoryBytes);
 
     FillTensor(input);
 

--- a/benchmarks/src/roccv/bench_cvt_color.cpp
+++ b/benchmarks/src/roccv/bench_cvt_color.cpp
@@ -41,8 +41,8 @@ BENCHMARK(CvtColor, GPU) {
     Tensor input(inReqs);
     Tensor output(outReqs);
 
-    roccvbench::RegisterMemoryUsage(input, results.inputMemoryBytes);
-    roccvbench::RegisterMemoryUsage(output, results.outputMemoryBytes);
+    RegisterMemoryUsage(input, results.inputMemoryBytes);
+    RegisterMemoryUsage(output, results.outputMemoryBytes);
 
     FillTensor(input);
 
@@ -72,8 +72,8 @@ BENCHMARK(CvtColor, CPU) {
     Tensor input(inReqs);
     Tensor output(outReqs);
 
-    roccvbench::RegisterMemoryUsage(input, results.inputMemoryBytes);
-    roccvbench::RegisterMemoryUsage(output, results.outputMemoryBytes);
+    RegisterMemoryUsage(input, results.inputMemoryBytes);
+    RegisterMemoryUsage(output, results.outputMemoryBytes);
 
     FillTensor(input);
 

--- a/benchmarks/src/roccv/bench_cvt_color.cpp
+++ b/benchmarks/src/roccv/bench_cvt_color.cpp
@@ -33,7 +33,6 @@ using namespace roccv;
 
 BENCHMARK(CvtColor, GPU) {
     roccvbench::BenchmarkResults results;
-    results.executionTime = 0.0f;
 
     TensorRequirements inReqs =
         Tensor::CalcRequirements(config.samples, (Size2D){config.width, config.height}, FMT_RGB8);
@@ -41,6 +40,9 @@ BENCHMARK(CvtColor, GPU) {
         Tensor::CalcRequirements(config.samples, (Size2D){config.width, config.height}, FMT_U8);
     Tensor input(inReqs);
     Tensor output(outReqs);
+
+    roccvbench::RegisterMemoryUsage(input, results.inputMemoryBytes);
+    roccvbench::RegisterMemoryUsage(output, results.outputMemoryBytes);
 
     FillTensor(input);
 
@@ -62,7 +64,6 @@ BENCHMARK(CvtColor, GPU) {
 
 BENCHMARK(CvtColor, CPU) {
     roccvbench::BenchmarkResults results;
-    results.executionTime = 0.0f;
 
     TensorRequirements inReqs =
         Tensor::CalcRequirements(config.samples, (Size2D){config.width, config.height}, FMT_RGB8, eDeviceType::CPU);
@@ -70,6 +71,9 @@ BENCHMARK(CvtColor, CPU) {
         Tensor::CalcRequirements(config.samples, (Size2D){config.width, config.height}, FMT_U8, eDeviceType::CPU);
     Tensor input(inReqs);
     Tensor output(outReqs);
+
+    roccvbench::RegisterMemoryUsage(input, results.inputMemoryBytes);
+    roccvbench::RegisterMemoryUsage(output, results.outputMemoryBytes);
 
     FillTensor(input);
 

--- a/benchmarks/src/roccv/bench_cvt_color.cpp
+++ b/benchmarks/src/roccv/bench_cvt_color.cpp
@@ -55,7 +55,7 @@ BENCHMARK(CvtColor, GPU) {
             op(stream, input, output, eColorConversionCode::COLOR_RGB2GRAY);
             HIP_VALIDATE_NO_ERRORS(hipStreamSynchronize(stream))
         },
-        results.executionTime, config.runs);
+        results.executionTime, config.runs, config.warmupRuns);
 
     HIP_VALIDATE_NO_ERRORS(hipStreamDestroy(stream));
 
@@ -80,7 +80,7 @@ BENCHMARK(CvtColor, CPU) {
     CvtColor op;
     ROCCV_BENCH_RECORD_BLOCK(
         { op(nullptr, input, output, eColorConversionCode::COLOR_RGB2GRAY, eDeviceType::CPU); }, results.executionTime,
-        config.runs);
+        config.runs, config.warmupRuns);
 
     return results;
 }

--- a/benchmarks/src/roccv/bench_flip.cpp
+++ b/benchmarks/src/roccv/bench_flip.cpp
@@ -33,12 +33,14 @@ using namespace roccv;
 
 BENCHMARK(Flip, GPU) {
     roccvbench::BenchmarkResults results;
-    results.executionTime = 0.0f;
 
     TensorRequirements reqs = Tensor::CalcRequirements(
         config.samples, (Size2D){static_cast<int>(config.width), static_cast<int>(config.height)}, FMT_RGB8);
     Tensor input(reqs);
     Tensor output(reqs);
+
+    roccvbench::RegisterMemoryUsage(input, results.inputMemoryBytes);
+    roccvbench::RegisterMemoryUsage(output, results.outputMemoryBytes);
 
     FillTensor(input);
 
@@ -60,13 +62,15 @@ BENCHMARK(Flip, GPU) {
 
 BENCHMARK(Flip, CPU) {
     roccvbench::BenchmarkResults results;
-    results.executionTime = 0.0f;
 
     TensorRequirements reqs = Tensor::CalcRequirements(
         config.samples, (Size2D){static_cast<int>(config.width), static_cast<int>(config.height)}, FMT_RGB8,
         eDeviceType::CPU);
     Tensor input(reqs);
     Tensor output(reqs);
+
+    roccvbench::RegisterMemoryUsage(input, results.inputMemoryBytes);
+    roccvbench::RegisterMemoryUsage(output, results.outputMemoryBytes);
 
     FillTensor(input);
 

--- a/benchmarks/src/roccv/bench_flip.cpp
+++ b/benchmarks/src/roccv/bench_flip.cpp
@@ -53,7 +53,7 @@ BENCHMARK(Flip, GPU) {
             op(stream, input, output, -1);
             HIP_VALIDATE_NO_ERRORS(hipStreamSynchronize(stream))
         },
-        results.executionTime, config.runs);
+        results.executionTime, config.runs, config.warmupRuns);
 
     HIP_VALIDATE_NO_ERRORS(hipStreamDestroy(stream));
 
@@ -75,7 +75,8 @@ BENCHMARK(Flip, CPU) {
     FillTensor(input);
 
     Flip op;
-    ROCCV_BENCH_RECORD_BLOCK({ op(nullptr, input, output, -1, eDeviceType::CPU); }, results.executionTime, config.runs);
+    ROCCV_BENCH_RECORD_BLOCK(
+        { op(nullptr, input, output, -1, eDeviceType::CPU); }, results.executionTime, config.runs, config.warmupRuns);
 
     return results;
 }

--- a/benchmarks/src/roccv/bench_flip.cpp
+++ b/benchmarks/src/roccv/bench_flip.cpp
@@ -39,8 +39,8 @@ BENCHMARK(Flip, GPU) {
     Tensor input(reqs);
     Tensor output(reqs);
 
-    roccvbench::RegisterMemoryUsage(input, results.inputMemoryBytes);
-    roccvbench::RegisterMemoryUsage(output, results.outputMemoryBytes);
+    RegisterMemoryUsage(input, results.inputMemoryBytes);
+    RegisterMemoryUsage(output, results.outputMemoryBytes);
 
     FillTensor(input);
 
@@ -69,8 +69,8 @@ BENCHMARK(Flip, CPU) {
     Tensor input(reqs);
     Tensor output(reqs);
 
-    roccvbench::RegisterMemoryUsage(input, results.inputMemoryBytes);
-    roccvbench::RegisterMemoryUsage(output, results.outputMemoryBytes);
+    RegisterMemoryUsage(input, results.inputMemoryBytes);
+    RegisterMemoryUsage(output, results.outputMemoryBytes);
 
     FillTensor(input);
 

--- a/benchmarks/src/roccv/bench_flip.cpp
+++ b/benchmarks/src/roccv/bench_flip.cpp
@@ -39,8 +39,8 @@ BENCHMARK(Flip, GPU) {
     Tensor input(reqs);
     Tensor output(reqs);
 
-    RegisterMemoryUsage(input, results.inputMemoryBytes);
-    RegisterMemoryUsage(output, results.outputMemoryBytes);
+    RegisterMemoryUsage(input, results.readMemoryBytes);
+    RegisterMemoryUsage(output, results.writtenMemoryBytes);
 
     FillTensor(input);
 
@@ -69,8 +69,8 @@ BENCHMARK(Flip, CPU) {
     Tensor input(reqs);
     Tensor output(reqs);
 
-    RegisterMemoryUsage(input, results.inputMemoryBytes);
-    RegisterMemoryUsage(output, results.outputMemoryBytes);
+    RegisterMemoryUsage(input, results.readMemoryBytes);
+    RegisterMemoryUsage(output, results.writtenMemoryBytes);
 
     FillTensor(input);
 

--- a/benchmarks/src/roccv/bench_gamma_contrast.cpp
+++ b/benchmarks/src/roccv/bench_gamma_contrast.cpp
@@ -40,8 +40,8 @@ BENCHMARK(GammaContrast, GPU) {
     Tensor output(reqs);
     float gamma = 2.2f;
 
-    RegisterMemoryUsage(input, results.inputMemoryBytes);
-    RegisterMemoryUsage(output, results.outputMemoryBytes);
+    RegisterMemoryUsage(input, results.readMemoryBytes);
+    RegisterMemoryUsage(output, results.writtenMemoryBytes);
 
     FillTensor(input);
 
@@ -71,8 +71,8 @@ BENCHMARK(GammaContrast, CPU) {
     Tensor output(reqs);
     float gamma = 2.2f;
 
-    RegisterMemoryUsage(input, results.inputMemoryBytes);
-    RegisterMemoryUsage(output, results.outputMemoryBytes);
+    RegisterMemoryUsage(input, results.readMemoryBytes);
+    RegisterMemoryUsage(output, results.writtenMemoryBytes);
 
     FillTensor(input);
 

--- a/benchmarks/src/roccv/bench_gamma_contrast.cpp
+++ b/benchmarks/src/roccv/bench_gamma_contrast.cpp
@@ -40,8 +40,8 @@ BENCHMARK(GammaContrast, GPU) {
     Tensor output(reqs);
     float gamma = 2.2f;
 
-    roccvbench::RegisterMemoryUsage(input, results.inputMemoryBytes);
-    roccvbench::RegisterMemoryUsage(output, results.outputMemoryBytes);
+    RegisterMemoryUsage(input, results.inputMemoryBytes);
+    RegisterMemoryUsage(output, results.outputMemoryBytes);
 
     FillTensor(input);
 
@@ -71,8 +71,8 @@ BENCHMARK(GammaContrast, CPU) {
     Tensor output(reqs);
     float gamma = 2.2f;
 
-    roccvbench::RegisterMemoryUsage(input, results.inputMemoryBytes);
-    roccvbench::RegisterMemoryUsage(output, results.outputMemoryBytes);
+    RegisterMemoryUsage(input, results.inputMemoryBytes);
+    RegisterMemoryUsage(output, results.outputMemoryBytes);
 
     FillTensor(input);
 

--- a/benchmarks/src/roccv/bench_gamma_contrast.cpp
+++ b/benchmarks/src/roccv/bench_gamma_contrast.cpp
@@ -54,7 +54,7 @@ BENCHMARK(GammaContrast, GPU) {
             op(stream, input, output, gamma);
             HIP_VALIDATE_NO_ERRORS(hipStreamSynchronize(stream))
         },
-        results.executionTime, config.runs);
+        results.executionTime, config.runs, config.warmupRuns);
 
     HIP_VALIDATE_NO_ERRORS(hipStreamDestroy(stream));
 
@@ -78,7 +78,8 @@ BENCHMARK(GammaContrast, CPU) {
 
     GammaContrast op;
     ROCCV_BENCH_RECORD_BLOCK(
-        { op(nullptr, input, output, gamma, eDeviceType::CPU); }, results.executionTime, config.runs);
+        { op(nullptr, input, output, gamma, eDeviceType::CPU); }, results.executionTime, config.runs,
+        config.warmupRuns);
 
     return results;
 }

--- a/benchmarks/src/roccv/bench_gamma_contrast.cpp
+++ b/benchmarks/src/roccv/bench_gamma_contrast.cpp
@@ -32,7 +32,6 @@ using namespace roccv;
 
 BENCHMARK(GammaContrast, GPU) {
     roccvbench::BenchmarkResults results;
-    results.executionTime = 0.0f;
 
     TensorRequirements reqs = Tensor::CalcRequirements(
         TensorShape(TensorLayout(TENSOR_LAYOUT_NHWC), {config.samples, config.height, config.width, 3}),
@@ -40,6 +39,9 @@ BENCHMARK(GammaContrast, GPU) {
     Tensor input(reqs);
     Tensor output(reqs);
     float gamma = 2.2f;
+
+    roccvbench::RegisterMemoryUsage(input, results.inputMemoryBytes);
+    roccvbench::RegisterMemoryUsage(output, results.outputMemoryBytes);
 
     FillTensor(input);
 
@@ -61,7 +63,6 @@ BENCHMARK(GammaContrast, GPU) {
 
 BENCHMARK(GammaContrast, CPU) {
     roccvbench::BenchmarkResults results;
-    results.executionTime = 0.0f;
 
     TensorRequirements reqs = Tensor::CalcRequirements(
         TensorShape(TensorLayout(TENSOR_LAYOUT_NHWC), {config.samples, config.height, config.width, 3}),
@@ -69,6 +70,9 @@ BENCHMARK(GammaContrast, CPU) {
     Tensor input(reqs);
     Tensor output(reqs);
     float gamma = 2.2f;
+
+    roccvbench::RegisterMemoryUsage(input, results.inputMemoryBytes);
+    roccvbench::RegisterMemoryUsage(output, results.outputMemoryBytes);
 
     FillTensor(input);
 

--- a/benchmarks/src/roccv/bench_histogram.cpp
+++ b/benchmarks/src/roccv/bench_histogram.cpp
@@ -42,8 +42,8 @@ BENCHMARK(Histogram, GPU) {
     Tensor input(inReqs);
     Tensor output(outReqs);
 
-    RegisterMemoryUsage(input, results.inputMemoryBytes);
-    RegisterMemoryUsage(output, results.outputMemoryBytes);
+    RegisterMemoryUsage(input, results.readMemoryBytes);
+    RegisterMemoryUsage(output, results.writtenMemoryBytes);
 
     FillTensor(input);
 
@@ -75,8 +75,8 @@ BENCHMARK(Histogram, CPU) {
     Tensor input(inReqs);
     Tensor output(outReqs);
 
-    RegisterMemoryUsage(input, results.inputMemoryBytes);
-    RegisterMemoryUsage(output, results.outputMemoryBytes);
+    RegisterMemoryUsage(input, results.readMemoryBytes);
+    RegisterMemoryUsage(output, results.writtenMemoryBytes);
 
     FillTensor(input);
 

--- a/benchmarks/src/roccv/bench_histogram.cpp
+++ b/benchmarks/src/roccv/bench_histogram.cpp
@@ -42,8 +42,8 @@ BENCHMARK(Histogram, GPU) {
     Tensor input(inReqs);
     Tensor output(outReqs);
 
-    roccvbench::RegisterMemoryUsage(input, results.inputMemoryBytes);
-    roccvbench::RegisterMemoryUsage(output, results.outputMemoryBytes);
+    RegisterMemoryUsage(input, results.inputMemoryBytes);
+    RegisterMemoryUsage(output, results.outputMemoryBytes);
 
     FillTensor(input);
 
@@ -75,8 +75,8 @@ BENCHMARK(Histogram, CPU) {
     Tensor input(inReqs);
     Tensor output(outReqs);
 
-    roccvbench::RegisterMemoryUsage(input, results.inputMemoryBytes);
-    roccvbench::RegisterMemoryUsage(output, results.outputMemoryBytes);
+    RegisterMemoryUsage(input, results.inputMemoryBytes);
+    RegisterMemoryUsage(output, results.outputMemoryBytes);
 
     FillTensor(input);
 

--- a/benchmarks/src/roccv/bench_histogram.cpp
+++ b/benchmarks/src/roccv/bench_histogram.cpp
@@ -56,7 +56,7 @@ BENCHMARK(Histogram, GPU) {
             op(stream, input, std::nullopt, output);
             HIP_VALIDATE_NO_ERRORS(hipStreamSynchronize(stream))
         },
-        results.executionTime, config.runs);
+        results.executionTime, config.runs, config.warmupRuns);
 
     HIP_VALIDATE_NO_ERRORS(hipStreamDestroy(stream));
 
@@ -82,7 +82,8 @@ BENCHMARK(Histogram, CPU) {
 
     Histogram op;
     ROCCV_BENCH_RECORD_BLOCK(
-        { op(nullptr, input, std::nullopt, output, eDeviceType::CPU); }, results.executionTime, config.runs);
+        { op(nullptr, input, std::nullopt, output, eDeviceType::CPU); }, results.executionTime, config.runs,
+        config.warmupRuns);
 
     return results;
 }

--- a/benchmarks/src/roccv/bench_histogram.cpp
+++ b/benchmarks/src/roccv/bench_histogram.cpp
@@ -34,7 +34,6 @@ using namespace roccv;
 
 BENCHMARK(Histogram, GPU) {
     roccvbench::BenchmarkResults results;
-    results.executionTime = 0.0f;
 
     Tensor::Requirements inReqs = Tensor::CalcRequirements(config.samples, {config.width, config.height}, FMT_U8);
     Tensor::Requirements outReqs = Tensor::CalcRequirements(
@@ -42,6 +41,9 @@ BENCHMARK(Histogram, GPU) {
 
     Tensor input(inReqs);
     Tensor output(outReqs);
+
+    roccvbench::RegisterMemoryUsage(input, results.inputMemoryBytes);
+    roccvbench::RegisterMemoryUsage(output, results.outputMemoryBytes);
 
     FillTensor(input);
 
@@ -63,7 +65,6 @@ BENCHMARK(Histogram, GPU) {
 
 BENCHMARK(Histogram, CPU) {
     roccvbench::BenchmarkResults results;
-    results.executionTime = 0.0f;
 
     Tensor::Requirements inReqs =
         Tensor::CalcRequirements(config.samples, {config.width, config.height}, FMT_U8, eDeviceType::CPU);
@@ -73,6 +74,9 @@ BENCHMARK(Histogram, CPU) {
 
     Tensor input(inReqs);
     Tensor output(outReqs);
+
+    roccvbench::RegisterMemoryUsage(input, results.inputMemoryBytes);
+    roccvbench::RegisterMemoryUsage(output, results.outputMemoryBytes);
 
     FillTensor(input);
 

--- a/benchmarks/src/roccv/bench_normalize.cpp
+++ b/benchmarks/src/roccv/bench_normalize.cpp
@@ -33,7 +33,6 @@ using namespace roccv;
 
 BENCHMARK(Normalize, GPU) {
     roccvbench::BenchmarkResults results;
-    results.executionTime = 0.0f;
 
     TensorRequirements reqs = Tensor::CalcRequirements(
         config.samples, (Size2D){static_cast<int>(config.width), static_cast<int>(config.height)}, FMT_RGB8);
@@ -44,6 +43,11 @@ BENCHMARK(Normalize, GPU) {
         TensorShape(TensorLayout(eTensorLayout::TENSOR_LAYOUT_NHWC), {1, 1, 1, 3}), DataType(eDataType::DATA_TYPE_F32));
     Tensor scale(paramTensorReqs);
     Tensor base(paramTensorReqs);
+
+    roccvbench::RegisterMemoryUsage(input, results.inputMemoryBytes);
+    roccvbench::RegisterMemoryUsage(output, results.outputMemoryBytes);
+    roccvbench::RegisterMemoryUsage(scale, results.inputMemoryBytes);
+    roccvbench::RegisterMemoryUsage(base, results.inputMemoryBytes);
 
     FillTensor(input);
     FillTensor(scale);
@@ -67,7 +71,6 @@ BENCHMARK(Normalize, GPU) {
 
 BENCHMARK(Normalize, CPU) {
     roccvbench::BenchmarkResults results;
-    results.executionTime = 0.0f;
 
     TensorRequirements reqs = Tensor::CalcRequirements(
         config.samples, (Size2D){static_cast<int>(config.width), static_cast<int>(config.height)}, FMT_RGB8,
@@ -80,6 +83,11 @@ BENCHMARK(Normalize, CPU) {
                                  DataType(eDataType::DATA_TYPE_F32), eDeviceType::CPU);
     Tensor scale(paramTensorReqs);
     Tensor base(paramTensorReqs);
+
+    roccvbench::RegisterMemoryUsage(input, results.inputMemoryBytes);
+    roccvbench::RegisterMemoryUsage(output, results.outputMemoryBytes);
+    roccvbench::RegisterMemoryUsage(scale, results.inputMemoryBytes);
+    roccvbench::RegisterMemoryUsage(base, results.inputMemoryBytes);
 
     FillTensor(input);
     FillTensor(scale);

--- a/benchmarks/src/roccv/bench_normalize.cpp
+++ b/benchmarks/src/roccv/bench_normalize.cpp
@@ -44,10 +44,10 @@ BENCHMARK(Normalize, GPU) {
     Tensor scale(paramTensorReqs);
     Tensor base(paramTensorReqs);
 
-    RegisterMemoryUsage(input, results.inputMemoryBytes);
-    RegisterMemoryUsage(output, results.outputMemoryBytes);
-    RegisterMemoryUsage(scale, results.inputMemoryBytes);
-    RegisterMemoryUsage(base, results.inputMemoryBytes);
+    RegisterMemoryUsage(input, results.readMemoryBytes);
+    RegisterMemoryUsage(output, results.writtenMemoryBytes);
+    RegisterMemoryUsage(scale, results.readMemoryBytes);
+    RegisterMemoryUsage(base, results.readMemoryBytes);
 
     FillTensor(input);
     FillTensor(scale);
@@ -84,10 +84,10 @@ BENCHMARK(Normalize, CPU) {
     Tensor scale(paramTensorReqs);
     Tensor base(paramTensorReqs);
 
-    RegisterMemoryUsage(input, results.inputMemoryBytes);
-    RegisterMemoryUsage(output, results.outputMemoryBytes);
-    RegisterMemoryUsage(scale, results.inputMemoryBytes);
-    RegisterMemoryUsage(base, results.inputMemoryBytes);
+    RegisterMemoryUsage(input, results.readMemoryBytes);
+    RegisterMemoryUsage(output, results.writtenMemoryBytes);
+    RegisterMemoryUsage(scale, results.readMemoryBytes);
+    RegisterMemoryUsage(base, results.readMemoryBytes);
 
     FillTensor(input);
     FillTensor(scale);

--- a/benchmarks/src/roccv/bench_normalize.cpp
+++ b/benchmarks/src/roccv/bench_normalize.cpp
@@ -62,7 +62,7 @@ BENCHMARK(Normalize, GPU) {
             op(stream, input, base, scale, output, 1.0f, 0.0f, 0.00001f, 0);
             HIP_VALIDATE_NO_ERRORS(hipStreamSynchronize(stream))
         },
-        results.executionTime, config.runs);
+        results.executionTime, config.runs, config.warmupRuns);
 
     HIP_VALIDATE_NO_ERRORS(hipStreamDestroy(stream));
 
@@ -96,7 +96,7 @@ BENCHMARK(Normalize, CPU) {
     Normalize op;
     ROCCV_BENCH_RECORD_BLOCK(
         { op(nullptr, input, base, scale, output, 1.0f, 0.0f, 0.00001f, 0, eDeviceType::CPU); }, results.executionTime,
-        config.runs);
+        config.runs, config.warmupRuns);
 
     return results;
 }

--- a/benchmarks/src/roccv/bench_normalize.cpp
+++ b/benchmarks/src/roccv/bench_normalize.cpp
@@ -44,10 +44,10 @@ BENCHMARK(Normalize, GPU) {
     Tensor scale(paramTensorReqs);
     Tensor base(paramTensorReqs);
 
-    roccvbench::RegisterMemoryUsage(input, results.inputMemoryBytes);
-    roccvbench::RegisterMemoryUsage(output, results.outputMemoryBytes);
-    roccvbench::RegisterMemoryUsage(scale, results.inputMemoryBytes);
-    roccvbench::RegisterMemoryUsage(base, results.inputMemoryBytes);
+    RegisterMemoryUsage(input, results.inputMemoryBytes);
+    RegisterMemoryUsage(output, results.outputMemoryBytes);
+    RegisterMemoryUsage(scale, results.inputMemoryBytes);
+    RegisterMemoryUsage(base, results.inputMemoryBytes);
 
     FillTensor(input);
     FillTensor(scale);
@@ -84,10 +84,10 @@ BENCHMARK(Normalize, CPU) {
     Tensor scale(paramTensorReqs);
     Tensor base(paramTensorReqs);
 
-    roccvbench::RegisterMemoryUsage(input, results.inputMemoryBytes);
-    roccvbench::RegisterMemoryUsage(output, results.outputMemoryBytes);
-    roccvbench::RegisterMemoryUsage(scale, results.inputMemoryBytes);
-    roccvbench::RegisterMemoryUsage(base, results.inputMemoryBytes);
+    RegisterMemoryUsage(input, results.inputMemoryBytes);
+    RegisterMemoryUsage(output, results.outputMemoryBytes);
+    RegisterMemoryUsage(scale, results.inputMemoryBytes);
+    RegisterMemoryUsage(base, results.inputMemoryBytes);
 
     FillTensor(input);
     FillTensor(scale);

--- a/benchmarks/src/roccv/bench_resize.cpp
+++ b/benchmarks/src/roccv/bench_resize.cpp
@@ -33,7 +33,6 @@ using namespace roccv;
 
 BENCHMARK(Resize, GPU) {
     roccvbench::BenchmarkResults results;
-    results.executionTime = 0.0f;
 
     Tensor::Requirements inputReqs =
         Tensor::CalcRequirements(config.samples, (Size2D){config.width, config.height}, FMT_RGB8);
@@ -41,6 +40,9 @@ BENCHMARK(Resize, GPU) {
         Tensor::CalcRequirements(config.samples, (Size2D){config.width * 2, config.height * 2}, FMT_RGB8);
     Tensor input(inputReqs);
     Tensor output(outputReqs);
+
+    roccvbench::RegisterMemoryUsage(input, results.inputMemoryBytes);
+    roccvbench::RegisterMemoryUsage(output, results.outputMemoryBytes);
 
     FillTensor(input);
 
@@ -62,7 +64,6 @@ BENCHMARK(Resize, GPU) {
 
 BENCHMARK(Resize, CPU) {
     roccvbench::BenchmarkResults results;
-    results.executionTime = 0.0f;
 
     Tensor::Requirements inputReqs =
         Tensor::CalcRequirements(config.samples, (Size2D){config.width, config.height}, FMT_RGB8, eDeviceType::CPU);
@@ -70,6 +71,9 @@ BENCHMARK(Resize, CPU) {
         config.samples, (Size2D){config.width * 2, config.height * 2}, FMT_RGB8, eDeviceType::CPU);
     Tensor input(inputReqs);
     Tensor output(outputReqs);
+
+    roccvbench::RegisterMemoryUsage(input, results.inputMemoryBytes);
+    roccvbench::RegisterMemoryUsage(output, results.outputMemoryBytes);
 
     FillTensor(input);
 

--- a/benchmarks/src/roccv/bench_resize.cpp
+++ b/benchmarks/src/roccv/bench_resize.cpp
@@ -41,8 +41,8 @@ BENCHMARK(Resize, GPU) {
     Tensor input(inputReqs);
     Tensor output(outputReqs);
 
-    RegisterMemoryUsage(input, results.inputMemoryBytes);
-    RegisterMemoryUsage(output, results.outputMemoryBytes);
+    RegisterMemoryUsage(input, results.readMemoryBytes);
+    RegisterMemoryUsage(output, results.writtenMemoryBytes);
 
     FillTensor(input);
 
@@ -72,8 +72,8 @@ BENCHMARK(Resize, CPU) {
     Tensor input(inputReqs);
     Tensor output(outputReqs);
 
-    RegisterMemoryUsage(input, results.inputMemoryBytes);
-    RegisterMemoryUsage(output, results.outputMemoryBytes);
+    RegisterMemoryUsage(input, results.readMemoryBytes);
+    RegisterMemoryUsage(output, results.writtenMemoryBytes);
 
     FillTensor(input);
 

--- a/benchmarks/src/roccv/bench_resize.cpp
+++ b/benchmarks/src/roccv/bench_resize.cpp
@@ -41,8 +41,8 @@ BENCHMARK(Resize, GPU) {
     Tensor input(inputReqs);
     Tensor output(outputReqs);
 
-    roccvbench::RegisterMemoryUsage(input, results.inputMemoryBytes);
-    roccvbench::RegisterMemoryUsage(output, results.outputMemoryBytes);
+    RegisterMemoryUsage(input, results.inputMemoryBytes);
+    RegisterMemoryUsage(output, results.outputMemoryBytes);
 
     FillTensor(input);
 
@@ -72,8 +72,8 @@ BENCHMARK(Resize, CPU) {
     Tensor input(inputReqs);
     Tensor output(outputReqs);
 
-    roccvbench::RegisterMemoryUsage(input, results.inputMemoryBytes);
-    roccvbench::RegisterMemoryUsage(output, results.outputMemoryBytes);
+    RegisterMemoryUsage(input, results.inputMemoryBytes);
+    RegisterMemoryUsage(output, results.outputMemoryBytes);
 
     FillTensor(input);
 

--- a/benchmarks/src/roccv/bench_resize.cpp
+++ b/benchmarks/src/roccv/bench_resize.cpp
@@ -55,7 +55,7 @@ BENCHMARK(Resize, GPU) {
             op(stream, input, output, eInterpolationType::INTERP_TYPE_LINEAR);
             HIP_VALIDATE_NO_ERRORS(hipStreamSynchronize(stream))
         },
-        results.executionTime, config.runs);
+        results.executionTime, config.runs, config.warmupRuns);
 
     HIP_VALIDATE_NO_ERRORS(hipStreamDestroy(stream));
 
@@ -80,7 +80,7 @@ BENCHMARK(Resize, CPU) {
     Resize op;
     ROCCV_BENCH_RECORD_BLOCK(
         { op(nullptr, input, output, eInterpolationType::INTERP_TYPE_LINEAR, eDeviceType::CPU); },
-        results.executionTime, config.runs);
+        results.executionTime, config.runs, config.warmupRuns);
 
     return results;
 }

--- a/benchmarks/src/roccv/bench_rotate.cpp
+++ b/benchmarks/src/roccv/bench_rotate.cpp
@@ -55,8 +55,8 @@ BENCHMARK(Rotate, GPU) {
     Tensor input(reqs);
     Tensor output(reqs);
 
-    roccvbench::RegisterMemoryUsage(input, results.inputMemoryBytes);
-    roccvbench::RegisterMemoryUsage(output, results.outputMemoryBytes);
+    RegisterMemoryUsage(input, results.inputMemoryBytes);
+    RegisterMemoryUsage(output, results.outputMemoryBytes);
 
     FillTensor(input);
 
@@ -90,8 +90,8 @@ BENCHMARK(Rotate, CPU) {
     Tensor input(reqs);
     Tensor output(reqs);
 
-    roccvbench::RegisterMemoryUsage(input, results.inputMemoryBytes);
-    roccvbench::RegisterMemoryUsage(output, results.outputMemoryBytes);
+    RegisterMemoryUsage(input, results.inputMemoryBytes);
+    RegisterMemoryUsage(output, results.outputMemoryBytes);
 
     FillTensor(input);
 

--- a/benchmarks/src/roccv/bench_rotate.cpp
+++ b/benchmarks/src/roccv/bench_rotate.cpp
@@ -48,13 +48,16 @@ double2 ComputeCenterShift(const double centerX, const double centerY, const dou
 
 BENCHMARK(Rotate, GPU) {
     roccvbench::BenchmarkResults results;
-    results.executionTime = 0.0f;
 
     TensorRequirements reqs = Tensor::CalcRequirements(
         TensorShape(TensorLayout(TENSOR_LAYOUT_NHWC), {config.samples, config.height, config.width, 3}),
         DataType(DATA_TYPE_U8));
     Tensor input(reqs);
     Tensor output(reqs);
+
+    roccvbench::RegisterMemoryUsage(input, results.inputMemoryBytes);
+    roccvbench::RegisterMemoryUsage(output, results.outputMemoryBytes);
+
     FillTensor(input);
 
     const double angle = 180;
@@ -80,13 +83,16 @@ BENCHMARK(Rotate, GPU) {
 
 BENCHMARK(Rotate, CPU) {
     roccvbench::BenchmarkResults results;
-    results.executionTime = 0.0f;
 
     TensorRequirements reqs = Tensor::CalcRequirements(
         TensorShape(TensorLayout(TENSOR_LAYOUT_NHWC), {config.samples, config.height, config.width, 3}),
         DataType(DATA_TYPE_U8), eDeviceType::CPU);
     Tensor input(reqs);
     Tensor output(reqs);
+
+    roccvbench::RegisterMemoryUsage(input, results.inputMemoryBytes);
+    roccvbench::RegisterMemoryUsage(output, results.outputMemoryBytes);
+
     FillTensor(input);
 
     const double angle = 180;

--- a/benchmarks/src/roccv/bench_rotate.cpp
+++ b/benchmarks/src/roccv/bench_rotate.cpp
@@ -74,7 +74,7 @@ BENCHMARK(Rotate, GPU) {
             op(stream, input, output, angle, shift, eInterpolationType::INTERP_TYPE_LINEAR);
             HIP_VALIDATE_NO_ERRORS(hipStreamSynchronize(stream))
         },
-        results.executionTime, config.runs);
+        results.executionTime, config.runs, config.warmupRuns);
 
     HIP_VALIDATE_NO_ERRORS(hipStreamDestroy(stream));
 
@@ -103,7 +103,7 @@ BENCHMARK(Rotate, CPU) {
     Rotate op;
     ROCCV_BENCH_RECORD_BLOCK(
         { op(nullptr, input, output, angle, shift, eInterpolationType::INTERP_TYPE_LINEAR, eDeviceType::CPU); },
-        results.executionTime, config.runs);
+        results.executionTime, config.runs, config.warmupRuns);
 
     return results;
 }

--- a/benchmarks/src/roccv/bench_rotate.cpp
+++ b/benchmarks/src/roccv/bench_rotate.cpp
@@ -55,8 +55,8 @@ BENCHMARK(Rotate, GPU) {
     Tensor input(reqs);
     Tensor output(reqs);
 
-    RegisterMemoryUsage(input, results.inputMemoryBytes);
-    RegisterMemoryUsage(output, results.outputMemoryBytes);
+    RegisterMemoryUsage(input, results.readMemoryBytes);
+    RegisterMemoryUsage(output, results.writtenMemoryBytes);
 
     FillTensor(input);
 
@@ -90,8 +90,8 @@ BENCHMARK(Rotate, CPU) {
     Tensor input(reqs);
     Tensor output(reqs);
 
-    RegisterMemoryUsage(input, results.inputMemoryBytes);
-    RegisterMemoryUsage(output, results.outputMemoryBytes);
+    RegisterMemoryUsage(input, results.readMemoryBytes);
+    RegisterMemoryUsage(output, results.writtenMemoryBytes);
 
     FillTensor(input);
 

--- a/benchmarks/src/roccv/bench_threshold.cpp
+++ b/benchmarks/src/roccv/bench_threshold.cpp
@@ -44,10 +44,10 @@ BENCHMARK(ThresholdBinary, GPU) {
     Tensor maxVal(paramReqs);
     Tensor thresh(paramReqs);
 
-    roccvbench::RegisterMemoryUsage(input, results.inputMemoryBytes);
-    roccvbench::RegisterMemoryUsage(output, results.outputMemoryBytes);
-    roccvbench::RegisterMemoryUsage(maxVal, results.inputMemoryBytes);
-    roccvbench::RegisterMemoryUsage(thresh, results.inputMemoryBytes);
+    RegisterMemoryUsage(input, results.inputMemoryBytes);
+    RegisterMemoryUsage(output, results.outputMemoryBytes);
+    RegisterMemoryUsage(maxVal, results.inputMemoryBytes);
+    RegisterMemoryUsage(thresh, results.inputMemoryBytes);
 
     FillTensor(input);
     FillTensor(maxVal);
@@ -83,10 +83,10 @@ BENCHMARK(ThresholdBinary, CPU) {
     Tensor maxVal(paramReqs);
     Tensor thresh(paramReqs);
 
-    roccvbench::RegisterMemoryUsage(input, results.inputMemoryBytes);
-    roccvbench::RegisterMemoryUsage(output, results.outputMemoryBytes);
-    roccvbench::RegisterMemoryUsage(maxVal, results.inputMemoryBytes);
-    roccvbench::RegisterMemoryUsage(thresh, results.inputMemoryBytes);
+    RegisterMemoryUsage(input, results.inputMemoryBytes);
+    RegisterMemoryUsage(output, results.outputMemoryBytes);
+    RegisterMemoryUsage(maxVal, results.inputMemoryBytes);
+    RegisterMemoryUsage(thresh, results.inputMemoryBytes);
 
     FillTensor(input);
     FillTensor(maxVal);

--- a/benchmarks/src/roccv/bench_threshold.cpp
+++ b/benchmarks/src/roccv/bench_threshold.cpp
@@ -33,7 +33,6 @@ using namespace roccv;
 
 BENCHMARK(ThresholdBinary, GPU) {
     roccvbench::BenchmarkResults results;
-    results.executionTime = 0.0f;
 
     TensorRequirements reqs = Tensor::CalcRequirements(
         config.samples, (Size2D){static_cast<int>(config.width), static_cast<int>(config.height)}, FMT_RGB8);
@@ -44,6 +43,11 @@ BENCHMARK(ThresholdBinary, GPU) {
         Tensor::CalcRequirements(TensorShape(TensorLayout(TENSOR_LAYOUT_N), {config.samples}), DataType(DATA_TYPE_F64));
     Tensor maxVal(paramReqs);
     Tensor thresh(paramReqs);
+
+    roccvbench::RegisterMemoryUsage(input, results.inputMemoryBytes);
+    roccvbench::RegisterMemoryUsage(output, results.outputMemoryBytes);
+    roccvbench::RegisterMemoryUsage(maxVal, results.inputMemoryBytes);
+    roccvbench::RegisterMemoryUsage(thresh, results.inputMemoryBytes);
 
     FillTensor(input);
     FillTensor(maxVal);
@@ -67,7 +71,6 @@ BENCHMARK(ThresholdBinary, GPU) {
 
 BENCHMARK(ThresholdBinary, CPU) {
     roccvbench::BenchmarkResults results;
-    results.executionTime = 0.0f;
 
     TensorRequirements reqs = Tensor::CalcRequirements(
         config.samples, (Size2D){static_cast<int>(config.width), static_cast<int>(config.height)}, FMT_RGB8,
@@ -79,6 +82,11 @@ BENCHMARK(ThresholdBinary, CPU) {
         TensorShape(TensorLayout(TENSOR_LAYOUT_N), {config.samples}), DataType(DATA_TYPE_F64), eDeviceType::CPU);
     Tensor maxVal(paramReqs);
     Tensor thresh(paramReqs);
+
+    roccvbench::RegisterMemoryUsage(input, results.inputMemoryBytes);
+    roccvbench::RegisterMemoryUsage(output, results.outputMemoryBytes);
+    roccvbench::RegisterMemoryUsage(maxVal, results.inputMemoryBytes);
+    roccvbench::RegisterMemoryUsage(thresh, results.inputMemoryBytes);
 
     FillTensor(input);
     FillTensor(maxVal);

--- a/benchmarks/src/roccv/bench_threshold.cpp
+++ b/benchmarks/src/roccv/bench_threshold.cpp
@@ -44,10 +44,10 @@ BENCHMARK(ThresholdBinary, GPU) {
     Tensor maxVal(paramReqs);
     Tensor thresh(paramReqs);
 
-    RegisterMemoryUsage(input, results.inputMemoryBytes);
-    RegisterMemoryUsage(output, results.outputMemoryBytes);
-    RegisterMemoryUsage(maxVal, results.inputMemoryBytes);
-    RegisterMemoryUsage(thresh, results.inputMemoryBytes);
+    RegisterMemoryUsage(input, results.readMemoryBytes);
+    RegisterMemoryUsage(output, results.writtenMemoryBytes);
+    RegisterMemoryUsage(maxVal, results.readMemoryBytes);
+    RegisterMemoryUsage(thresh, results.readMemoryBytes);
 
     FillTensor(input);
     FillTensor(maxVal);
@@ -83,10 +83,10 @@ BENCHMARK(ThresholdBinary, CPU) {
     Tensor maxVal(paramReqs);
     Tensor thresh(paramReqs);
 
-    RegisterMemoryUsage(input, results.inputMemoryBytes);
-    RegisterMemoryUsage(output, results.outputMemoryBytes);
-    RegisterMemoryUsage(maxVal, results.inputMemoryBytes);
-    RegisterMemoryUsage(thresh, results.inputMemoryBytes);
+    RegisterMemoryUsage(input, results.readMemoryBytes);
+    RegisterMemoryUsage(output, results.writtenMemoryBytes);
+    RegisterMemoryUsage(maxVal, results.readMemoryBytes);
+    RegisterMemoryUsage(thresh, results.readMemoryBytes);
 
     FillTensor(input);
     FillTensor(maxVal);

--- a/benchmarks/src/roccv/bench_threshold.cpp
+++ b/benchmarks/src/roccv/bench_threshold.cpp
@@ -62,7 +62,7 @@ BENCHMARK(ThresholdBinary, GPU) {
             op(stream, input, output, thresh, maxVal);
             HIP_VALIDATE_NO_ERRORS(hipStreamSynchronize(stream))
         },
-        results.executionTime, config.runs);
+        results.executionTime, config.runs, config.warmupRuns);
 
     HIP_VALIDATE_NO_ERRORS(hipStreamDestroy(stream));
 
@@ -94,7 +94,8 @@ BENCHMARK(ThresholdBinary, CPU) {
 
     Threshold op(eThresholdType::THRESH_BINARY, config.samples);
     ROCCV_BENCH_RECORD_BLOCK(
-        { op(nullptr, input, output, thresh, maxVal, eDeviceType::CPU); }, results.executionTime, config.runs);
+        { op(nullptr, input, output, thresh, maxVal, eDeviceType::CPU); }, results.executionTime, config.runs,
+        config.warmupRuns);
 
     return results;
 }

--- a/benchmarks/src/roccv/bench_warp_affine.cpp
+++ b/benchmarks/src/roccv/bench_warp_affine.cpp
@@ -43,8 +43,8 @@ BENCHMARK(WarpAffine, GPU) {
 
     FillTensor(input);
 
-    roccvbench::RegisterMemoryUsage(input, results.inputMemoryBytes);
-    roccvbench::RegisterMemoryUsage(output, results.outputMemoryBytes);
+    RegisterMemoryUsage(input, results.inputMemoryBytes);
+    RegisterMemoryUsage(output, results.outputMemoryBytes);
 
     WarpAffine op;
     hipStream_t stream;
@@ -76,8 +76,8 @@ BENCHMARK(WarpAffine, CPU) {
 
     FillTensor(input);
 
-    roccvbench::RegisterMemoryUsage(input, results.inputMemoryBytes);
-    roccvbench::RegisterMemoryUsage(output, results.outputMemoryBytes);
+    RegisterMemoryUsage(input, results.inputMemoryBytes);
+    RegisterMemoryUsage(output, results.outputMemoryBytes);
 
     WarpAffine op;
     ROCCV_BENCH_RECORD_BLOCK(

--- a/benchmarks/src/roccv/bench_warp_affine.cpp
+++ b/benchmarks/src/roccv/bench_warp_affine.cpp
@@ -33,7 +33,6 @@ using namespace roccv;
 
 BENCHMARK(WarpAffine, GPU) {
     roccvbench::BenchmarkResults results;
-    results.executionTime = 0.0f;
 
     TensorRequirements reqs = Tensor::CalcRequirements(
         config.samples, (Size2D){static_cast<int>(config.width), static_cast<int>(config.height)}, FMT_RGB8);
@@ -43,6 +42,9 @@ BENCHMARK(WarpAffine, GPU) {
     AffineTransform affineMatrix = {1, 0, 0, 1, -1, 120};
 
     FillTensor(input);
+
+    roccvbench::RegisterMemoryUsage(input, results.inputMemoryBytes);
+    roccvbench::RegisterMemoryUsage(output, results.outputMemoryBytes);
 
     WarpAffine op;
     hipStream_t stream;
@@ -63,7 +65,6 @@ BENCHMARK(WarpAffine, GPU) {
 
 BENCHMARK(WarpAffine, CPU) {
     roccvbench::BenchmarkResults results;
-    results.executionTime = 0.0f;
 
     TensorRequirements reqs = Tensor::CalcRequirements(
         config.samples, (Size2D){static_cast<int>(config.width), static_cast<int>(config.height)}, FMT_RGB8,
@@ -74,6 +75,9 @@ BENCHMARK(WarpAffine, CPU) {
     AffineTransform affineMatrix = {1, 0, 0, 1, -1, 120};
 
     FillTensor(input);
+
+    roccvbench::RegisterMemoryUsage(input, results.inputMemoryBytes);
+    roccvbench::RegisterMemoryUsage(output, results.outputMemoryBytes);
 
     WarpAffine op;
     ROCCV_BENCH_RECORD_BLOCK(

--- a/benchmarks/src/roccv/bench_warp_affine.cpp
+++ b/benchmarks/src/roccv/bench_warp_affine.cpp
@@ -56,7 +56,7 @@ BENCHMARK(WarpAffine, GPU) {
                eBorderType::BORDER_TYPE_CONSTANT, make_float4(0.0f, 0.0f, 0.0f, 1.0f));
             HIP_VALIDATE_NO_ERRORS(hipStreamSynchronize(stream))
         },
-        results.executionTime, config.runs);
+        results.executionTime, config.runs, config.warmupRuns);
 
     HIP_VALIDATE_NO_ERRORS(hipStreamDestroy(stream));
 
@@ -85,7 +85,7 @@ BENCHMARK(WarpAffine, CPU) {
             op(nullptr, input, output, affineMatrix, false, eInterpolationType::INTERP_TYPE_LINEAR,
                eBorderType::BORDER_TYPE_CONSTANT, make_float4(0.0f, 0.0f, 0.0f, 1.0f), eDeviceType::CPU);
         },
-        results.executionTime, config.runs);
+        results.executionTime, config.runs, config.warmupRuns);
 
     return results;
 }

--- a/benchmarks/src/roccv/bench_warp_affine.cpp
+++ b/benchmarks/src/roccv/bench_warp_affine.cpp
@@ -43,8 +43,8 @@ BENCHMARK(WarpAffine, GPU) {
 
     FillTensor(input);
 
-    RegisterMemoryUsage(input, results.inputMemoryBytes);
-    RegisterMemoryUsage(output, results.outputMemoryBytes);
+    RegisterMemoryUsage(input, results.readMemoryBytes);
+    RegisterMemoryUsage(output, results.writtenMemoryBytes);
 
     WarpAffine op;
     hipStream_t stream;
@@ -76,8 +76,8 @@ BENCHMARK(WarpAffine, CPU) {
 
     FillTensor(input);
 
-    RegisterMemoryUsage(input, results.inputMemoryBytes);
-    RegisterMemoryUsage(output, results.outputMemoryBytes);
+    RegisterMemoryUsage(input, results.readMemoryBytes);
+    RegisterMemoryUsage(output, results.writtenMemoryBytes);
 
     WarpAffine op;
     ROCCV_BENCH_RECORD_BLOCK(

--- a/benchmarks/src/roccv/bench_warp_perspective.cpp
+++ b/benchmarks/src/roccv/bench_warp_perspective.cpp
@@ -33,7 +33,6 @@ using namespace roccv;
 
 BENCHMARK(WarpPerspective, GPU) {
     roccvbench::BenchmarkResults results;
-    results.executionTime = 0.0f;
 
     TensorRequirements reqs = Tensor::CalcRequirements(
         config.samples, (Size2D){static_cast<int>(config.width), static_cast<int>(config.height)}, FMT_RGB8);
@@ -43,6 +42,9 @@ BENCHMARK(WarpPerspective, GPU) {
     PerspectiveTransform transformMatrix = {1, 0, 0, 0, 1, 0, -0.001, 0, 1};
 
     FillTensor(input);
+
+    roccvbench::RegisterMemoryUsage(input, results.inputMemoryBytes);
+    roccvbench::RegisterMemoryUsage(output, results.outputMemoryBytes);
 
     WarpPerspective op;
     hipStream_t stream;
@@ -63,7 +65,6 @@ BENCHMARK(WarpPerspective, GPU) {
 
 BENCHMARK(WarpPerspective, CPU) {
     roccvbench::BenchmarkResults results;
-    results.executionTime = 0.0f;
 
     TensorRequirements reqs = Tensor::CalcRequirements(
         config.samples, (Size2D){static_cast<int>(config.width), static_cast<int>(config.height)}, FMT_RGB8,
@@ -74,6 +75,9 @@ BENCHMARK(WarpPerspective, CPU) {
     PerspectiveTransform transformMatrix = {1, 0, 0, 0, 1, 0, -0.001, 0, 1};
 
     FillTensor(input);
+
+    roccvbench::RegisterMemoryUsage(input, results.inputMemoryBytes);
+    roccvbench::RegisterMemoryUsage(output, results.outputMemoryBytes);
 
     WarpPerspective op;
     ROCCV_BENCH_RECORD_BLOCK(

--- a/benchmarks/src/roccv/bench_warp_perspective.cpp
+++ b/benchmarks/src/roccv/bench_warp_perspective.cpp
@@ -43,8 +43,8 @@ BENCHMARK(WarpPerspective, GPU) {
 
     FillTensor(input);
 
-    roccvbench::RegisterMemoryUsage(input, results.inputMemoryBytes);
-    roccvbench::RegisterMemoryUsage(output, results.outputMemoryBytes);
+    RegisterMemoryUsage(input, results.inputMemoryBytes);
+    RegisterMemoryUsage(output, results.outputMemoryBytes);
 
     WarpPerspective op;
     hipStream_t stream;
@@ -76,8 +76,8 @@ BENCHMARK(WarpPerspective, CPU) {
 
     FillTensor(input);
 
-    roccvbench::RegisterMemoryUsage(input, results.inputMemoryBytes);
-    roccvbench::RegisterMemoryUsage(output, results.outputMemoryBytes);
+    RegisterMemoryUsage(input, results.inputMemoryBytes);
+    RegisterMemoryUsage(output, results.outputMemoryBytes);
 
     WarpPerspective op;
     ROCCV_BENCH_RECORD_BLOCK(

--- a/benchmarks/src/roccv/bench_warp_perspective.cpp
+++ b/benchmarks/src/roccv/bench_warp_perspective.cpp
@@ -56,7 +56,7 @@ BENCHMARK(WarpPerspective, GPU) {
                eBorderType::BORDER_TYPE_CONSTANT, make_float4(0.0f, 0.0f, 0.0f, 1.0f));
             HIP_VALIDATE_NO_ERRORS(hipStreamSynchronize(stream))
         },
-        results.executionTime, config.runs);
+        results.executionTime, config.runs, config.warmupRuns);
 
     HIP_VALIDATE_NO_ERRORS(hipStreamDestroy(stream));
 
@@ -85,7 +85,7 @@ BENCHMARK(WarpPerspective, CPU) {
             op(nullptr, input, output, transformMatrix, false, eInterpolationType::INTERP_TYPE_LINEAR,
                eBorderType::BORDER_TYPE_CONSTANT, make_float4(0.0f, 0.0f, 0.0f, 1.0f), eDeviceType::CPU);
         },
-        results.executionTime, config.runs);
+        results.executionTime, config.runs, config.warmupRuns);
 
     return results;
 }

--- a/benchmarks/src/roccv/bench_warp_perspective.cpp
+++ b/benchmarks/src/roccv/bench_warp_perspective.cpp
@@ -43,8 +43,8 @@ BENCHMARK(WarpPerspective, GPU) {
 
     FillTensor(input);
 
-    RegisterMemoryUsage(input, results.inputMemoryBytes);
-    RegisterMemoryUsage(output, results.outputMemoryBytes);
+    RegisterMemoryUsage(input, results.readMemoryBytes);
+    RegisterMemoryUsage(output, results.writtenMemoryBytes);
 
     WarpPerspective op;
     hipStream_t stream;
@@ -76,8 +76,8 @@ BENCHMARK(WarpPerspective, CPU) {
 
     FillTensor(input);
 
-    RegisterMemoryUsage(input, results.inputMemoryBytes);
-    RegisterMemoryUsage(output, results.outputMemoryBytes);
+    RegisterMemoryUsage(input, results.readMemoryBytes);
+    RegisterMemoryUsage(output, results.writtenMemoryBytes);
 
     WarpPerspective op;
     ROCCV_BENCH_RECORD_BLOCK(

--- a/benchmarks/src/roccv/roccv_bench_helpers.hpp
+++ b/benchmarks/src/roccv/roccv_bench_helpers.hpp
@@ -29,3 +29,13 @@
  * @param tensor The tensor to fill with random values.
  */
 extern void FillTensor(const roccv::Tensor& tensor);
+
+/**
+ * @brief Registers the memory usage of a tensor.
+ *
+ * @param tensor The tensor to register the memory usage of.
+ * @param memoryUsage The memory usage to register.
+ */
+inline void RegisterMemoryUsage(const roccv::Tensor& tensor, size_t& memoryUsage) {
+    memoryUsage += tensor.shape().size() * tensor.dtype().size();
+}


### PR DESCRIPTION
## Motivation

Add a warmup to the benchmarking suite and include total memory throughput statistics.

## Technical Details

* A number of warmup runs added to the configuration file.
* Improvements made to the python graphing script. Includes total memory throughput and spacing improvements.
* Benchmarks now record memory throughput for input/output tensors separately.

## Test Plan

* Ensure all benchmarks run properly and that the resulting data looks proper.

## Test Result

* Benchmarks run without error and produce realistic results.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
