### PR TITLE
[BUG FIX] Removed pragma unroll from thresholding_device.hpp

### DIFF
--- a/include/kernels/device/thresholding_device.hpp
+++ b/include/kernels/device/thresholding_device.hpp
@@ -49,7 +49,6 @@ __global__ void binary_generic(SrcWrapper input, DstWrapper output,
         double mv = maxVal.at(z_idx);
         src_type inputVal = input.at(z_idx, y_idx, x_idx, 0);
         dst_type outputVal;
-#pragma unroll
         for (int i = 0; i < output.channels(); i++) {
             double ip = StaticCast<double>(GetElement(inputVal, i));
             double outVal = ip > th ? mv : 0;
@@ -78,7 +77,6 @@ __global__ void binary_inv_generic(SrcWrapper input, DstWrapper output,
         double mv = maxVal.at(z_idx);
         src_type inputVal = input.at(z_idx, y_idx, x_idx, 0);
         dst_type outputVal;
-#pragma unroll
         for (int i = 0; i < output.channels(); i++) {
             double ip = StaticCast<double>(GetElement(inputVal, i));
             double outVal = ip > th ? 0 : mv;
@@ -105,7 +103,6 @@ __global__ void trunc_generic(SrcWrapper input, DstWrapper output,
         double th = thresh.at(z_idx);
         src_type inputVal = input.at(z_idx, y_idx, x_idx, 0);
         dst_type outputVal;
-#pragma unroll
         for (int i = 0; i < output.channels(); i++) {
             double ip = StaticCast<double>(GetElement(inputVal, i));
             double outVal = ip > th ? th : ip;
@@ -132,7 +129,6 @@ __global__ void tozero_generic(SrcWrapper input, DstWrapper output,
         double th = thresh.at(z_idx);
         src_type inputVal = input.at(z_idx, y_idx, x_idx, 0);
         dst_type outputVal;
-#pragma unroll
         for (int i = 0; i < output.channels(); i++) {
             double ip = StaticCast<double>(GetElement(inputVal, i));
             double outVal = ip > th ? ip : 0;
@@ -160,7 +156,6 @@ __global__ void tozeroinv_generic(SrcWrapper input, DstWrapper output,
     double th = thresh.at(z_idx);
     src_type inputVal = input.at(z_idx, y_idx, x_idx, 0);
     dst_type outputVal;
-#pragma unroll
     for (int i = 0; i < output.channels(); i++) {
         double ip = StaticCast<double>(GetElement(inputVal, i));
         double outVal = ip > th ? 0 : ip;


### PR DESCRIPTION
## Motivation

Removed unneeded pragma unroll from thresholding_device.hpp that was causing warnings to be thrown during compilation.

## Technical Details


## Test Plan

Compile and run C++ and Python tests.

## Test Result

Compiles with no warnings and C++ and Python tests pass.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
