### PR TITLE
Roccv docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,3 +1,26 @@
+# ##############################################################################
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# ##############################################################################
+
 # Dockerfile to build and test rocCV on AMD GPU (ROCm)
 # Build from repo root. Tag format: roccv:<IMAGE_TAG_SUFFIX>-<date>
 #

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,68 @@
+# Dockerfile to build and test rocCV on AMD GPU (ROCm)
+# Build from repo root. Tag format: roccv:<IMAGE_TAG_SUFFIX>-<date>
+#
+# Docker cannot derive one ARG from another. To have IMAGE_TAG_SUFFIX follow
+# BASE_DOCKER_IMAGE, use docker/build.sh (it sets IMAGE_TAG_SUFFIX from
+# BASE_DOCKER_IMAGE) or pass both when calling docker build:
+#   SUFFIX=$(echo "${BASE_DOCKER_IMAGE}" | sed 's|^[^/]*/||' | tr ':' '-')
+#   docker build -t roccv:${SUFFIX}-$(date +%Y%m%d) --build-arg BASE_DOCKER_IMAGE=... --build-arg IMAGE_TAG_SUFFIX=${SUFFIX} -f docker/Dockerfile .
+
+ARG BASE_DOCKER_IMAGE=rocm/dev-ubuntu-24.04
+ARG IMAGE_TAG_SUFFIX=dev-ubuntu-24.04
+ARG GPU_ARCH
+ARG BUILD_DATE
+
+FROM ${BASE_DOCKER_IMAGE}
+
+LABEL org.opencontainers.image.created="${BUILD_DATE}" \
+      org.opencontainers.image.base="${BASE_DOCKER_IMAGE}" \
+      roccv.image.tag.suffix="${IMAGE_TAG_SUFFIX}"
+
+ENV ROCM_PATH=/opt/rocm
+ENV PATH="${ROCM_PATH}/bin:${PATH}"
+ENV LD_LIBRARY_PATH="${ROCM_PATH}/lib:${LD_LIBRARY_PATH}"
+ENV HIP_PLATFORM=amd
+
+# Build deps and test deps (OpenCV for samples/tests, pytest, numpy)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    cmake \
+    git \
+    libopencv-dev \
+    python3-dev \
+    python3-pip \
+    python3-pytest \
+    python3-numpy \
+    python3-opencv \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace
+
+# Copy repo from build context (build from repo root: docker build -f docker/Dockerfile .)
+COPY . roccv/
+
+# Initialize submodules (pybind11, dlpack)
+RUN cd roccv && git submodule update --init --recursive
+
+WORKDIR /workspace/roccv
+
+# Configure and build rocCV with tests and Python bindings.
+# GPU_ARCH: when set, build only for that GPU (e.g. gfx90a); otherwise use default targets.
+ARG GPU_ARCH
+RUN mkdir -p build && cd build \
+    && cmake .. \
+        -D CMAKE_BUILD_TYPE=Release \
+        -D BUILD_PYPACKAGE=ON \
+        -D TESTS=ON \
+        -D SAMPLES=ON \
+        -D BENCHMARKS=ON \
+        $( [ -n "${GPU_ARCH}" ] && echo "-D GPU_TARGETS=${GPU_ARCH}" ) \
+    && cmake --build . --parallel $(nproc)
+
+# Install into image (optional; tests can run from build dir)
+RUN cd build && cmake --install . --prefix /opt/rocm
+
+# For runtime: ensure Python can find rocpycv
+ENV PYTHONPATH="${ROCM_PATH}/lib:${PYTHONPATH}"
+
+# Default: run C++ and Python tests
+WORKDIR /workspace/roccv/build

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,3 +1,5 @@
+[![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+
 # rocCV Docker
 
 Build and run [rocCV](https://github.com/ROCm/rocCV) in a container on AMD GPUs using the ROCm stack.

--- a/docker/README.md
+++ b/docker/README.md
@@ -76,6 +76,33 @@ docker run --rm \
   ctest -R '^test_' --output-on-failure -V
 ```
 
+### Run Python tests
+
+Python tests use pytest and need GPU access so `rocpycv` can run on the device:
+
+```bash
+docker run --rm \
+  --device=/dev/kfd --device=/dev/dri \
+  --security-opt seccomp=unconfined \
+  --group-add=video \
+  -w /workspace/roccv/tests/roccv/python \
+  roccv:dev-ubuntu-24.04-$(date +%Y%m%d) \
+  python3 -m pytest -v
+```
+
+Run a single test file:
+
+```bash
+docker run --rm \
+  --device=/dev/kfd --device=/dev/dri \
+  --security-opt seccomp=unconfined \
+  -w /workspace/roccv/tests/roccv/python \
+  roccv:dev-ubuntu-24.04-$(date +%Y%m%d) \
+  python3 -m pytest -v test_op_resize.py
+```
+
+`PYTHONPATH` is set in the image so `rocpycv` is found; the working directory is the Python test directory.
+
 ### Run benchmarks
 
 Benchmarks need GPU access. Mount a directory to get results on the host:

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,110 @@
+# rocCV Docker
+
+Build and run [rocCV](https://github.com/ROCm/rocCV) in a container on AMD GPUs using the ROCm stack.
+
+## Prerequisites
+
+- **Host:** Linux with the ROCm kernel driver (`amdgpu-dkms`) installed. See [ROCm installation](https://rocm.docs.amd.com/projects/install-on-linux/en/latest/).
+- **Docker** installed, with permission to run containers with `--device=/dev/kfd` and `--device=/dev/dri`.
+
+## Build
+
+Build from the **repository root** (parent of `docker/`). The Dockerfile copies the current repository from the build context; run `git submodule update --init --recursive` first so submodules are included.
+
+### Using the build script (recommended)
+
+`build.sh` derives the image tag suffix from `BASE_DOCKER_IMAGE` so you only set the base image:
+
+```bash
+# Default base (rocm/dev-ubuntu-24.04) → e.g. roccv:dev-ubuntu-24.04-20260211
+./docker/build.sh
+
+# Custom base image (suffix derived automatically)
+BASE_DOCKER_IMAGE=rocm/dev-ubuntu-22.04:7.1.1-complete ./docker/build.sh
+
+# Pass extra build args to docker build
+./docker/build.sh --build-arg GPU_ARCH=gfx90a
+```
+
+### Using docker build directly
+
+Tag format: `roccv:<IMAGE_TAG_SUFFIX>-<date>` (date = `$(date +%Y%m%d)`).
+
+```bash
+# Default base and tag
+docker build -t roccv:dev-ubuntu-24.04-$(date +%Y%m%d) -f docker/Dockerfile .
+
+# Custom base: derive IMAGE_TAG_SUFFIX (strip repo prefix, replace ':' with '-')
+BASE_DOCKER_IMAGE=rocm/dev-ubuntu-22.04:7.1.1-complete
+SUFFIX=$(echo "${BASE_DOCKER_IMAGE}" | sed 's|^[^/]*/||' | tr ':' '-')
+docker build -t roccv:${SUFFIX}-$(date +%Y%m%d) \
+  --build-arg BASE_DOCKER_IMAGE=${BASE_DOCKER_IMAGE} \
+  --build-arg IMAGE_TAG_SUFFIX=${SUFFIX} \
+  -f docker/Dockerfile .
+```
+
+### Build arguments
+
+| Argument | Default | Description |
+|----------|---------|-------------|
+| `BASE_DOCKER_IMAGE` | `rocm/dev-ubuntu-24.04` | Base ROCm image. |
+| `IMAGE_TAG_SUFFIX` | `dev-ubuntu-24.04` | Used in the image tag; should match the base (e.g. `dev-ubuntu-22.04-7.1.1`). Use `build.sh` to derive from `BASE_DOCKER_IMAGE`. |
+| `GPU_ARCH` | *(all defaults)* | Single GPU target (e.g. `gfx90a`, `gfx908`, `gfx1030`) for a faster build. |
+| `BUILD_DATE` | — | Optional; e.g. `$(date +%Y%m%d)` for image labels. |
+
+## Run
+
+Use a tag that matches your build (e.g. `roccv:dev-ubuntu-24.04-20260211` or the output of `build.sh`).
+
+### Interactive shell (with GPU)
+
+```bash
+docker run -it --rm \
+  --device=/dev/kfd --device=/dev/dri \
+  --security-opt seccomp=unconfined \
+  --group-add=video \
+  roccv:dev-ubuntu-24.04-$(date +%Y%m%d)
+```
+
+### Run C++ tests
+
+```bash
+docker run --rm \
+  --device=/dev/kfd --device=/dev/dri \
+  --security-opt seccomp=unconfined \
+  roccv:dev-ubuntu-24.04-$(date +%Y%m%d) \
+  ctest -R '^test_' --output-on-failure -V
+```
+
+### Run benchmarks
+
+Benchmarks need GPU access. Mount a directory to get results on the host:
+
+```bash
+mkdir -p results
+docker run --rm \
+  --device=/dev/kfd --device=/dev/dri \
+  --security-opt seccomp=unconfined \
+  --group-add=video \
+  -v $(pwd)/results:/workspace/roccv/build \
+  -w /workspace/roccv/build \
+  roccv:dev-ubuntu-24.04-$(date +%Y%m%d) \
+  ./bin/roccv_bench --config ../benchmarks/config.json
+```
+
+Results are in `results/roccv_bench_results.json`. For more options:
+
+```bash
+docker run --rm roccv:dev-ubuntu-24.04-$(date +%Y%m%d) ./bin/roccv_bench --help
+```
+
+## Image contents
+
+- rocCV built from the repository in the build context, with tests, samples, benchmarks, and Python bindings.
+- Installed under `/opt/rocm`; `PYTHONPATH` includes the rocCV Python module path.
+- Working directory in the container: `/workspace/roccv/build` (for `ctest` or `roccv_bench`).
+
+## See also
+
+- [rocCV README](../README.md) — project overview and dependencies.
+- [benchmarks/README.md](../benchmarks/README.md) — benchmark configuration and graphing.

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -19,6 +19,6 @@ docker build -t "${IMAGE_TAG}" \
   --build-arg IMAGE_TAG_SUFFIX="${IMAGE_TAG_SUFFIX}" \
   --build-arg BUILD_DATE="${DATE}" \
   -f docker/Dockerfile \
-  "$@"
+  "$@" .
 
 echo "Built ${IMAGE_TAG}"

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Build rocCV Docker image. IMAGE_TAG_SUFFIX is derived from BASE_DOCKER_IMAGE
+# (strip repo prefix, replace ':' with '-') so you only need to set the base image.
+#
+# Usage (from repo root):
+#   ./docker/build.sh
+#   BASE_DOCKER_IMAGE=rocm/dev-ubuntu-22.04:7.1.1-complete ./docker/build.sh
+#   ./docker/build.sh --build-arg GPU_ARCH=gfx90a
+
+set -e
+BASE_DOCKER_IMAGE=${BASE_DOCKER_IMAGE:-rocm/dev-ubuntu-24.04}
+IMAGE_TAG_SUFFIX=$(echo "${BASE_DOCKER_IMAGE}" | sed 's|^[^/]*/||' | tr ':' '-')
+DATE=$(date +%Y%m%d)
+IMAGE_TAG="roccv:${IMAGE_TAG_SUFFIX}-${DATE}"
+
+cd "$(dirname "$0")/.."
+docker build -t "${IMAGE_TAG}" \
+  --build-arg BASE_DOCKER_IMAGE="${BASE_DOCKER_IMAGE}" \
+  --build-arg IMAGE_TAG_SUFFIX="${IMAGE_TAG_SUFFIX}" \
+  --build-arg BUILD_DATE="${DATE}" \
+  -f docker/Dockerfile \
+  "$@"
+
+echo "Built ${IMAGE_TAG}"

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,3 +1,26 @@
+# ##############################################################################
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# ##############################################################################
+
 #!/usr/bin/env bash
 # Build rocCV Docker image. IMAGE_TAG_SUFFIX is derived from BASE_DOCKER_IMAGE
 # (strip repo prefix, replace ':' with '-') so you only need to set the base image.


### PR DESCRIPTION
## Motivation

<!-- Manual efforts needed to build and test rocCV. Using docker images simplifies build and test on any AMD architectures -->

## Technical Details

<!-- Added Dockerfile, README and build script to generate docker image -->

## Test Plan

<!-- Please read README.md for the testing plan. Tested on MI300 with ./docker/build.sh --build-arg GPU_ARCH=gfx942 -->

## Test Result

<!-- Launch the docker container and tested ctest, pytest and benchmarks -->

