### PR TITLE
[Bugfix]: Add necessary include in benchmark utils target

### DIFF
--- a/benchmarks/roccvbench/CMakeLists.txt
+++ b/benchmarks/roccvbench/CMakeLists.txt
@@ -27,4 +27,8 @@ project(roccvbench-utils)
 
 file(GLOB_RECURSE SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
 add_library(${PROJECT_NAME} STATIC ${SOURCES})
-target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
+target_include_directories(${PROJECT_NAME} 
+    PUBLIC
+        "${CMAKE_CURRENT_SOURCE_DIR}/include"
+        "${CMAKE_CURRENT_SOURCE_DIR}/../vendor"
+)


### PR DESCRIPTION
## Description
* Adds a necessary include to the benchmark utilities target. Without this, the build system fails if `<nlohmann/json,hpp>` is not available on a system path.