### PR TITLE
[Hotfix]: Fix SaturateCast signed -> unsigned (small -> big) branching logic

### DIFF
--- a/include/core/detail/casting.hpp
+++ b/include/core/detail/casting.hpp
@@ -39,8 +39,8 @@ __device__ __host__ T ScalarSaturateCast(U v) {
         // Any float -> any integral
         return static_cast<T>(std::clamp<U>(std::round(v), static_cast<U>(std::numeric_limits<T>::min()),
                                             static_cast<U>(std::numeric_limits<T>::max())));
-    } else if constexpr (std::is_integral_v<T> && std::is_integral_v<U> && std::is_signed_v<U> && std::is_signed_v<T> &&
-                         smallToBig) {
+    } else if constexpr (std::is_integral_v<T> && std::is_integral_v<U> && std::is_signed_v<U> &&
+                         std::is_unsigned_v<T> && smallToBig) {
         // Any integral signed -> Any integral unsigned, small -> big or equal
         return v <= 0 ? 0 : static_cast<T>(v);
     } else if constexpr (std::is_integral_v<U> && std::is_integral_v<T> &&


### PR DESCRIPTION
## PR Description:
* Fixes a bug in SaturationCast which caused signed -> unsigned integer conversions to fall into the wrong branch and incorrectly overflow, leading to undefined behavior.