### PR TITLE
[Bugfix] Fix invalid stream use in Histogram tests

### DIFF
--- a/tests/roccv/cpp/src/tests/operators/test_op_histogram.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_histogram.cpp
@@ -160,20 +160,16 @@ void TestCorrectness(int batchSize, int width, int height, ImageFormat format, e
     Histogram op;
     op(stream, input, std::nullopt, histogram, device);
     HIP_VALIDATE_NO_ERRORS(hipStreamSynchronize(stream));
-    HIP_VALIDATE_NO_ERRORS(hipStreamDestroy(stream));
 
     // Copy data from histogram tensor into a host allocated vector
     std::vector<BT> result(histogram.shape().size());
     CopyTensorIntoVector(result, histogram);
 
     // Run roccv::Histogram operator with mask to obtain actual results
-    hipStream_t streamMask;
-    HIP_VALIDATE_NO_ERRORS(hipStreamCreate(&streamMask));
-
     Histogram maskOp;
-    maskOp(streamMask, input, mask, histogramWithMask, device);
-    HIP_VALIDATE_NO_ERRORS(hipStreamSynchronize(streamMask));
-    HIP_VALIDATE_NO_ERRORS(hipStreamDestroy(streamMask));
+    maskOp(stream, input, mask, histogramWithMask, device);
+    HIP_VALIDATE_NO_ERRORS(hipStreamSynchronize(stream));
+    HIP_VALIDATE_NO_ERRORS(hipStreamDestroy(stream));
 
     // Copy data from histogramWithMask tensor into a host allocated vector
     std::vector<BT> maskResult(histogramWithMask.shape().size());

--- a/tests/roccv/cpp/src/tests/operators/test_op_histogram.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_histogram.cpp
@@ -171,7 +171,7 @@ void TestCorrectness(int batchSize, int width, int height, ImageFormat format, e
     HIP_VALIDATE_NO_ERRORS(hipStreamCreate(&streamMask));
 
     Histogram maskOp;
-    maskOp(stream, input, mask, histogramWithMask, device);
+    maskOp(streamMask, input, mask, histogramWithMask, device);
     HIP_VALIDATE_NO_ERRORS(hipStreamSynchronize(streamMask));
     HIP_VALIDATE_NO_ERRORS(hipStreamDestroy(streamMask));
 


### PR DESCRIPTION
## Description
- Ensure `test_op_histogram.cpp` uses `streamMask` instead of `stream` when running `maskOp`. Otherwise, it uses a stream that may already be destroyed, and synchronizes on the wrong stream.