### PR TITLE
[Benchmarking]: Improve GPU path speed and add CSV/JSON export support

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ##############################################################################
-# Copyright (c)  - 2025 Advanced Micro Devices, Inc.
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -34,7 +34,10 @@ endif()
 
 project(roccv_bench)
 
-set(BENCHMARK_INCLUDES ${BENCHMARK_INCLUDES} "${CMAKE_CURRENT_SOURCE_DIR}/vendor" "${CMAKE_CURRENT_SOURCE_DIR}/roccvbench/include")
+add_subdirectory(roccvbench)
+
+set(BENCHMARK_INCLUDES ${BENCHMARK_INCLUDES} "${CMAKE_CURRENT_SOURCE_DIR}/vendor")
+set(BENCHMARK_LIBS ${BENCHMARK_LIBS} roccvbench-utils)
 
 # Include roccv benchmark units
 set(BUILD_ROCCV_BENCHMARKS ON)

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -37,13 +37,26 @@ project(roccv_bench)
 set(BENCHMARK_INCLUDES ${BENCHMARK_INCLUDES} "${CMAKE_CURRENT_SOURCE_DIR}/vendor" "${CMAKE_CURRENT_SOURCE_DIR}/roccvbench/include")
 
 # Include roccv benchmark units
-if(BUILD_FROM_SOURCE)
-    message("-- ${Green}${PROJECT_NAME} -- Found rocCV")
+set(BUILD_ROCCV_BENCHMARKS ON)
+if (NOT BUILD_FROM_SOURCE)
+    message("-- ${Yellow}${PROJECT_NAME} -- Benchmarks cannot be built as a standalone project. rocCV benchmarks will not be included in the benchmarks${ColorReset}")
+    set(BUILD_ROCCV_BENCHMARKS OFF)
+endif()
+
+find_package(rocrand QUIET)
+if(NOT rocrand_FOUND)
+    message("-- ${Yellow}${PROJECT_NAME} -- rocRAND not found.${ColorReset}")
+    set(BUILD_ROCCV_BENCHMARKS OFF)
+else()
+    message("-- ${Green}${PROJECT_NAME} -- Found rocRAND version ${rocrand_VERSION}.${ColorReset}")
+endif()
+
+if(BUILD_ROCCV_BENCHMARKS)
     set(BENCHMARK_SOURCES ${BENCHMARK_SOURCES} "${CMAKE_CURRENT_SOURCE_DIR}/src/roccv/*.cpp")
     set(BENCHMARK_INCLUDES ${BENCHMARK_INCLUDES} "${CMAKE_CURRENT_SOURCE_DIR}/src/roccv" "${ROCCV_SOURCE_DIR}/include")
-    set(BENCHMARK_LIBS ${BENCHMARK_LIBS} roccv)
+    set(BENCHMARK_LIBS ${BENCHMARK_LIBS} roccv roc::rocrand)
 else()
-    message("-- ${Yellow}${PROJECT_NAME} -- Could not find rocCV, it will not be included in the benchmarks${ColorReset}")
+    message("-- ${Yellow}${PROJECT_NAME} -- Missing required dependencies for rocCV benchmarks. rocCV benchmarks will not be included in the benchmarks${ColorReset}")
 endif()
 
 # Include OpenCV benchmark units

--- a/benchmarks/generate_graphs.py
+++ b/benchmarks/generate_graphs.py
@@ -1,5 +1,5 @@
 # ##############################################################################
-# Copyright (c)  - 2025 Advanced Micro Devices, Inc.
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/benchmarks/generate_graphs.py
+++ b/benchmarks/generate_graphs.py
@@ -48,7 +48,7 @@ BAR_COLORS = [
 GRAPH_STYLE = "dark_background"
 
 
-def plot_annotated_bars(ax, x, y, labels):
+def plot_annotated_bars(ax, x, y, labels, format_string="%.2f"):
     num_benchmarks_in_group = len(y)
     x_indices = np.arange(len(x))  # Positions for the groups of bars
 
@@ -75,7 +75,7 @@ def plot_annotated_bars(ax, x, y, labels):
             # Position text slightly above the bar
             text_y = bar_height
 
-            ax.text(text_x, text_y, f'{bar_height:.2f}',  # Format to 2 decimal places
+            ax.text(text_x, text_y, format_string % bar_height,  # Format to decimal places
                     ha='center', va='bottom', fontsize=6, color='lightgray', zorder=10)
 
     ax.set_xticks(x_indices)
@@ -97,21 +97,19 @@ if __name__ == "__main__":
         data = json.load(file)
 
     # Get device information from results file
-    cpu_name = data["device_info"]["cpu"]["name"]
-    cpu_threads = data["device_info"]["cpu"]["threads"]
-    gpu_name = data["device_info"]["gpu"]["name"]
+    cpu_name = data["metadata"]["cpu"]
+    cpu_threads = data["metadata"]["cpu_threads"]
+    gpu_name = data["metadata"]["gpu"]
 
     graph_footnote = f"Benchmarks performed with {gpu_name} (GPU) and {cpu_name} (CPU) with {cpu_threads} threads. Execution time does not include data transfer latency from CPU to GPU and vice-versa."
 
     for category in data["results"]:
-        benchmarks_in_category = data["results"][category]
-
         fig, ax = plt.subplots(1, 3, dpi=200, figsize=(15, 6))
 
         # Setup execution time axis
         ex_time_ax = ax[0]
         ex_time_ax.set_xlabel("Batch Size")
-        ex_time_ax.set_ylabel("Execution Time (ms) [Log Scale]\n(Lower is better)")
+        ex_time_ax.set_ylabel("Execution Time (s) [Log Scale]\n(Lower is better)")
         ex_time_ax.set_title("Execution Time")
         ex_time_ax.set_yscale('log')
 
@@ -128,26 +126,42 @@ if __name__ == "__main__":
         throughput_ax.set_xlabel("Batch Size")
         throughput_ax.set_title("Total Memory Throughput")
         throughput_ax.set_yscale('log')
+        
+        benchmarks_in_category = data["results"][category]
+        
+        # Shared x-axis: sample counts (taken from the first benchmark's runs)
+        first_benchmark = next(iter(benchmarks_in_category.values()))
+        samples = [run["samples"] for run in first_benchmark]
 
-        # Gather data and plot results
-        benchmark_names = []
-        execution_time_data = []
-        samples = data["results"][category][0]["samples"]
-        image_height = data["results"][category][0]["height"][0]
-        image_width = data["results"][category][0]["width"][0]
+        # One entry per benchmark name (e.g. "GPU", and potentially "CPU" later)
+        benchmark_names = []          # labels for the legend
+        execution_time_data = []      # list of lists: one list of values per benchmark
         fps_data = []
         throughput_data = []
 
-        for benchmark in benchmarks_in_category:
-            benchmark_names.append(benchmark["name"])
-            execution_time_data.append(benchmark["execution_time"])
-            fps_data.append([1000 / (benchmark["execution_time"][i] / samples[i])
-                            for i in range(len(benchmark["execution_time"]))])
-            throughput_data.append([(benchmark["read_memory_bytes"][i] + benchmark["written_memory_bytes"][i]) / (benchmark["execution_time"][i] / 1000.0) / 1e9 for i in range(len(benchmark["execution_time"]))])
+        for bench_name, runs in benchmarks_in_category.items():
+            benchmark_names.append(bench_name)
 
-        plot_annotated_bars(ex_time_ax, samples, execution_time_data, benchmark_names)
-        plot_annotated_bars(fps_ax, samples, fps_data, benchmark_names)
-        plot_annotated_bars(throughput_ax, samples, throughput_data, benchmark_names)
+            ex_times = []
+            fps_vals = []
+            tp_vals = []
+
+            for run in runs:
+                ex_time_ms = run["execution_time"]
+                n_samples = run["samples"]
+                total_bytes = run["read_memory_bytes"] + run["written_memory_bytes"]
+
+                ex_times.append(run["execution_time"])
+                fps_vals.append(n_samples / run["execution_time"])
+                tp_vals.append(total_bytes / run["execution_time"] / 1e9)  # GB/s
+
+            execution_time_data.append(ex_times)
+            fps_data.append(fps_vals)
+            throughput_data.append(tp_vals)
+
+        plot_annotated_bars(ex_time_ax, samples, execution_time_data, benchmark_names, format_string="%.4g")
+        plot_annotated_bars(fps_ax, samples, fps_data, benchmark_names, format_string="%.2f")
+        plot_annotated_bars(throughput_ax, samples, throughput_data, benchmark_names, format_string="%.2f")
 
         
         handles, labels = ex_time_ax.get_legend_handles_labels()
@@ -156,7 +170,7 @@ if __name__ == "__main__":
         # Set bottom text for entire figure
         fig.subplots_adjust(bottom=0.25, wspace=0.35)
         fig.text(0.5, 0.02, graph_footnote, wrap=True, ha='center', fontsize=8, alpha=0.7)
-        fig.suptitle(f"{category} Benchmarks (Batches of {image_width}x{image_height} 8-bit Images)")
+        fig.suptitle(f"{category} Benchmarks")
 
         output_filename = os.path.join(args.output_dir, f"bench_{category}.png")
 

--- a/benchmarks/generate_graphs.py
+++ b/benchmarks/generate_graphs.py
@@ -147,7 +147,6 @@ if __name__ == "__main__":
             tp_vals = []
 
             for run in runs:
-                ex_time_ms = run["execution_time"]
                 n_samples = run["samples"]
                 total_bytes = run["read_memory_bytes"] + run["written_memory_bytes"]
 

--- a/benchmarks/roccvbench/CMakeLists.txt
+++ b/benchmarks/roccvbench/CMakeLists.txt
@@ -1,0 +1,30 @@
+# ##############################################################################
+# Copyright (c)  - 2025 Advanced Micro Devices, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# ##############################################################################
+
+cmake_minimum_required(VERSION 3.15)
+
+project(roccvbench-utils)
+
+file(GLOB_RECURSE SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
+add_library(${PROJECT_NAME} STATIC ${SOURCES})
+target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)

--- a/benchmarks/roccvbench/CMakeLists.txt
+++ b/benchmarks/roccvbench/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ##############################################################################
-# Copyright (c)  - 2025 Advanced Micro Devices, Inc.
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/benchmarks/roccvbench/include/roccvbench/registry.hpp
+++ b/benchmarks/roccvbench/include/roccvbench/registry.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights

--- a/benchmarks/roccvbench/include/roccvbench/registry.hpp
+++ b/benchmarks/roccvbench/include/roccvbench/registry.hpp
@@ -41,7 +41,7 @@ class BenchmarkRegistry {
     }
 
     void registerBenchmark(const std::string& category, const std::string& name,
-                           std::function<BenchmarkResults(const BenchmarkConfig&)> func) {
+                           std::function<BenchmarkResults(const BenchmarkConfig&, roccvbench::RunData&)> func) {
         if (m_benchmarks.count(category) == 0) {
             m_benchmarks.emplace(category, std::vector<Benchmark>());
         }
@@ -65,8 +65,10 @@ class BenchmarkRegistry {
  * @brief Creates a benchmark unit for roccv with a provided name.
  *
  */
-#define BENCHMARK(category, name)                                                                       \
-    roccvbench::BenchmarkResults Benchmark_##category##name(const roccvbench::BenchmarkConfig& config); \
-    REGISTER_BENCHMARK(Benchmark_##category##name, name, category);                                     \
-    roccvbench::BenchmarkResults Benchmark_##category##name(const roccvbench::BenchmarkConfig& config)
+#define BENCHMARK(category, name)                                                                      \
+    roccvbench::BenchmarkResults Benchmark_##category##name(const roccvbench::BenchmarkConfig& config, \
+                                                            roccvbench::RunData& runData);             \
+    REGISTER_BENCHMARK(Benchmark_##category##name, name, category);                                    \
+    roccvbench::BenchmarkResults Benchmark_##category##name(const roccvbench::BenchmarkConfig& config, \
+                                                            roccvbench::RunData& runData)
 }  // namespace roccvbench

--- a/benchmarks/roccvbench/include/roccvbench/results.hpp
+++ b/benchmarks/roccvbench/include/roccvbench/results.hpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#pragma once
+
+#include <map>
+#include <string>
+#include <variant>
+#include <vector>
+
+namespace roccvbench {
+
+using BenchValue = std::variant<double, size_t, std::string>;
+
+/**
+ * @brief Class for storing and managing benchmark run data.
+ *
+ */
+class RunData {
+   public:
+    RunData() = default;
+    RunData(const std::map<std::string, BenchValue>& runData) : m_runData(runData) {}
+
+    const std::map<std::string, BenchValue>& getValues() const { return m_runData; }
+    void addValue(const std::string& key, const BenchValue& value) { m_runData[key] = value; }
+
+   private:
+    std::map<std::string, BenchValue> m_runData;
+};
+
+/**
+ * @brief Class for storing and managing benchmark results.
+ *
+ */
+class Results {
+   public:
+    void RegisterRun(const RunData& runData) { m_runData.push_back(runData); }
+    void SetMetadata(const std::map<std::string, BenchValue>& metadata) { m_metadata = metadata; }
+
+    const std::vector<RunData>& getRuns() const { return m_runData; }
+    const std::map<std::string, BenchValue>& getMetadata() const { return m_metadata; }
+
+   private:
+    std::vector<RunData> m_runData;
+    std::map<std::string, BenchValue> m_metadata;
+};
+}  // namespace roccvbench

--- a/benchmarks/roccvbench/include/roccvbench/results.hpp
+++ b/benchmarks/roccvbench/include/roccvbench/results.hpp
@@ -22,13 +22,14 @@
 #pragma once
 
 #include <map>
+#include <set>
 #include <string>
 #include <variant>
 #include <vector>
 
 namespace roccvbench {
 
-using BenchValue = std::variant<double, size_t, std::string>;
+using BenchValue = std::variant<double, size_t, std::string, int>;
 
 /**
  * @brief Class for storing and managing benchmark run data.
@@ -52,14 +53,23 @@ class RunData {
  */
 class Results {
    public:
-    void RegisterRun(const RunData& runData) { m_runData.push_back(runData); }
-    void SetMetadata(const std::map<std::string, BenchValue>& metadata) { m_metadata = metadata; }
+    Results() = default;
+
+    void registerRun(const RunData& runData) {
+        m_runData.push_back(runData);
+        for (const auto& [key, _] : runData.getValues()) {
+            m_registeredKeys.insert(key);
+        }
+    }
+    void setMetadata(const std::map<std::string, BenchValue>& metadata) { m_metadata = metadata; }
 
     const std::vector<RunData>& getRuns() const { return m_runData; }
     const std::map<std::string, BenchValue>& getMetadata() const { return m_metadata; }
+    const std::set<std::string>& getRegisteredKeys() const { return m_registeredKeys; }
 
    private:
     std::vector<RunData> m_runData;
     std::map<std::string, BenchValue> m_metadata;
+    std::set<std::string> m_registeredKeys;
 };
 }  // namespace roccvbench

--- a/benchmarks/roccvbench/include/roccvbench/serializers.hpp
+++ b/benchmarks/roccvbench/include/roccvbench/serializers.hpp
@@ -34,6 +34,7 @@ namespace roccvbench {
 class IBenchmarkSerializer {
    public:
     virtual void serialize(const Results& results, std::filesystem::path& filepath) = 0;
+    virtual ~IBenchmarkSerializer() = default;
 };
 
 /**

--- a/benchmarks/roccvbench/include/roccvbench/serializers.hpp
+++ b/benchmarks/roccvbench/include/roccvbench/serializers.hpp
@@ -33,7 +33,7 @@ namespace roccvbench {
  */
 class IBenchmarkSerializer {
    public:
-    virtual void serialize(const Results& results, std::filesystem::path& filepath) = 0;
+    virtual void serialize(const Results& results, const std::filesystem::path& filepath) = 0;
     virtual ~IBenchmarkSerializer() = default;
 };
 
@@ -43,7 +43,7 @@ class IBenchmarkSerializer {
  */
 class JsonBenchmarkSerializer : public IBenchmarkSerializer {
    public:
-    void serialize(const Results& results, std::filesystem::path& filepath) override;
+    void serialize(const Results& results, const std::filesystem::path& filepath) override;
 };
 
 /**
@@ -52,6 +52,6 @@ class JsonBenchmarkSerializer : public IBenchmarkSerializer {
  */
 class CsvBenchmarkSerializer : public IBenchmarkSerializer {
    public:
-    void serialize(const Results& results, std::filesystem::path& filepath) override;
+    void serialize(const Results& results, const std::filesystem::path& filepath) override;
 };
 }  // namespace roccvbench

--- a/benchmarks/roccvbench/include/roccvbench/serializers.hpp
+++ b/benchmarks/roccvbench/include/roccvbench/serializers.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights

--- a/benchmarks/roccvbench/include/roccvbench/serializers.hpp
+++ b/benchmarks/roccvbench/include/roccvbench/serializers.hpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#pragma once
+
+#include <filesystem>
+
+#include "results.hpp"
+
+namespace roccvbench {
+
+/**
+ * @brief Interface for benchmark serializers.
+ *
+ */
+class IBenchmarkSerializer {
+   public:
+    virtual void serialize(const Results& results, std::filesystem::path& filepath) = 0;
+};
+
+/**
+ * @brief JSON benchmark serializer.
+ *
+ */
+class JsonBenchmarkSerializer : public IBenchmarkSerializer {
+   public:
+    void serialize(const Results& results, std::filesystem::path& filepath) override;
+};
+
+/**
+ * @brief CSV benchmark serializer.
+ *
+ */
+class CsvBenchmarkSerializer : public IBenchmarkSerializer {
+   public:
+    void serialize(const Results& results, std::filesystem::path& filepath) override;
+};
+}  // namespace roccvbench

--- a/benchmarks/roccvbench/include/roccvbench/structs.hpp
+++ b/benchmarks/roccvbench/include/roccvbench/structs.hpp
@@ -25,6 +25,8 @@
 #include <functional>
 #include <string>
 
+#include "results.hpp"
+
 namespace roccvbench {
 
 /**
@@ -53,6 +55,6 @@ struct BenchmarkConfig {
 struct Benchmark {
     std::string category;
     std::string name;
-    std::function<BenchmarkResults(const BenchmarkConfig&)> func;
+    std::function<BenchmarkResults(const BenchmarkConfig&, roccvbench::RunData&)> func;
 };
 }  // namespace roccvbench

--- a/benchmarks/roccvbench/include/roccvbench/structs.hpp
+++ b/benchmarks/roccvbench/include/roccvbench/structs.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights

--- a/benchmarks/roccvbench/include/roccvbench/utils.hpp
+++ b/benchmarks/roccvbench/include/roccvbench/utils.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights

--- a/benchmarks/roccvbench/include/roccvbench/utils.hpp
+++ b/benchmarks/roccvbench/include/roccvbench/utils.hpp
@@ -58,7 +58,7 @@ std::vector<T> RandVector(size_t size) {
 }
 
 /**
- * @brief Records the execution time in milliseconds of a block of code <code> by running it <numRuns> times and taking
+ * @brief Records the execution time in seconds of a block of code <code> by running it <numRuns> times and taking
  * the mean of the results. The resulting mean is written to <executionTime>.
  *
  */
@@ -75,7 +75,7 @@ std::vector<T> RandVector(size_t size) {
                 numValidRuns++;                                                                                 \
             }                                                                                                   \
         }                                                                                                       \
-        executionTime = totalExecutionTime / numValidRuns;                                                      \
+        executionTime = (totalExecutionTime / numValidRuns) / 1000.0;                                           \
     }
 
 }  // namespace roccvbench

--- a/benchmarks/roccvbench/src/serializers.cpp
+++ b/benchmarks/roccvbench/src/serializers.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights

--- a/benchmarks/roccvbench/src/serializers.cpp
+++ b/benchmarks/roccvbench/src/serializers.cpp
@@ -21,9 +21,39 @@
 
 #include "roccvbench/serializers.hpp"
 
+#include <fstream>
+#include <stdexcept>
+
 namespace roccvbench {
 
 // TODO: Implement JSON and CSV serializers.
 void JsonBenchmarkSerializer::serialize(const Results& results, std::filesystem::path& filepath) { return; }
-void CsvBenchmarkSerializer::serialize(const Results& results, std::filesystem::path& filepath) { return; }
+void CsvBenchmarkSerializer::serialize(const Results& results, std::filesystem::path& filepath) {
+    std::ofstream file(filepath);
+
+    if (!file.is_open()) {
+        throw std::runtime_error("Failed to open file for writing: " + filepath.string());
+    }
+
+    for (const auto& key : results.getRegisteredKeys()) {
+        file << key << ",";
+    }
+    for (const auto& [key, value] : results.getMetadata()) {
+        file << key << ",";
+    }
+
+    file << std::endl;
+
+    for (const auto& run : results.getRuns()) {
+        for (const auto& key : results.getRegisteredKeys()) {
+            std::visit([&file](const auto& val) { file << val << ","; }, run.getValues().at(key));
+        }
+        for (const auto& [key, value] : results.getMetadata()) {
+            std::visit([&file](const auto& val) { file << val << ","; }, value);
+        }
+        file << std::endl;
+    }
+
+    file.close();
+}
 }  // namespace roccvbench

--- a/benchmarks/roccvbench/src/serializers.cpp
+++ b/benchmarks/roccvbench/src/serializers.cpp
@@ -24,10 +24,32 @@
 #include <fstream>
 #include <nlohmann/json.hpp>
 #include <stdexcept>
+#include <type_traits>
 
 namespace roccvbench {
 
-void JsonBenchmarkSerializer::serialize(const Results& results, std::filesystem::path& filepath) {
+namespace {
+/**
+ * @brief Writes a value to a CSV file, ensuring that strings are quoted.
+ *
+ * @param file The file to write the value to.
+ * @param value The value to write.
+ */
+void WriteCsvValue(std::ofstream& file, const BenchValue& value) {
+    std::visit(
+        [&file](const auto& val) {
+            using T = std::decay_t<decltype(val)>;
+            if constexpr (std::is_same_v<T, std::string>) {
+                file << "\"" << val << "\"";
+            } else {
+                file << val;
+            }
+        },
+        value);
+}
+}  // namespace
+
+void JsonBenchmarkSerializer::serialize(const Results& results, const std::filesystem::path& filepath) {
     nlohmann::json json;
 
     const auto metadata = results.getMetadata();
@@ -59,11 +81,16 @@ void JsonBenchmarkSerializer::serialize(const Results& results, std::filesystem:
     }
 
     std::ofstream file(filepath);
+
+    if (!file.is_open()) {
+        throw std::runtime_error("Failed to open file for writing: " + filepath.string());
+    }
+
     file << json.dump(4);
     file.close();
 }
 
-void CsvBenchmarkSerializer::serialize(const Results& results, std::filesystem::path& filepath) {
+void CsvBenchmarkSerializer::serialize(const Results& results, const std::filesystem::path& filepath) {
     std::ofstream file(filepath);
 
     if (!file.is_open()) {
@@ -93,12 +120,12 @@ void CsvBenchmarkSerializer::serialize(const Results& results, std::filesystem::
                 continue;
             }
             file << sep;
-            std::visit([&file](const auto& val) { file << val; }, run.getValues().at(key));
+            WriteCsvValue(file, run.getValues().at(key));
             sep = ",";
         }
         for (const auto& [key, value] : results.getMetadata()) {
             file << sep;
-            std::visit([&file](const auto& val) { file << val; }, value);
+            WriteCsvValue(file, value);
             sep = ",";
         }
         file << std::endl;

--- a/benchmarks/roccvbench/src/serializers.cpp
+++ b/benchmarks/roccvbench/src/serializers.cpp
@@ -31,10 +31,11 @@ void JsonBenchmarkSerializer::serialize(const Results& results, std::filesystem:
     nlohmann::json json;
 
     const auto metadata = results.getMetadata();
-
-    json["device_info"]["cpu"]["name"] = std::get<std::string>(metadata.at("cpu"));
-    json["device_info"]["cpu"]["threads"] = std::get<size_t>(metadata.at("cpu_threads"));
-    json["device_info"]["gpu"]["name"] = std::get<std::string>(metadata.at("gpu"));
+    auto metadata_json = nlohmann::json::object();
+    for (const auto& [key, value] : metadata) {
+        metadata_json[key] = std::visit([](const auto& val) -> nlohmann::json { return val; }, value);
+    }
+    json["metadata"] = metadata_json;
 
     json["results"] = nlohmann::json::object();
 

--- a/benchmarks/roccvbench/src/serializers.cpp
+++ b/benchmarks/roccvbench/src/serializers.cpp
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "roccvbench/serializers.hpp"
+
+namespace roccvbench {
+
+// TODO: Implement JSON and CSV serializers.
+void JsonBenchmarkSerializer::serialize(const Results& results, std::filesystem::path& filepath) { return; }
+void CsvBenchmarkSerializer::serialize(const Results& results, std::filesystem::path& filepath) { return; }
+}  // namespace roccvbench

--- a/benchmarks/roccvbench/src/serializers.cpp
+++ b/benchmarks/roccvbench/src/serializers.cpp
@@ -22,12 +22,46 @@
 #include "roccvbench/serializers.hpp"
 
 #include <fstream>
+#include <nlohmann/json.hpp>
 #include <stdexcept>
 
 namespace roccvbench {
 
-// TODO: Implement JSON and CSV serializers.
-void JsonBenchmarkSerializer::serialize(const Results& results, std::filesystem::path& filepath) { return; }
+void JsonBenchmarkSerializer::serialize(const Results& results, std::filesystem::path& filepath) {
+    nlohmann::json json;
+
+    const auto metadata = results.getMetadata();
+
+    json["device_info"]["cpu"]["name"] = std::get<std::string>(metadata.at("cpu"));
+    json["device_info"]["cpu"]["threads"] = std::get<size_t>(metadata.at("cpu_threads"));
+    json["device_info"]["gpu"]["name"] = std::get<std::string>(metadata.at("gpu"));
+
+    json["results"] = nlohmann::json::object();
+
+    for (const auto& run : results.getRuns()) {
+        const auto& values = run.getValues();
+        std::string name = std::get<std::string>(values.at("name"));
+        std::string category = std::get<std::string>(values.at("category"));
+
+        if (json["results"].find(category) == json["results"].end()) {
+            json["results"][category] = nlohmann::json::object();
+        }
+        if (json["results"][category].find(name) == json["results"][category].end()) {
+            json["results"][category][name] = nlohmann::json::array();
+        }
+
+        auto runData = nlohmann::json::object();
+        for (const auto& [key, value] : values) {
+            runData[key] = std::visit([](const auto& val) -> nlohmann::json { return val; }, value);
+        }
+        json["results"][category][name].emplace_back(runData);
+    }
+
+    std::ofstream file(filepath);
+    file << json.dump(4);
+    file.close();
+}
+
 void CsvBenchmarkSerializer::serialize(const Results& results, std::filesystem::path& filepath) {
     std::ofstream file(filepath);
 

--- a/benchmarks/roccvbench/src/serializers.cpp
+++ b/benchmarks/roccvbench/src/serializers.cpp
@@ -70,21 +70,36 @@ void CsvBenchmarkSerializer::serialize(const Results& results, std::filesystem::
         throw std::runtime_error("Failed to open file for writing: " + filepath.string());
     }
 
+    // Write header
+    std::string sep;
     for (const auto& key : results.getRegisteredKeys()) {
-        file << key << ",";
+        file << sep << key;
+        sep = ",";
     }
     for (const auto& [key, value] : results.getMetadata()) {
-        file << key << ",";
+        file << sep << key;
+        sep = ",";
     }
 
     file << std::endl;
 
+    // Write data rows
     for (const auto& run : results.getRuns()) {
+        sep = "";
         for (const auto& key : results.getRegisteredKeys()) {
-            std::visit([&file](const auto& val) { file << val << ","; }, run.getValues().at(key));
+            if (!run.getValues().contains(key)) {
+                file << sep;
+                sep = ",";
+                continue;
+            }
+            file << sep;
+            std::visit([&file](const auto& val) { file << val; }, run.getValues().at(key));
+            sep = ",";
         }
         for (const auto& [key, value] : results.getMetadata()) {
-            std::visit([&file](const auto& val) { file << val << ","; }, value);
+            file << sep;
+            std::visit([&file](const auto& val) { file << val; }, value);
+            sep = ",";
         }
         file << std::endl;
     }

--- a/benchmarks/src/main.cpp
+++ b/benchmarks/src/main.cpp
@@ -251,6 +251,18 @@ int main(int argc, char** argv) {
         return EXIT_FAILURE;
     }
 
+    // Create serializer based on the output file extension
+    std::filesystem::path outputPath(outputFilepath);
+    roccvbench::IBenchmarkSerializer* serializer;
+    if (outputPath.extension() == ".json") {
+        serializer = new roccvbench::JsonBenchmarkSerializer();
+    } else if (outputPath.extension() == ".csv") {
+        serializer = new roccvbench::CsvBenchmarkSerializer();
+    } else {
+        std::cerr << "Error: Unsupported output file extension: " << outputPath.extension() << std::endl;
+        return EXIT_FAILURE;
+    }
+
     // Load benchmark configuration file
     std::vector<roccvbench::BenchmarkConfig> configs = loadConfig(configFilepath);
 
@@ -261,15 +273,9 @@ int main(int argc, char** argv) {
     HIP_VALIDATE_NO_ERRORS(hipGetDeviceProperties(&props, device_id));
 
     roccvbench::Results results;
-    // nlohmann::json resultsJson;
-
-    // Write device information to output JSON
-    // resultsJson["device_info"]["gpu"]["name"] = props.name;
-    // resultsJson["device_info"]["cpu"]["name"] = getCPUName();
-    // resultsJson["device_info"]["cpu"]["threads"] = std::thread::hardware_concurrency();
 
     results.setMetadata(
-        {{"gpu_name", props.name}, {"cpu_name", getCPUName()}, {"cpu_threads", std::thread::hardware_concurrency()}});
+        {{"gpu", props.name}, {"cpu", getCPUName()}, {"cpu_threads", std::thread::hardware_concurrency()}});
 
     // Determine the final list of categories to run and store it in selectedCategories.
 
@@ -354,10 +360,15 @@ int main(int argc, char** argv) {
 
     // Write benchmark results to disk
     std::filesystem::path resultPath(outputFilepath);
-    roccvbench::CsvBenchmarkSerializer serializer;
-    serializer.serialize(results, resultPath);
+    try {
+        serializer->serialize(results, resultPath);
+    } catch (const std::exception& e) {
+        std::cerr << "Error: Failed to serialize benchmark results: " << e.what() << std::endl;
+        return EXIT_FAILURE;
+    }
 
     std::cout << "Wrote benchmark results to " << std::filesystem::absolute(resultPath) << std::endl;
+    delete serializer;
 
     return 0;
 }

--- a/benchmarks/src/main.cpp
+++ b/benchmarks/src/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights

--- a/benchmarks/src/main.cpp
+++ b/benchmarks/src/main.cpp
@@ -347,6 +347,7 @@ int main(int argc, char** argv) {
                     runData.addValue("samples", config.samples);
                     runData.addValue("read_memory_bytes", result.readMemoryBytes);
                     runData.addValue("written_memory_bytes", result.writtenMemoryBytes);
+                    runData.addValue("warmup_runs", config.warmupRuns);
 
                     results.registerRun(runData);
                 }

--- a/benchmarks/src/main.cpp
+++ b/benchmarks/src/main.cpp
@@ -28,6 +28,8 @@
 #include <map>
 #include <nlohmann/json.hpp>
 #include <roccvbench/registry.hpp>
+#include <roccvbench/results.hpp>
+#include <roccvbench/serializers.hpp>
 #include <thread>
 
 /**
@@ -258,12 +260,16 @@ int main(int argc, char** argv) {
     hipDeviceProp_t props;
     HIP_VALIDATE_NO_ERRORS(hipGetDeviceProperties(&props, device_id));
 
-    nlohmann::json resultsJson;
+    roccvbench::Results results;
+    // nlohmann::json resultsJson;
 
     // Write device information to output JSON
-    resultsJson["device_info"]["gpu"]["name"] = props.name;
-    resultsJson["device_info"]["cpu"]["name"] = getCPUName();
-    resultsJson["device_info"]["cpu"]["threads"] = std::thread::hardware_concurrency();
+    // resultsJson["device_info"]["gpu"]["name"] = props.name;
+    // resultsJson["device_info"]["cpu"]["name"] = getCPUName();
+    // resultsJson["device_info"]["cpu"]["threads"] = std::thread::hardware_concurrency();
+
+    results.setMetadata(
+        {{"gpu_name", props.name}, {"cpu_name", getCPUName()}, {"cpu_threads", std::thread::hardware_concurrency()}});
 
     // Determine the final list of categories to run and store it in selectedCategories.
 
@@ -325,18 +331,20 @@ int main(int argc, char** argv) {
                               << ", warmupRuns=" << config.warmupRuns << "]" << std::endl;
                     auto result = benchmark.func(config);
 
-                    // Write run results to output JSON
-                    runResultsJson["width"].push_back(config.width);
-                    runResultsJson["height"].push_back(config.height);
-                    runResultsJson["runs"].push_back(config.runs);
-                    runResultsJson["execution_time"].push_back(result.executionTime);
-                    runResultsJson["samples"].push_back(config.samples);
-                    runResultsJson["read_memory_bytes"].push_back(result.readMemoryBytes);
-                    runResultsJson["written_memory_bytes"].push_back(result.writtenMemoryBytes);
+                    roccvbench::RunData runData;
+                    runData.addValue("name", benchmark.name);
+                    runData.addValue("category", benchmark.category);
+                    runData.addValue("width", config.width);
+                    runData.addValue("height", config.height);
+                    runData.addValue("runs", config.runs);
+                    runData.addValue("execution_time", result.executionTime);
+                    runData.addValue("samples", config.samples);
+                    runData.addValue("read_memory_bytes", result.readMemoryBytes);
+                    runData.addValue("written_memory_bytes", result.writtenMemoryBytes);
+
+                    results.registerRun(runData);
                 }
                 std::cout << std::endl;
-
-                resultsJson["results"][benchmark.category].push_back(runResultsJson);
             }
         }
     } catch (roccv::Exception e) {
@@ -346,15 +354,8 @@ int main(int argc, char** argv) {
 
     // Write benchmark results to disk
     std::filesystem::path resultPath(outputFilepath);
-    std::ofstream resultFile(resultPath);
-
-    if (!resultFile.is_open()) {
-        std::cerr << "Unable to open " << resultPath << " for writing results" << std::endl;
-        return EXIT_FAILURE;
-    }
-
-    resultFile << std::setw(4) << resultsJson << std::endl;
-    resultFile.close();
+    roccvbench::CsvBenchmarkSerializer serializer;
+    serializer.serialize(results, resultPath);
 
     std::cout << "Wrote benchmark results to " << std::filesystem::absolute(resultPath) << std::endl;
 

--- a/benchmarks/src/main.cpp
+++ b/benchmarks/src/main.cpp
@@ -253,11 +253,11 @@ int main(int argc, char** argv) {
 
     // Create serializer based on the output file extension
     std::filesystem::path outputPath(outputFilepath);
-    roccvbench::IBenchmarkSerializer* serializer;
+    std::unique_ptr<roccvbench::IBenchmarkSerializer> serializer;
     if (outputPath.extension() == ".json") {
-        serializer = new roccvbench::JsonBenchmarkSerializer();
+        serializer = std::make_unique<roccvbench::JsonBenchmarkSerializer>();
     } else if (outputPath.extension() == ".csv") {
-        serializer = new roccvbench::CsvBenchmarkSerializer();
+        serializer = std::make_unique<roccvbench::CsvBenchmarkSerializer>();
     } else {
         std::cerr << "Error: Unsupported output file extension: " << outputPath.extension() << std::endl;
         return EXIT_FAILURE;
@@ -369,7 +369,6 @@ int main(int argc, char** argv) {
     }
 
     std::cout << "Wrote benchmark results to " << std::filesystem::absolute(resultPath) << std::endl;
-    delete serializer;
 
     return 0;
 }

--- a/benchmarks/src/main.cpp
+++ b/benchmarks/src/main.cpp
@@ -274,8 +274,9 @@ int main(int argc, char** argv) {
 
     roccvbench::Results results;
 
-    results.setMetadata(
-        {{"gpu", props.name}, {"cpu", getCPUName()}, {"cpu_threads", std::thread::hardware_concurrency()}});
+    results.setMetadata({{"gpu", props.name},
+                         {"cpu", getCPUName()},
+                         {"cpu_threads", static_cast<size_t>(std::thread::hardware_concurrency())}});
 
     // Determine the final list of categories to run and store it in selectedCategories.
 

--- a/benchmarks/src/main.cpp
+++ b/benchmarks/src/main.cpp
@@ -335,9 +335,9 @@ int main(int argc, char** argv) {
                     std::cout << "\tConfig [samples=" << config.samples << ", height=" << config.height
                               << ", width=" << config.width << ", runs=" << config.runs
                               << ", warmupRuns=" << config.warmupRuns << "]" << std::endl;
-                    auto result = benchmark.func(config);
-
                     roccvbench::RunData runData;
+                    auto result = benchmark.func(config, runData);
+
                     runData.addValue("name", benchmark.name);
                     runData.addValue("category", benchmark.category);
                     runData.addValue("width", config.width);

--- a/benchmarks/src/main.cpp
+++ b/benchmarks/src/main.cpp
@@ -105,8 +105,8 @@ void printHelp(const char* programName) {
     std::cout << "Required Arguments:\n";
     std::cout << "  --config, -c:                   The JSON configuration file to run the benchmarks.\n";
     std::cout << "Optional Arguments:\n";
-    std::cout << "  --output, -o:                   The output JSON filepath for benchmark results. Defaults to\n";
-    std::cout << "                                  roccv_bench_results.json.\n";
+    std::cout << "  --output, -o:                   The output filepath for benchmark results. Defaults to\n";
+    std::cout << "                                  roccv_bench_results.json. Supported file extensions: .json, .csv\n";
     std::cout << "Options:\n";
     std::cout << "  --help, -h:                     Displays this help message.\n";
     std::cout << "  --list, -l:                     Lists the available benchmark categories and exits the program.\n";

--- a/benchmarks/src/opencv/bench_copy_make_border.cpp
+++ b/benchmarks/src/opencv/bench_copy_make_border.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights

--- a/benchmarks/src/opencv/bench_copy_make_border.cpp
+++ b/benchmarks/src/opencv/bench_copy_make_border.cpp
@@ -24,7 +24,7 @@
 
 #include "opencv_bench_helpers.hpp"
 
-BENCHMARK(CopyMakeBorder, OpenCV_Constant) {
+BENCHMARK(CopyMakeBorderConstant, OpenCV) {
     roccvbench::BenchmarkResults results;
 
     const int top = 9;

--- a/benchmarks/src/roccv/bench_copy_make_border.cpp
+++ b/benchmarks/src/roccv/bench_copy_make_border.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights

--- a/benchmarks/src/roccv/bench_copy_make_border.cpp
+++ b/benchmarks/src/roccv/bench_copy_make_border.cpp
@@ -31,7 +31,7 @@
 
 using namespace roccv;
 
-BENCHMARK(CopyMakeBorder, GPU_Constant) {
+BENCHMARK(CopyMakeBorderConstant, GPU) {
     roccvbench::BenchmarkResults results;
 
     const int top = 9;
@@ -67,7 +67,7 @@ BENCHMARK(CopyMakeBorder, GPU_Constant) {
     return results;
 }
 
-BENCHMARK(CopyMakeBorder, CPU_Constant) {
+BENCHMARK(CopyMakeBorderConstant, CPU) {
     roccvbench::BenchmarkResults results;
 
     const int top = 9;
@@ -95,7 +95,7 @@ BENCHMARK(CopyMakeBorder, CPU_Constant) {
     return results;
 }
 
-BENCHMARK(CopyMakeBorder, GPU_Reflect) {
+BENCHMARK(CopyMakeBorderReflect, GPU) {
     roccvbench::BenchmarkResults results;
     results.executionTime = 0.0f;
 
@@ -132,7 +132,7 @@ BENCHMARK(CopyMakeBorder, GPU_Reflect) {
     return results;
 }
 
-BENCHMARK(CopyMakeBorder, CPU_Reflect) {
+BENCHMARK(CopyMakeBorderReflect, CPU) {
     roccvbench::BenchmarkResults results;
     results.executionTime = 0.0f;
 

--- a/benchmarks/src/roccv/roccv_bench_helpers.cpp
+++ b/benchmarks/src/roccv/roccv_bench_helpers.cpp
@@ -62,7 +62,12 @@ void FillTensorImpl(const roccv::Tensor& tensor) {
     } else {
         throw std::runtime_error("Unsupported data type.");
     }
-    HIP_VALIDATE_NO_ERRORS(hipDeviceSynchronize());
+
+    // Synchronize the GPU to ensure that the data is ready to be used.
+    if (tensor.device() == eDeviceType::GPU) {
+        HIP_VALIDATE_NO_ERRORS(hipDeviceSynchronize());
+    }
+
     rocrand_destroy_generator(generator);
 }
 }  // namespace

--- a/benchmarks/src/roccv/roccv_bench_helpers.cpp
+++ b/benchmarks/src/roccv/roccv_bench_helpers.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights

--- a/benchmarks/src/roccv/roccv_bench_helpers.cpp
+++ b/benchmarks/src/roccv/roccv_bench_helpers.cpp
@@ -25,6 +25,9 @@
 #include <rocrand/rocrand.h>
 
 #include <roccvbench/utils.hpp>
+#include <stdexcept>
+#include <type_traits>
+#include <unordered_map>
 
 namespace {
 static rocrand_generator GetGenerator(eDeviceType device) {

--- a/benchmarks/src/roccv/roccv_bench_helpers.cpp
+++ b/benchmarks/src/roccv/roccv_bench_helpers.cpp
@@ -22,69 +22,57 @@
 #include "roccv_bench_helpers.hpp"
 
 #include <core/hip_assert.h>
+#include <rocrand/rocrand.h>
 
 #include <roccvbench/utils.hpp>
-#include <vector>
 
-template <typename T>
-void MoveToTensor(const roccv::Tensor& tensor, const std::vector<T>& vec) {
-    auto tensor_data = tensor.exportData<roccv::TensorDataStrided>();
-    switch (tensor.device()) {
+namespace {
+static rocrand_generator GetGenerator(eDeviceType device) {
+    rocrand_generator gen;
+    switch (device) {
         case eDeviceType::GPU: {
-            HIP_VALIDATE_NO_ERRORS(hipMemcpy(tensor_data.basePtr(), vec.data(),
-                                             tensor.shape().size() * tensor.dtype().size(), hipMemcpyHostToDevice));
+            rocrand_create_generator(&gen, ROCRAND_RNG_PSEUDO_DEFAULT);
             break;
         }
-
         case eDeviceType::CPU: {
-            HIP_VALIDATE_NO_ERRORS(hipMemcpy(tensor_data.basePtr(), vec.data(),
-                                             tensor.shape().size() * tensor.dtype().size(), hipMemcpyHostToHost));
-            break;
-        }
-    }
-}
-
-void FillTensor(const roccv::Tensor& tensor) {
-    switch (tensor.dtype().etype()) {
-        case DATA_TYPE_U8: {
-            std::vector<uint8_t> vec = roccvbench::RandVector<uint8_t>(tensor.shape().size());
-            MoveToTensor<uint8_t>(tensor, vec);
-            break;
-        }
-
-        case DATA_TYPE_S8: {
-            std::vector<int8_t> vec = roccvbench::RandVector<int8_t>(tensor.shape().size());
-            MoveToTensor<int8_t>(tensor, vec);
-            break;
-        }
-
-        case DATA_TYPE_F32: {
-            std::vector<float> vec = roccvbench::RandVector<float>(tensor.shape().size());
-            MoveToTensor<float>(tensor, vec);
-            break;
-        }
-
-        case DATA_TYPE_F64: {
-            std::vector<double> vec = roccvbench::RandVector<double>(tensor.shape().size());
-            MoveToTensor<double>(tensor, vec);
-            break;
-        }
-
-        case DATA_TYPE_S32: {
-            std::vector<int32_t> vec = roccvbench::RandVector<int32_t>(tensor.shape().size());
-            MoveToTensor<int32_t>(tensor, vec);
-            break;
-        }
-
-        case DATA_TYPE_U32: {
-            std::vector<uint32_t> vec = roccvbench::RandVector<uint32_t>(tensor.shape().size());
-            MoveToTensor<uint32_t>(tensor, vec);
+            rocrand_create_generator_host_blocking(&gen, ROCRAND_RNG_PSEUDO_DEFAULT);
             break;
         }
 
         default: {
-            throw std::runtime_error("Unsupported tensor data type.");
-            break;
+            throw std::runtime_error("Unsupported device type.");
         }
     }
+
+    return gen;
+}
+
+template <typename T>
+void FillTensorImpl(const roccv::Tensor& tensor) {
+    const auto tensor_data = tensor.exportData<roccv::TensorDataStrided>();
+    const auto generator = GetGenerator(tensor.device());
+
+    if constexpr (std::is_integral_v<T>) {
+        rocrand_generate_char(generator, static_cast<unsigned char*>(tensor_data.basePtr()),
+                              tensor.shape().size() * tensor.dtype().size());
+    } else if constexpr (std::is_same_v<T, float>) {
+        rocrand_generate_uniform(generator, static_cast<float*>(tensor_data.basePtr()), tensor.shape().size());
+    } else if constexpr (std::is_same_v<T, double>) {
+        rocrand_generate_uniform_double(generator, static_cast<double*>(tensor_data.basePtr()), tensor.shape().size());
+    } else {
+        throw std::runtime_error("Unsupported data type.");
+    }
+    HIP_VALIDATE_NO_ERRORS(hipDeviceSynchronize());
+}
+}  // namespace
+
+void FillTensor(const roccv::Tensor& tensor) {
+    static const std::unordered_map<eDataType, void (*)(const roccv::Tensor&)> fillTensorImpls = {
+        {eDataType::DATA_TYPE_U8, FillTensorImpl<uint8_t>},   {eDataType::DATA_TYPE_S8, FillTensorImpl<int8_t>},
+        {eDataType::DATA_TYPE_U16, FillTensorImpl<uint16_t>}, {eDataType::DATA_TYPE_S16, FillTensorImpl<int16_t>},
+        {eDataType::DATA_TYPE_U32, FillTensorImpl<uint32_t>}, {eDataType::DATA_TYPE_S32, FillTensorImpl<int32_t>},
+        {eDataType::DATA_TYPE_F32, FillTensorImpl<float>},    {eDataType::DATA_TYPE_F64, FillTensorImpl<double>},
+    };
+
+    fillTensorImpls.at(tensor.dtype().etype())(tensor);
 }

--- a/benchmarks/src/roccv/roccv_bench_helpers.cpp
+++ b/benchmarks/src/roccv/roccv_bench_helpers.cpp
@@ -75,5 +75,8 @@ void FillTensor(const roccv::Tensor& tensor) {
         {eDataType::DATA_TYPE_F32, FillTensorImpl<float>},    {eDataType::DATA_TYPE_F64, FillTensorImpl<double>},
     };
 
+    if (!fillTensorImpls.contains(tensor.dtype().etype())) {
+        throw std::runtime_error("Unsupported data type.");
+    }
     fillTensorImpls.at(tensor.dtype().etype())(tensor);
 }

--- a/benchmarks/src/roccv/roccv_bench_helpers.cpp
+++ b/benchmarks/src/roccv/roccv_bench_helpers.cpp
@@ -30,48 +30,61 @@
 #include <unordered_map>
 
 namespace {
-static rocrand_generator GetGenerator(eDeviceType device) {
-    rocrand_generator gen;
-    switch (device) {
-        case eDeviceType::GPU: {
-            rocrand_create_generator(&gen, ROCRAND_RNG_PSEUDO_DEFAULT);
-            break;
-        }
-        case eDeviceType::CPU: {
-            rocrand_create_generator_host_blocking(&gen, ROCRAND_RNG_PSEUDO_DEFAULT);
-            break;
-        }
 
-        default: {
-            throw std::runtime_error("Unsupported device type.");
+class RandomGenerator {
+   public:
+    RandomGenerator(eDeviceType device) {
+        switch (device) {
+            case eDeviceType::GPU: {
+                rocrand_create_generator(&m_gen, ROCRAND_RNG_PSEUDO_DEFAULT);
+                break;
+            }
+            case eDeviceType::CPU: {
+                rocrand_create_generator_host_blocking(&m_gen, ROCRAND_RNG_PSEUDO_DEFAULT);
+                break;
+            }
+            default: {
+                throw std::runtime_error("Unsupported device type.");
+            }
         }
     }
 
-    return gen;
-}
+    /**
+     * @brief Generates random data into a tensor.
+     *
+     * @tparam T The type of the data to generate.
+     * @param tensor The tensor to generate data into.
+     */
+    template <typename T>
+    void generate(const roccv::Tensor& tensor) {
+        const auto tensor_data = tensor.exportData<roccv::TensorDataStrided>();
+
+        if constexpr (std::is_integral_v<T>) {
+            rocrand_generate_char(m_gen, static_cast<unsigned char*>(tensor_data.basePtr()),
+                                  tensor.shape().size() * tensor.dtype().size());
+        } else if constexpr (std::is_same_v<T, float>) {
+            rocrand_generate_uniform(m_gen, static_cast<float*>(tensor_data.basePtr()), tensor.shape().size());
+        } else if constexpr (std::is_same_v<T, double>) {
+            rocrand_generate_uniform_double(m_gen, static_cast<double*>(tensor_data.basePtr()), tensor.shape().size());
+        } else {
+            throw std::runtime_error("Unsupported data type.");
+        }
+
+        if (tensor.device() == eDeviceType::GPU) {
+            HIP_VALIDATE_NO_ERRORS(hipDeviceSynchronize());
+        }
+    }
+
+    ~RandomGenerator() { rocrand_destroy_generator(m_gen); }
+
+   private:
+    rocrand_generator m_gen;
+};
 
 template <typename T>
 void FillTensorImpl(const roccv::Tensor& tensor) {
-    const auto tensor_data = tensor.exportData<roccv::TensorDataStrided>();
-    const auto generator = GetGenerator(tensor.device());
-
-    if constexpr (std::is_integral_v<T>) {
-        rocrand_generate_char(generator, static_cast<unsigned char*>(tensor_data.basePtr()),
-                              tensor.shape().size() * tensor.dtype().size());
-    } else if constexpr (std::is_same_v<T, float>) {
-        rocrand_generate_uniform(generator, static_cast<float*>(tensor_data.basePtr()), tensor.shape().size());
-    } else if constexpr (std::is_same_v<T, double>) {
-        rocrand_generate_uniform_double(generator, static_cast<double*>(tensor_data.basePtr()), tensor.shape().size());
-    } else {
-        throw std::runtime_error("Unsupported data type.");
-    }
-
-    // Synchronize the GPU to ensure that the data is ready to be used.
-    if (tensor.device() == eDeviceType::GPU) {
-        HIP_VALIDATE_NO_ERRORS(hipDeviceSynchronize());
-    }
-
-    rocrand_destroy_generator(generator);
+    RandomGenerator generator(tensor.device());
+    generator.generate<T>(tensor);
 }
 }  // namespace
 

--- a/benchmarks/src/roccv/roccv_bench_helpers.cpp
+++ b/benchmarks/src/roccv/roccv_bench_helpers.cpp
@@ -63,6 +63,7 @@ void FillTensorImpl(const roccv::Tensor& tensor) {
         throw std::runtime_error("Unsupported data type.");
     }
     HIP_VALIDATE_NO_ERRORS(hipDeviceSynchronize());
+    rocrand_destroy_generator(generator);
 }
 }  // namespace
 


### PR DESCRIPTION
## PR Details:
* Uses rocRAND to generate randomized data directly on the GPU. Speeds up benchmarking time (not actual benchmark results, but the time it takes to record them) significantly for the GPU path.
* Changes made to how benchmark data is collected and recorded. Allows for more flexible addition of data per-operator in the future.
* Now supports CSV and JSON exporting.
* Changes made to `generate_graphs.py` to support the new JSON format.
* CopyMakeBorder is split into two categories for data consistency purposes.
* Benchmark execution time is now recorded in seconds. No longer using milliseconds.

## Notes:
* rocRAND is now a dependency when building benchmarks. This should not be an issue as rocRAND is already included in the ROCm stack. Main build of the library not affected, as benchmarks are not built by default.
