### PR TITLE
[New Operator] Essam's Initial implementation of the refactored Advanced Color Convert

### DIFF
--- a/docs/reference/rocCV-supported-operators.rst
+++ b/docs/reference/rocCV-supported-operators.rst
@@ -12,6 +12,7 @@ The rocCV is a collection of the following computer vision operators that are su
 .. csv-table::
     :header: "Operator", "Description", "Datatypes", "Layouts"
     
+    "AdvCvtColor","Converts color spaces with explicit BT601/BT709/BT2020 coefficients, including NV12/NV21 paths.","U8","NHWC, HWC"
     "BilateralFilter", "Applies a bilateral filter.", "U8", "NHWC, HWC"
     "BndBox","Draws bounding boxes on the images in a tensor.","U8","NHWC, HWC"
     "Composite","Composites two input tensors using a provided alpha mask.","U8, S8, U32, S32, F32","NHWC, HWC"

--- a/docs/supported-operators.md
+++ b/docs/supported-operators.md
@@ -4,6 +4,7 @@ See below for a list of Computer Vision operators rocCV supports.
 
 |Name|Description|Datatypes|Layouts|CPU/GPU Support|
 |-|-|-|-|-|
+|AdvCvtColor|Converts color spaces using explicit BT601/BT709/BT2020 coefficients and supports NV12/NV21 paths.|U8|NHWC, HWC|Both|
 |BilateralFilter|Applies a bilateral filter to reduce image noise while preserving strong edges.|U8, S8, U16, S16, U32, S32, F32, F64|NHWC, HWC|Both|
 |BndBox|Draws rectangular borders using the specified locations, dimensions and colors, in order to show the locations and sizes of objects in an image.|U8, S8|NHWC, HWC|Both|
 |CenterCrop|Crops an image at its center with a given rectangular region.|U8, S8, U16, S16, U32, S32, F32, F64|NHWC, HWC|Both|

--- a/include/kernels/common/adv_cvt_color_coefficients.hpp
+++ b/include/kernels/common/adv_cvt_color_coefficients.hpp
@@ -20,23 +20,21 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-#include "op_bilateral_filter.hpp"
-#include "op_bnd_box.hpp"
-#include "op_composite.hpp"
-#include "op_copy_make_border.hpp"
-#include "op_custom_crop.hpp"
-#include "op_center_crop.hpp"
-#include "op_cvt_color.hpp"
-#include "op_adv_cvt_color.hpp"
-#include "op_flip.hpp"
-#include "op_gamma_contrast.hpp"
-#include "op_histogram.hpp"
-#include "op_non_max_suppression.hpp"
-#include "op_normalize.hpp"
-#include "op_remap.hpp"
-#include "op_resize.hpp"
-#include "op_rotate.hpp"
-#include "op_thresholding.hpp"
-#include "op_warp_affine.hpp"
-#include "op_warp_perspective.hpp"
-#include "op_convert_to.hpp"
+#pragma once
+
+namespace Kernels {
+
+struct AdvCvtColorCoefficients {
+    float r2y;
+    float g2y;
+    float b2y;
+    float b2u;
+    float r2v;
+
+    float v2r;
+    float u2g;
+    float v2g;
+    float u2b;
+};
+
+}  // namespace Kernels

--- a/include/kernels/device/adv_cvt_color_device.hpp
+++ b/include/kernels/device/adv_cvt_color_device.hpp
@@ -46,9 +46,9 @@ __global__ void rgb_or_bgr_to_yuv_adv(SrcWrapper input, DstWrapper output, AdvCv
     T inVal = Swizzle<S>(input.at(z_idx, y_idx, x_idx, 0));
     work_type_t inValF = StaticCast<work_type_t>(inVal);
 
-    float y = inValF.x * coeff.r2y + inValF.y * coeff.g2y + inValF.z * coeff.b2y;
-    float u = (inValF.z - y) * coeff.b2u + delta;
-    float v = (inValF.x - y) * coeff.r2v + delta;
+    float y = fmaf(inValF.z, coeff.b2y, fmaf(inValF.y, coeff.g2y, fmaf(inValF.x, coeff.r2y, 0.0f)));
+    float u = fmaf((inValF.z - y), coeff.b2u, delta);
+    float v = fmaf((inValF.x - y), coeff.r2v, delta);
 
     output.at(z_idx, y_idx, x_idx, 0) = SaturateCast<T>(make_float3(y, u, v));
 }
@@ -67,9 +67,9 @@ __global__ void yuv_to_rgb_or_bgr_adv(SrcWrapper input, DstWrapper output, AdvCv
     T inVal = input.at(z_idx, y_idx, x_idx, 0);
     work_type_t inValF = StaticCast<work_type_t>(inVal);
 
-    float r = inValF.x + (inValF.z - delta) * coeff.v2r;
-    float g = inValF.x + (inValF.y - delta) * coeff.u2g + (inValF.z - delta) * coeff.v2g;
-    float b = inValF.x + (inValF.y - delta) * coeff.u2b;
+    float r = fmaf((inValF.z - delta), coeff.v2r, inValF.x);
+    float g = fmaf((inValF.z - delta), coeff.v2g, fmaf((inValF.y - delta), coeff.u2g, inValF.x));
+    float b = fmaf((inValF.y - delta), coeff.u2b, inValF.x);
 
     output.at(z_idx, y_idx, x_idx, 0) = Swizzle<S>(SaturateCast<T>(make_float3(r, g, b)));
 }
@@ -93,9 +93,9 @@ __global__ void nv12_or_nv21_to_rgb_or_bgr_adv(SrcWrapper input, DstWrapper outp
     float u = static_cast<float>(input.at(z_idx, uvRow, uvCol + uidx, 0).x);
     float v = static_cast<float>(input.at(z_idx, uvRow, uvCol + (1 - uidx), 0).x);
 
-    float r = y + (v - delta) * coeff.v2r;
-    float g = y + (u - delta) * coeff.u2g + (v - delta) * coeff.v2g;
-    float b = y + (u - delta) * coeff.u2b;
+    float r = fmaf((v - delta), coeff.v2r, y);
+    float g = fmaf((v - delta), coeff.v2g, fmaf((u - delta), coeff.u2g, y));
+    float b = fmaf((u - delta), coeff.u2b, y);
 
     if constexpr (NumElements<DstT> == 4) {
         output.at(z_idx, y_idx, x_idx, 0) = Swizzle<S>(SaturateCast<DstT>(make_float4(r, g, b, 255.0f)));
@@ -121,9 +121,9 @@ __global__ void rgb_or_bgr_to_nv12_or_nv21_adv(SrcWrapper input, DstWrapper outp
 
     SrcT p0 = Swizzle<S>(input.at(z_idx, y_idx, x_idx, 0));
     work_type_t rgb0 = StaticCast<work_type_t>(p0);
-    float y0 = rgb0.x * coeff.r2y + rgb0.y * coeff.g2y + rgb0.z * coeff.b2y;
-    float u0 = (rgb0.z - y0) * coeff.b2u;
-    float v0 = (rgb0.x - y0) * coeff.r2v;
+    float y0 = fmaf(rgb0.z, coeff.b2y, fmaf(rgb0.y, coeff.g2y, fmaf(rgb0.x, coeff.r2y, 0.0f)));
+    float u0 = fmaf((rgb0.z - y0), coeff.b2u, 0.0f);
+    float v0 = fmaf((rgb0.x - y0), coeff.r2v, 0.0f);
 
     output.at(z_idx, y_idx, x_idx, 0) = SaturateCast<uchar1>(y0);
 
@@ -137,9 +137,9 @@ __global__ void rgb_or_bgr_to_nv12_or_nv21_adv(SrcWrapper input, DstWrapper outp
     work_type_t rgb2 = StaticCast<work_type_t>(p2);
     work_type_t rgb3 = StaticCast<work_type_t>(p3);
 
-    float y1 = rgb1.x * coeff.r2y + rgb1.y * coeff.g2y + rgb1.z * coeff.b2y;
-    float y2 = rgb2.x * coeff.r2y + rgb2.y * coeff.g2y + rgb2.z * coeff.b2y;
-    float y3 = rgb3.x * coeff.r2y + rgb3.y * coeff.g2y + rgb3.z * coeff.b2y;
+    float y1 = fmaf(rgb1.x, coeff.r2y, fmaf(rgb1.y, coeff.g2y, fmaf(rgb1.z, coeff.b2y, 0.0f)));
+    float y2 = fmaf(rgb2.x, coeff.r2y, fmaf(rgb2.y, coeff.g2y, fmaf(rgb2.z, coeff.b2y, 0.0f)));
+    float y3 = fmaf(rgb3.x, coeff.r2y, fmaf(rgb3.y, coeff.g2y, fmaf(rgb3.z, coeff.b2y, 0.0f)));
 
     float u1 = (rgb1.z - y1) * coeff.b2u;
     float u2 = (rgb2.z - y2) * coeff.b2u;
@@ -152,8 +152,8 @@ __global__ void rgb_or_bgr_to_nv12_or_nv21_adv(SrcWrapper input, DstWrapper outp
     int uvRow = rgbHeight + y_idx / 2;
     int uvCol = x_idx;
 
-    float uAvg = (u0 + u1 + u2 + u3) * 0.25f + delta;
-    float vAvg = (v0 + v1 + v2 + v3) * 0.25f + delta;
+    float uAvg = fmaf((u0 + u1 + u2 + u3), 0.25f, delta);
+    float vAvg = fmaf((v0 + v1 + v2 + v3), 0.25f, delta);
 
     output.at(z_idx, uvRow, uvCol + uidx, 0) = SaturateCast<uchar1>(uAvg);
     output.at(z_idx, uvRow, uvCol + (1 - uidx), 0) = SaturateCast<uchar1>(vAvg);

--- a/include/kernels/device/adv_cvt_color_device.hpp
+++ b/include/kernels/device/adv_cvt_color_device.hpp
@@ -1,0 +1,162 @@
+/**
+Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#pragma once
+
+#include <hip/hip_runtime.h>
+
+#include <core/detail/casting.hpp>
+#include <core/detail/swizzling.hpp>
+#include <core/detail/type_traits.hpp>
+
+#include "kernels/common/adv_cvt_color_coefficients.hpp"
+
+namespace Kernels::Device {
+
+template <typename T, roccv::eSwizzle S, typename SrcWrapper, typename DstWrapper>
+__global__ void rgb_or_bgr_to_yuv_adv(SrcWrapper input, DstWrapper output, AdvCvtColorCoefficients coeff, float delta) {
+    using namespace roccv::detail;
+    using work_type_t = MakeType<float, NumElements<T>>;
+
+    const int x_idx = threadIdx.x + blockIdx.x * blockDim.x;
+    const int y_idx = threadIdx.y + blockIdx.y * blockDim.y;
+    const int z_idx = blockIdx.z;
+
+    if (x_idx >= output.width() || y_idx >= output.height()) return;
+
+    T inVal = Swizzle<S>(input.at(z_idx, y_idx, x_idx, 0));
+    work_type_t inValF = StaticCast<work_type_t>(inVal);
+
+    float y = inValF.x * coeff.r2y + inValF.y * coeff.g2y + inValF.z * coeff.b2y;
+    float u = (inValF.z - y) * coeff.b2u + delta;
+    float v = (inValF.x - y) * coeff.r2v + delta;
+
+    output.at(z_idx, y_idx, x_idx, 0) = SaturateCast<T>(make_float3(y, u, v));
+}
+
+template <typename T, roccv::eSwizzle S, typename SrcWrapper, typename DstWrapper>
+__global__ void yuv_to_rgb_or_bgr_adv(SrcWrapper input, DstWrapper output, AdvCvtColorCoefficients coeff, float delta) {
+    using namespace roccv::detail;
+    using work_type_t = MakeType<float, NumElements<T>>;
+
+    const int x_idx = threadIdx.x + blockIdx.x * blockDim.x;
+    const int y_idx = threadIdx.y + blockIdx.y * blockDim.y;
+    const int z_idx = blockIdx.z;
+
+    if (x_idx >= output.width() || y_idx >= output.height()) return;
+
+    T inVal = input.at(z_idx, y_idx, x_idx, 0);
+    work_type_t inValF = StaticCast<work_type_t>(inVal);
+
+    float r = inValF.x + (inValF.z - delta) * coeff.v2r;
+    float g = inValF.x + (inValF.y - delta) * coeff.u2g + (inValF.z - delta) * coeff.v2g;
+    float b = inValF.x + (inValF.y - delta) * coeff.u2b;
+
+    output.at(z_idx, y_idx, x_idx, 0) = Swizzle<S>(SaturateCast<T>(make_float3(r, g, b)));
+}
+
+template <roccv::eSwizzle S, typename SrcWrapper, typename DstWrapper, typename DstT>
+__global__ void nv12_or_nv21_to_rgb_or_bgr_adv(SrcWrapper input, DstWrapper output, AdvCvtColorCoefficients coeff,
+                                                float delta, int uidx) {
+    using namespace roccv::detail;
+
+    const int x_idx = threadIdx.x + blockIdx.x * blockDim.x;
+    const int y_idx = threadIdx.y + blockIdx.y * blockDim.y;
+    const int z_idx = blockIdx.z;
+
+    if (x_idx >= output.width() || y_idx >= output.height()) return;
+
+    const int rgbHeight = output.height();
+    const int uvRow = rgbHeight + y_idx / 2;
+    const int uvCol = x_idx & ~1;
+
+    float y = static_cast<float>(input.at(z_idx, y_idx, x_idx, 0).x);
+    float u = static_cast<float>(input.at(z_idx, uvRow, uvCol + uidx, 0).x);
+    float v = static_cast<float>(input.at(z_idx, uvRow, uvCol + (1 - uidx), 0).x);
+
+    float r = y + (v - delta) * coeff.v2r;
+    float g = y + (u - delta) * coeff.u2g + (v - delta) * coeff.v2g;
+    float b = y + (u - delta) * coeff.u2b;
+
+    if constexpr (NumElements<DstT> == 4) {
+        output.at(z_idx, y_idx, x_idx, 0) = Swizzle<S>(SaturateCast<DstT>(make_float4(r, g, b, 255.0f)));
+    } else {
+        output.at(z_idx, y_idx, x_idx, 0) = Swizzle<S>(SaturateCast<DstT>(make_float3(r, g, b)));
+    }
+}
+
+template <typename SrcT, roccv::eSwizzle S, typename SrcWrapper, typename DstWrapper>
+__global__ void rgb_or_bgr_to_nv12_or_nv21_adv(SrcWrapper input, DstWrapper output, AdvCvtColorCoefficients coeff,
+                                                float delta, int uidx) {
+    using namespace roccv::detail;
+    using work_type_t = MakeType<float, NumElements<SrcT>>;
+
+    const int x_idx = threadIdx.x + blockIdx.x * blockDim.x;
+    const int y_idx = threadIdx.y + blockIdx.y * blockDim.y;
+    const int z_idx = blockIdx.z;
+
+    const int width = input.width();
+    const int rgbHeight = input.height();
+
+    if (x_idx >= width || y_idx >= rgbHeight) return;
+
+    SrcT p0 = Swizzle<S>(input.at(z_idx, y_idx, x_idx, 0));
+    work_type_t rgb0 = StaticCast<work_type_t>(p0);
+    float y0 = rgb0.x * coeff.r2y + rgb0.y * coeff.g2y + rgb0.z * coeff.b2y;
+    float u0 = (rgb0.z - y0) * coeff.b2u;
+    float v0 = (rgb0.x - y0) * coeff.r2v;
+
+    output.at(z_idx, y_idx, x_idx, 0) = SaturateCast<uchar1>(y0);
+
+    if ((x_idx & 1) != 0 || (y_idx & 1) != 0) return;
+    if (x_idx + 1 >= width || y_idx + 1 >= rgbHeight) return;
+
+    SrcT p1 = Swizzle<S>(input.at(z_idx, y_idx, x_idx + 1, 0));
+    SrcT p2 = Swizzle<S>(input.at(z_idx, y_idx + 1, x_idx, 0));
+    SrcT p3 = Swizzle<S>(input.at(z_idx, y_idx + 1, x_idx + 1, 0));
+    work_type_t rgb1 = StaticCast<work_type_t>(p1);
+    work_type_t rgb2 = StaticCast<work_type_t>(p2);
+    work_type_t rgb3 = StaticCast<work_type_t>(p3);
+
+    float y1 = rgb1.x * coeff.r2y + rgb1.y * coeff.g2y + rgb1.z * coeff.b2y;
+    float y2 = rgb2.x * coeff.r2y + rgb2.y * coeff.g2y + rgb2.z * coeff.b2y;
+    float y3 = rgb3.x * coeff.r2y + rgb3.y * coeff.g2y + rgb3.z * coeff.b2y;
+
+    float u1 = (rgb1.z - y1) * coeff.b2u;
+    float u2 = (rgb2.z - y2) * coeff.b2u;
+    float u3 = (rgb3.z - y3) * coeff.b2u;
+
+    float v1 = (rgb1.x - y1) * coeff.r2v;
+    float v2 = (rgb2.x - y2) * coeff.r2v;
+    float v3 = (rgb3.x - y3) * coeff.r2v;
+
+    int uvRow = rgbHeight + y_idx / 2;
+    int uvCol = x_idx;
+
+    float uAvg = (u0 + u1 + u2 + u3) * 0.25f + delta;
+    float vAvg = (v0 + v1 + v2 + v3) * 0.25f + delta;
+
+    output.at(z_idx, uvRow, uvCol + uidx, 0) = SaturateCast<uchar1>(uAvg);
+    output.at(z_idx, uvRow, uvCol + (1 - uidx), 0) = SaturateCast<uchar1>(vAvg);
+}
+
+}  // namespace Kernels::Device

--- a/include/kernels/host/adv_cvt_color_host.hpp
+++ b/include/kernels/host/adv_cvt_color_host.hpp
@@ -1,0 +1,164 @@
+/**
+Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#pragma once
+
+#include <hip/hip_runtime.h>
+
+#include <core/detail/casting.hpp>
+#include <core/detail/swizzling.hpp>
+#include <core/detail/type_traits.hpp>
+
+#include "kernels/common/adv_cvt_color_coefficients.hpp"
+
+namespace Kernels::Host {
+
+template <typename T, roccv::eSwizzle S, typename SrcWrapper, typename DstWrapper>
+void rgb_or_bgr_to_yuv_adv(SrcWrapper input, DstWrapper output, AdvCvtColorCoefficients coeff, float delta) {
+    using namespace roccv::detail;
+    using work_type_t = MakeType<float, NumElements<T>>;
+
+#pragma omp parallel for
+    for (int z_idx = 0; z_idx < output.batches(); z_idx++) {
+        for (int y_idx = 0; y_idx < output.height(); y_idx++) {
+            for (int x_idx = 0; x_idx < output.width(); x_idx++) {
+                T inVal = Swizzle<S>(input.at(z_idx, y_idx, x_idx, 0));
+                work_type_t inValF = StaticCast<work_type_t>(inVal);
+
+                float y = inValF.x * coeff.r2y + inValF.y * coeff.g2y + inValF.z * coeff.b2y;
+                float u = (inValF.z - y) * coeff.b2u + delta;
+                float v = (inValF.x - y) * coeff.r2v + delta;
+
+                output.at(z_idx, y_idx, x_idx, 0) = SaturateCast<T>(make_float3(y, u, v));
+            }
+        }
+    }
+}
+
+template <typename T, roccv::eSwizzle S, typename SrcWrapper, typename DstWrapper>
+void yuv_to_rgb_or_bgr_adv(SrcWrapper input, DstWrapper output, AdvCvtColorCoefficients coeff, float delta) {
+    using namespace roccv::detail;
+    using work_type_t = MakeType<float, NumElements<T>>;
+
+#pragma omp parallel for
+    for (int z_idx = 0; z_idx < output.batches(); z_idx++) {
+        for (int y_idx = 0; y_idx < output.height(); y_idx++) {
+            for (int x_idx = 0; x_idx < output.width(); x_idx++) {
+                T inVal = input.at(z_idx, y_idx, x_idx, 0);
+                work_type_t inValF = StaticCast<work_type_t>(inVal);
+
+                float r = inValF.x + (inValF.z - delta) * coeff.v2r;
+                float g = inValF.x + (inValF.y - delta) * coeff.u2g + (inValF.z - delta) * coeff.v2g;
+                float b = inValF.x + (inValF.y - delta) * coeff.u2b;
+
+                output.at(z_idx, y_idx, x_idx, 0) = Swizzle<S>(SaturateCast<T>(make_float3(r, g, b)));
+            }
+        }
+    }
+}
+
+template <roccv::eSwizzle S, typename SrcWrapper, typename DstWrapper, typename DstT>
+void nv12_or_nv21_to_rgb_or_bgr_adv(SrcWrapper input, DstWrapper output, AdvCvtColorCoefficients coeff, float delta,
+                                    int uidx) {
+    using namespace roccv::detail;
+
+#pragma omp parallel for
+    for (int z_idx = 0; z_idx < output.batches(); z_idx++) {
+        for (int y_idx = 0; y_idx < output.height(); y_idx++) {
+            for (int x_idx = 0; x_idx < output.width(); x_idx++) {
+                int rgbHeight = output.height();
+                int uvRow = rgbHeight + y_idx / 2;
+                int uvCol = x_idx & ~1;
+
+                float y = static_cast<float>(input.at(z_idx, y_idx, x_idx, 0).x);
+                float u = static_cast<float>(input.at(z_idx, uvRow, uvCol + uidx, 0).x);
+                float v = static_cast<float>(input.at(z_idx, uvRow, uvCol + (1 - uidx), 0).x);
+
+                float r = y + (v - delta) * coeff.v2r;
+                float g = y + (u - delta) * coeff.u2g + (v - delta) * coeff.v2g;
+                float b = y + (u - delta) * coeff.u2b;
+
+                if constexpr (NumElements<DstT> == 4) {
+                    output.at(z_idx, y_idx, x_idx, 0) =
+                        Swizzle<S>(SaturateCast<DstT>(make_float4(r, g, b, 255.0f)));
+                } else {
+                    output.at(z_idx, y_idx, x_idx, 0) = Swizzle<S>(SaturateCast<DstT>(make_float3(r, g, b)));
+                }
+            }
+        }
+    }
+}
+
+template <typename SrcT, roccv::eSwizzle S, typename SrcWrapper, typename DstWrapper>
+void rgb_or_bgr_to_nv12_or_nv21_adv(SrcWrapper input, DstWrapper output, AdvCvtColorCoefficients coeff, float delta,
+                                    int uidx) {
+    using namespace roccv::detail;
+    using work_type_t = MakeType<float, NumElements<SrcT>>;
+
+#pragma omp parallel for
+    for (int z_idx = 0; z_idx < output.batches(); z_idx++) {
+        for (int y_idx = 0; y_idx < input.height(); y_idx++) {
+            for (int x_idx = 0; x_idx < input.width(); x_idx++) {
+                SrcT p0 = Swizzle<S>(input.at(z_idx, y_idx, x_idx, 0));
+                work_type_t rgb0 = StaticCast<work_type_t>(p0);
+                float y0 = rgb0.x * coeff.r2y + rgb0.y * coeff.g2y + rgb0.z * coeff.b2y;
+                float u0 = (rgb0.z - y0) * coeff.b2u;
+                float v0 = (rgb0.x - y0) * coeff.r2v;
+
+                output.at(z_idx, y_idx, x_idx, 0) = SaturateCast<uchar1>(y0);
+
+                if ((x_idx & 1) != 0 || (y_idx & 1) != 0) continue;
+                if (x_idx + 1 >= input.width() || y_idx + 1 >= input.height()) continue;
+
+                SrcT p1 = Swizzle<S>(input.at(z_idx, y_idx, x_idx + 1, 0));
+                SrcT p2 = Swizzle<S>(input.at(z_idx, y_idx + 1, x_idx, 0));
+                SrcT p3 = Swizzle<S>(input.at(z_idx, y_idx + 1, x_idx + 1, 0));
+                work_type_t rgb1 = StaticCast<work_type_t>(p1);
+                work_type_t rgb2 = StaticCast<work_type_t>(p2);
+                work_type_t rgb3 = StaticCast<work_type_t>(p3);
+
+                float y1 = rgb1.x * coeff.r2y + rgb1.y * coeff.g2y + rgb1.z * coeff.b2y;
+                float y2 = rgb2.x * coeff.r2y + rgb2.y * coeff.g2y + rgb2.z * coeff.b2y;
+                float y3 = rgb3.x * coeff.r2y + rgb3.y * coeff.g2y + rgb3.z * coeff.b2y;
+
+                float u1 = (rgb1.z - y1) * coeff.b2u;
+                float u2 = (rgb2.z - y2) * coeff.b2u;
+                float u3 = (rgb3.z - y3) * coeff.b2u;
+
+                float v1 = (rgb1.x - y1) * coeff.r2v;
+                float v2 = (rgb2.x - y2) * coeff.r2v;
+                float v3 = (rgb3.x - y3) * coeff.r2v;
+
+                int uvRow = input.height() + y_idx / 2;
+                int uvCol = x_idx;
+
+                float uAvg = (u0 + u1 + u2 + u3) * 0.25f + delta;
+                float vAvg = (v0 + v1 + v2 + v3) * 0.25f + delta;
+
+                output.at(z_idx, uvRow, uvCol + uidx, 0) = SaturateCast<uchar1>(uAvg);
+                output.at(z_idx, uvRow, uvCol + (1 - uidx), 0) = SaturateCast<uchar1>(vAvg);
+            }
+        }
+    }
+}
+
+}  // namespace Kernels::Host

--- a/include/op_adv_cvt_color.hpp
+++ b/include/op_adv_cvt_color.hpp
@@ -1,0 +1,102 @@
+/**
+Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#pragma once
+
+#include <hip/hip_runtime.h>
+#include <operator_types.h>
+
+#include <i_operator.hpp>
+
+#include "core/tensor.hpp"
+
+namespace roccv {
+/**
+ * @brief Class for managing the Advanced Color Conversion operator.
+ *
+ */
+class AdvCvtColor final : public IOperator {
+   public:
+    /**
+     * @brief Constructs the Advanced Color Conversion operator.
+     */
+    AdvCvtColor();
+
+    /**
+     * @brief Destroys the Advanced Color Conversion operator.
+     */
+    ~AdvCvtColor();
+
+    /**
+     * @brief Executes advanced color conversions with explicit color-spec coefficients.
+     *
+     * Limitations:
+     *
+     * Input:
+     *       Supported TensorLayout(s): [NHWC, HWC]
+     *       Supported DataType(s):     [U8]
+     *
+     * Output:
+     *       Supported TensorLayout(s): [NHWC, HWC]
+     *       Supported DataType(s):     [U8]
+     *
+     * Input/Output dependency:
+     *
+     *       Property      |  Input == Output
+     *      -------------- | -------------
+     *       TensorLayout  | Yes
+     *       DataType      | Yes
+     *       Width         | Yes
+     *       Batch         | Yes
+     *
+     * Supported Color Conversion Codes:
+     *
+     *    - COLOR_RGB2YUV
+     *    - COLOR_BGR2YUV
+     *    - COLOR_YUV2RGB
+     *    - COLOR_YUV2BGR
+     *    - COLOR_YUV2RGB_NV12
+     *    - COLOR_YUV2BGR_NV12
+     *    - COLOR_YUV2RGB_NV21
+     *    - COLOR_YUV2BGR_NV21
+     *    - COLOR_RGB2YUV_NV12
+     *    - COLOR_BGR2YUV_NV12
+     *    - COLOR_RGB2YUV_NV21
+     *    - COLOR_BGR2YUV_NV21
+     *
+     * Supported color specifications:
+     *
+     *    - BT601
+     *    - BT709
+     *    - BT2020
+     *
+     * @param[in] stream The HIP stream to run this operation on.
+     * @param[in] input Input tensor.
+     * @param[out] output Output tensor.
+     * @param[in] conversionCode Color conversion code.
+     * @param[in] colorSpec Color specification for conversion matrix coefficients.
+     * @param[in] device Device to execute on (GPU or CPU).
+     */
+    void operator()(hipStream_t stream, const Tensor &input, Tensor &output, eColorConversionCode conversionCode,
+                    eColorSpec colorSpec, eDeviceType device = eDeviceType::GPU);
+};
+}  // namespace roccv

--- a/include/operator_types.h
+++ b/include/operator_types.h
@@ -1,5 +1,5 @@
 /**
-Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -56,6 +56,15 @@ typedef enum eColorConversionCode {
     COLOR_BGR2RGB = 5,
     COLOR_RGB2GRAY = 6,
     COLOR_BGR2GRAY = 7,
+
+    COLOR_YUV2RGB_NV12 = 8,
+    COLOR_YUV2BGR_NV12 = 9,
+    COLOR_YUV2RGB_NV21 = 10,
+    COLOR_YUV2BGR_NV21 = 11,
+    COLOR_RGB2YUV_NV12 = 12,
+    COLOR_BGR2YUV_NV12 = 13,
+    COLOR_RGB2YUV_NV21 = 14,
+    COLOR_BGR2YUV_NV21 = 15,
 } eColorConversionCode;
 
 typedef enum eAxis {

--- a/python/include/operators/py_op_adv_cvt_color.hpp
+++ b/python/include/operators/py_op_adv_cvt_color.hpp
@@ -20,23 +20,21 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-#include "op_bilateral_filter.hpp"
-#include "op_bnd_box.hpp"
-#include "op_composite.hpp"
-#include "op_copy_make_border.hpp"
-#include "op_custom_crop.hpp"
-#include "op_center_crop.hpp"
-#include "op_cvt_color.hpp"
-#include "op_adv_cvt_color.hpp"
-#include "op_flip.hpp"
-#include "op_gamma_contrast.hpp"
-#include "op_histogram.hpp"
-#include "op_non_max_suppression.hpp"
-#include "op_normalize.hpp"
-#include "op_remap.hpp"
-#include "op_resize.hpp"
-#include "op_rotate.hpp"
-#include "op_thresholding.hpp"
-#include "op_warp_affine.hpp"
-#include "op_warp_perspective.hpp"
-#include "op_convert_to.hpp"
+#pragma once
+
+#include <operator_types.h>
+#include <pybind11/pybind11.h>
+
+#include "py_stream.hpp"
+#include "py_tensor.hpp"
+
+namespace py = pybind11;
+
+class PyOpAdvCvtColor {
+   public:
+    static void Export(py::module& m);
+    static PyTensor Execute(PyTensor& input, eColorConversionCode conversionCode, eColorSpec colorSpec,
+                            std::optional<std::reference_wrapper<PyStream>> stream, eDeviceType device);
+    static void ExecuteInto(PyTensor& output, PyTensor& input, eColorConversionCode conversionCode, eColorSpec colorSpec,
+                            std::optional<std::reference_wrapper<PyStream>> stream, eDeviceType device);
+};

--- a/python/src/main.cpp
+++ b/python/src/main.cpp
@@ -31,6 +31,7 @@ THE SOFTWARE.
 #include "operators/py_op_copy_make_border.hpp"
 #include "operators/py_op_custom_crop.hpp"
 #include "operators/py_op_cvt_color.hpp"
+#include "operators/py_op_adv_cvt_color.hpp"
 #include "operators/py_op_flip.hpp"
 #include "operators/py_op_gamma_contrast.hpp"
 #include "operators/py_op_histogram.hpp"
@@ -72,6 +73,7 @@ PYBIND11_MODULE(rocpycv, m) {
     PyOpThreshold::Export(m);
     PyOpRemap::Export(m);
     PyOpCvtColor::Export(m);
+    PyOpAdvCvtColor::Export(m);
     PyOpBndBox::Export(m);
     PyOpGammaContrast::Export(m);
     PyOpComposite::Export(m);

--- a/python/src/operators/py_op_adv_cvt_color.cpp
+++ b/python/src/operators/py_op_adv_cvt_color.cpp
@@ -1,0 +1,134 @@
+/**
+Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#include "operators/py_op_adv_cvt_color.hpp"
+
+#include <op_adv_cvt_color.hpp>
+
+namespace {
+
+bool isSemiPlanarToInterleaved(eColorConversionCode code) {
+    switch (code) {
+        case COLOR_YUV2RGB_NV12:
+        case COLOR_YUV2BGR_NV12:
+        case COLOR_YUV2RGB_NV21:
+        case COLOR_YUV2BGR_NV21: return true;
+        default: return false;
+    }
+}
+
+bool isInterleavedToSemiPlanar(eColorConversionCode code) {
+    switch (code) {
+        case COLOR_RGB2YUV_NV12:
+        case COLOR_BGR2YUV_NV12:
+        case COLOR_RGB2YUV_NV21:
+        case COLOR_BGR2YUV_NV21: return true;
+        default: return false;
+    }
+}
+
+}  // namespace
+
+PyTensor PyOpAdvCvtColor::Execute(PyTensor& input, eColorConversionCode conversionCode, eColorSpec colorSpec,
+                                  std::optional<std::reference_wrapper<PyStream>> stream, eDeviceType device) {
+    hipStream_t hipStream = stream.has_value() ? stream.value().get().getStream() : nullptr;
+
+    auto inputTensor = input.getTensor();
+    auto inputLayout = inputTensor->layout();
+    int hIdx = inputLayout.height_index();
+    int cIdx = inputLayout.channels_index();
+
+    std::vector<int64_t> outputDims;
+    outputDims.reserve(inputTensor->rank());
+    for (int i = 0; i < inputTensor->rank(); i++) {
+        outputDims.push_back(inputTensor->shape(i));
+    }
+
+    if (isSemiPlanarToInterleaved(conversionCode)) {
+        outputDims[hIdx] = (outputDims[hIdx] * 2) / 3;
+        outputDims[cIdx] = 3;
+    } else if (isInterleavedToSemiPlanar(conversionCode)) {
+        outputDims[hIdx] = (outputDims[hIdx] * 3) / 2;
+        outputDims[cIdx] = 1;
+    } else {
+        outputDims[cIdx] = 3;
+    }
+
+    roccv::TensorShape outputShape(inputLayout, outputDims);
+    auto outputTensor = std::make_shared<roccv::Tensor>(outputShape, inputTensor->dtype(), device);
+
+    roccv::AdvCvtColor op;
+    op(hipStream, *inputTensor, *outputTensor, conversionCode, colorSpec, device);
+    return PyTensor(outputTensor);
+}
+
+void PyOpAdvCvtColor::ExecuteInto(PyTensor& output, PyTensor& input, eColorConversionCode conversionCode,
+                                  eColorSpec colorSpec, std::optional<std::reference_wrapper<PyStream>> stream,
+                                  eDeviceType device) {
+    hipStream_t hipStream = stream.has_value() ? stream.value().get().getStream() : nullptr;
+
+    roccv::AdvCvtColor op;
+    op(hipStream, *input.getTensor(), *output.getTensor(), conversionCode, colorSpec, device);
+}
+
+void PyOpAdvCvtColor::Export(py::module& m) {
+    using namespace py::literals;
+
+    m.def("advcvtcolor", &PyOpAdvCvtColor::Execute, "src"_a, "conversion_code"_a, "color_spec"_a,
+          "stream"_a = nullptr, "device"_a = eDeviceType::GPU, R"pbdoc(
+
+            Executes the Advanced Color Convert operation on the given HIP stream.
+
+            See also:
+                Refer to the rocCV C++ API reference for more information on this operation.
+
+            Args:
+                src (rocpycv.Tensor): Input tensor containing one or more images.
+                conversion_code (eColorConversionCode): Conversion code specifying the formats being converted.
+                color_spec (eColorSpec): Color specification selecting BT601/BT709/BT2020 conversion matrices.
+                stream (rocpycv.Stream, optional): HIP stream to run this operation on.
+                device (rocpycv.Device, optional): The device to run this operation on. Defaults to GPU.
+
+            Returns:
+                rocpycv.Tensor: The output tensor.
+          )pbdoc");
+
+    m.def("advcvtcolor_into", &PyOpAdvCvtColor::ExecuteInto, "dst"_a, "src"_a, "conversion_code"_a,
+          "color_spec"_a, "stream"_a = nullptr, "device"_a = eDeviceType::GPU, R"pbdoc(
+
+            Executes the Advanced Color Convert operation on the given HIP stream.
+
+            See also:
+                Refer to the rocCV C++ API reference for more information on this operation.
+
+            Args:
+                dst (rocpycv.Tensor): Output tensor for storing modified image data.
+                src (rocpycv.Tensor): Input tensor containing one or more images.
+                conversion_code (eColorConversionCode): Conversion code specifying the formats being converted.
+                color_spec (eColorSpec): Color specification selecting BT601/BT709/BT2020 conversion matrices.
+                stream (rocpycv.Stream, optional): HIP stream to run this operation on.
+                device (rocpycv.Device, optional): The device to run this operation on. Defaults to GPU.
+
+            Returns:
+                None
+          )pbdoc");
+}

--- a/python/src/py_enums.cpp
+++ b/python/src/py_enums.cpp
@@ -1,5 +1,5 @@
 /**
-Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -106,6 +106,14 @@ void PyEnums::Export(py::module& m) {
         .value("COLOR_BGR2RGB", COLOR_BGR2RGB)
         .value("COLOR_RGB2GRAY", COLOR_RGB2GRAY)
         .value("COLOR_BGR2GRAY", COLOR_BGR2GRAY)
+        .value("COLOR_YUV2RGB_NV12", COLOR_YUV2RGB_NV12)
+        .value("COLOR_YUV2BGR_NV12", COLOR_YUV2BGR_NV12)
+        .value("COLOR_YUV2RGB_NV21", COLOR_YUV2RGB_NV21)
+        .value("COLOR_YUV2BGR_NV21", COLOR_YUV2BGR_NV21)
+        .value("COLOR_RGB2YUV_NV12", COLOR_RGB2YUV_NV12)
+        .value("COLOR_BGR2YUV_NV12", COLOR_BGR2YUV_NV12)
+        .value("COLOR_RGB2YUV_NV21", COLOR_RGB2YUV_NV21)
+        .value("COLOR_BGR2YUV_NV21", COLOR_BGR2YUV_NV21)
         .export_values();
 
     // eRemapType Enum Bindings

--- a/python/src/rocpycv/rocpycv.pyi
+++ b/python/src/rocpycv/rocpycv.pyi
@@ -11,11 +11,19 @@ BT709: eColorSpec
 COLOR_BGR2GRAY: eColorConversionCode
 COLOR_BGR2RGB: eColorConversionCode
 COLOR_BGR2YUV: eColorConversionCode
+COLOR_BGR2YUV_NV12: eColorConversionCode
+COLOR_BGR2YUV_NV21: eColorConversionCode
 COLOR_RGB2BGR: eColorConversionCode
 COLOR_RGB2GRAY: eColorConversionCode
 COLOR_RGB2YUV: eColorConversionCode
+COLOR_RGB2YUV_NV12: eColorConversionCode
+COLOR_RGB2YUV_NV21: eColorConversionCode
 COLOR_YUV2BGR: eColorConversionCode
+COLOR_YUV2BGR_NV12: eColorConversionCode
+COLOR_YUV2BGR_NV21: eColorConversionCode
 COLOR_YUV2RGB: eColorConversionCode
+COLOR_YUV2RGB_NV12: eColorConversionCode
+COLOR_YUV2RGB_NV21: eColorConversionCode
 CONSTANT: eBorderType
 CPU: eDeviceType
 CUBIC: eInterpolationType
@@ -322,11 +330,19 @@ class eColorConversionCode:
     COLOR_BGR2GRAY: ClassVar[eColorConversionCode] = ...
     COLOR_BGR2RGB: ClassVar[eColorConversionCode] = ...
     COLOR_BGR2YUV: ClassVar[eColorConversionCode] = ...
+    COLOR_BGR2YUV_NV12: ClassVar[eColorConversionCode] = ...
+    COLOR_BGR2YUV_NV21: ClassVar[eColorConversionCode] = ...
     COLOR_RGB2BGR: ClassVar[eColorConversionCode] = ...
     COLOR_RGB2GRAY: ClassVar[eColorConversionCode] = ...
     COLOR_RGB2YUV: ClassVar[eColorConversionCode] = ...
+    COLOR_RGB2YUV_NV12: ClassVar[eColorConversionCode] = ...
+    COLOR_RGB2YUV_NV21: ClassVar[eColorConversionCode] = ...
     COLOR_YUV2BGR: ClassVar[eColorConversionCode] = ...
+    COLOR_YUV2BGR_NV12: ClassVar[eColorConversionCode] = ...
+    COLOR_YUV2BGR_NV21: ClassVar[eColorConversionCode] = ...
     COLOR_YUV2RGB: ClassVar[eColorConversionCode] = ...
+    COLOR_YUV2RGB_NV12: ClassVar[eColorConversionCode] = ...
+    COLOR_YUV2RGB_NV21: ClassVar[eColorConversionCode] = ...
     __entries: ClassVar[dict] = ...
     def __init__(self, value: int) -> None:
         """__init__(self: rocpycv.rocpycv.eColorConversionCode, value: int) -> None"""
@@ -819,6 +835,49 @@ def cvtcolor_into(dst: Tensor, src: Tensor, conversion_code: eColorConversionCod
                     dst (rocpycv.Tensor): Output tensor for storing modified image data.
                     src (rocpycv.Tensor): Input tensor containing one or more images.
                     conversion_code (eColorConversionCode): Conversion code specifying the formats being converted (ex. COLOR_RGB2YUV)
+                    stream (rocpycv.Stream, optional): HIP stream to run this operation on.
+                    device (rocpycv.Device, optional): The device to run this operation on. Defaults to GPU.
+
+                Returns:
+                    None
+          
+    """
+def advcvtcolor(src: Tensor, conversion_code: eColorConversionCode, color_spec: eColorSpec, stream: Stream | None = ..., device: eDeviceType = ...) -> Tensor:
+    """advcvtcolor(src: rocpycv.rocpycv.Tensor, conversion_code: rocpycv.rocpycv.eColorConversionCode, color_spec: rocpycv.rocpycv.eColorSpec, stream: Optional[rocpycv.rocpycv.Stream] = None, device: rocpycv.rocpycv.eDeviceType = <eDeviceType.GPU: 0>) -> rocpycv.rocpycv.Tensor
+
+
+    
+                Executes the Advanced Color Convert operation on the given HIP stream.
+
+                See also:
+                    Refer to the rocCV C++ API reference for more information on this operation.
+            
+                Args:
+                    src (rocpycv.Tensor): Input tensor containing one or more images.
+                    conversion_code (eColorConversionCode): Conversion code specifying the formats being converted.
+                    color_spec (eColorSpec): Color specification selecting BT601/BT709/BT2020 conversion matrices.
+                    stream (rocpycv.Stream, optional): HIP stream to run this operation on.
+                    device (rocpycv.Device, optional): The device to run this operation on. Defaults to GPU.
+
+                Returns:
+                    rocpycv.Tensor: The output tensor.
+          
+    """
+def advcvtcolor_into(dst: Tensor, src: Tensor, conversion_code: eColorConversionCode, color_spec: eColorSpec, stream: Stream | None = ..., device: eDeviceType = ...) -> None:
+    """advcvtcolor_into(dst: rocpycv.rocpycv.Tensor, src: rocpycv.rocpycv.Tensor, conversion_code: rocpycv.rocpycv.eColorConversionCode, color_spec: rocpycv.rocpycv.eColorSpec, stream: Optional[rocpycv.rocpycv.Stream] = None, device: rocpycv.rocpycv.eDeviceType = <eDeviceType.GPU: 0>) -> None
+
+
+
+                Executes the Advanced Color Convert operation on the given HIP stream.
+
+                See also:
+                    Refer to the rocCV C++ API reference for more information on this operation.
+            
+                Args:
+                    dst (rocpycv.Tensor): Output tensor for storing modified image data.
+                    src (rocpycv.Tensor): Input tensor containing one or more images.
+                    conversion_code (eColorConversionCode): Conversion code specifying the formats being converted.
+                    color_spec (eColorSpec): Color specification selecting BT601/BT709/BT2020 conversion matrices.
                     stream (rocpycv.Stream, optional): HIP stream to run this operation on.
                     device (rocpycv.Device, optional): The device to run this operation on. Defaults to GPU.
 

--- a/src/op_adv_cvt_color.cpp
+++ b/src/op_adv_cvt_color.cpp
@@ -1,0 +1,336 @@
+/**
+Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#include "op_adv_cvt_color.hpp"
+
+#include <hip/hip_runtime.h>
+
+#include "common/validation_helpers.hpp"
+#include "core/tensor.hpp"
+#include "core/wrappers/image_wrapper.hpp"
+#include "kernels/common/adv_cvt_color_coefficients.hpp"
+#include "kernels/device/adv_cvt_color_device.hpp"
+#include "kernels/host/adv_cvt_color_host.hpp"
+
+namespace roccv {
+namespace {
+constexpr float kDelta = 128.0f;
+
+inline int64_t GetBatch(const Tensor &tensor) {
+    int batchIdx = tensor.layout().batch_index();
+    return batchIdx < 0 ? 1 : tensor.shape(batchIdx);
+}
+
+inline int64_t GetHeight(const Tensor &tensor) {
+    return tensor.shape(tensor.layout().height_index());
+}
+
+inline int64_t GetWidth(const Tensor &tensor) {
+    return tensor.shape(tensor.layout().width_index());
+}
+
+inline int64_t GetChannels(const Tensor &tensor) {
+    return tensor.shape(tensor.layout().channels_index());
+}
+
+inline bool IsSemiPlanarToInterleaved(eColorConversionCode code) {
+    switch (code) {
+        case COLOR_YUV2RGB_NV12:
+        case COLOR_YUV2BGR_NV12:
+        case COLOR_YUV2RGB_NV21:
+        case COLOR_YUV2BGR_NV21: return true;
+        default: return false;
+    }
+}
+
+inline bool IsInterleavedToSemiPlanar(eColorConversionCode code) {
+    switch (code) {
+        case COLOR_RGB2YUV_NV12:
+        case COLOR_BGR2YUV_NV12:
+        case COLOR_RGB2YUV_NV21:
+        case COLOR_BGR2YUV_NV21: return true;
+        default: return false;
+    }
+}
+
+inline bool IsInterleaved444(eColorConversionCode code) {
+    switch (code) {
+        case COLOR_RGB2YUV:
+        case COLOR_BGR2YUV:
+        case COLOR_YUV2RGB:
+        case COLOR_YUV2BGR: return true;
+        default: return false;
+    }
+}
+
+inline bool IsSupportedCode(eColorConversionCode code) {
+    return IsInterleaved444(code) || IsSemiPlanarToInterleaved(code) || IsInterleavedToSemiPlanar(code);
+}
+
+inline bool IsBGRCode(eColorConversionCode code) {
+    switch (code) {
+        case COLOR_BGR2YUV:
+        case COLOR_YUV2BGR:
+        case COLOR_YUV2BGR_NV12:
+        case COLOR_YUV2BGR_NV21:
+        case COLOR_BGR2YUV_NV12:
+        case COLOR_BGR2YUV_NV21: return true;
+        default: return false;
+    }
+}
+
+inline bool IsNV12Code(eColorConversionCode code) {
+    switch (code) {
+        case COLOR_YUV2RGB_NV12:
+        case COLOR_YUV2BGR_NV12:
+        case COLOR_RGB2YUV_NV12:
+        case COLOR_BGR2YUV_NV12: return true;
+        default: return false;
+    }
+}
+
+inline Kernels::AdvCvtColorCoefficients GetCoefficients(eColorSpec spec) {
+    switch (spec) {
+        case BT601:
+            return {0.299f, 0.587f, 0.114f, 0.564334086f, 0.713266762f, 1.402f, -0.344f, -0.714f, 1.772f};
+        case BT709:
+            return {0.2126f, 0.7152f, 0.0722f, 0.538909248f, 0.63500127f, 1.5748f, -0.187324f, -0.468124f, 1.8556f};
+        case BT2020:
+            return {0.2627f, 0.6780f, 0.0593f, 0.531519082f, 0.678150007f, 1.4746f, -0.16455f, -0.57135f, 1.8814f};
+        default:
+            throw Exception("Unsupported color specification.", eStatusType::INVALID_COMBINATION);
+    }
+}
+
+inline int DivUp(int n, int d) {
+    return (n + d - 1) / d;
+}
+
+}  // namespace
+
+AdvCvtColor::AdvCvtColor() {}
+
+AdvCvtColor::~AdvCvtColor() {}
+
+void AdvCvtColor::operator()(hipStream_t stream, const Tensor &input, Tensor &output, eColorConversionCode conversionCode,
+                             eColorSpec colorSpec, eDeviceType device) {
+    CHECK_TENSOR_DEVICE(input, device);
+    CHECK_TENSOR_DEVICE(output, device);
+
+    CHECK_TENSOR_LAYOUT(input, eTensorLayout::TENSOR_LAYOUT_NHWC, eTensorLayout::TENSOR_LAYOUT_HWC);
+    CHECK_TENSOR_LAYOUT(output, eTensorLayout::TENSOR_LAYOUT_NHWC, eTensorLayout::TENSOR_LAYOUT_HWC);
+    CHECK_TENSOR_COMPARISON(input.layout() == output.layout());
+
+    CHECK_TENSOR_DATATYPES(input, eDataType::DATA_TYPE_U8);
+    CHECK_TENSOR_DATATYPES(output, eDataType::DATA_TYPE_U8);
+
+    CHECK_TENSOR_COMPARISON(IsSupportedCode(conversionCode));
+
+    const int64_t inBatch = GetBatch(input);
+    const int64_t outBatch = GetBatch(output);
+    const int64_t inWidth = GetWidth(input);
+    const int64_t outWidth = GetWidth(output);
+    const int64_t inHeight = GetHeight(input);
+    const int64_t outHeight = GetHeight(output);
+    const int64_t inChannels = GetChannels(input);
+    const int64_t outChannels = GetChannels(output);
+
+    CHECK_TENSOR_COMPARISON(inBatch == outBatch);
+    CHECK_TENSOR_COMPARISON(inWidth == outWidth);
+
+    if (IsInterleaved444(conversionCode)) {
+        CHECK_TENSOR_COMPARISON(inHeight == outHeight);
+        CHECK_TENSOR_COMPARISON(inChannels == 3);
+        CHECK_TENSOR_COMPARISON(outChannels == 3);
+    } else if (IsSemiPlanarToInterleaved(conversionCode)) {
+        CHECK_TENSOR_COMPARISON(inChannels == 1);
+        CHECK_TENSOR_COMPARISON(outChannels == 3 || outChannels == 4);
+        CHECK_TENSOR_COMPARISON(inWidth % 2 == 0);
+        CHECK_TENSOR_COMPARISON(inHeight % 3 == 0);
+        CHECK_TENSOR_COMPARISON(outHeight == (inHeight * 2) / 3);
+    } else {
+        CHECK_TENSOR_COMPARISON(inChannels == 3 || inChannels == 4);
+        CHECK_TENSOR_COMPARISON(outChannels == 1);
+        CHECK_TENSOR_COMPARISON(inWidth % 2 == 0);
+        CHECK_TENSOR_COMPARISON(inHeight % 2 == 0);
+        CHECK_TENSOR_COMPARISON(outHeight == (inHeight * 3) / 2);
+    }
+
+    Kernels::AdvCvtColorCoefficients coeff = GetCoefficients(colorSpec);
+    const bool bgr = IsBGRCode(conversionCode);
+    const int uidx = IsNV12Code(conversionCode) ? 0 : 1;
+
+    if (device == eDeviceType::GPU) {
+        dim3 blockSize(32, 16);
+
+        if (IsInterleaved444(conversionCode)) {
+            dim3 gridSize(DivUp(static_cast<int>(outWidth), blockSize.x), DivUp(static_cast<int>(outHeight), blockSize.y),
+                          static_cast<unsigned int>(outBatch));
+
+            switch (conversionCode) {
+                case COLOR_BGR2YUV:
+                    Kernels::Device::rgb_or_bgr_to_yuv_adv<uchar3, eSwizzle::ZYXW>
+                        <<<gridSize, blockSize, 0, stream>>>(ImageWrapper<uchar3>(input), ImageWrapper<uchar3>(output),
+                                                              coeff, kDelta);
+                    break;
+                case COLOR_RGB2YUV:
+                    Kernels::Device::rgb_or_bgr_to_yuv_adv<uchar3, eSwizzle::XYZW>
+                        <<<gridSize, blockSize, 0, stream>>>(ImageWrapper<uchar3>(input), ImageWrapper<uchar3>(output),
+                                                              coeff, kDelta);
+                    break;
+                case COLOR_YUV2BGR:
+                    Kernels::Device::yuv_to_rgb_or_bgr_adv<uchar3, eSwizzle::ZYXW>
+                        <<<gridSize, blockSize, 0, stream>>>(ImageWrapper<uchar3>(input), ImageWrapper<uchar3>(output),
+                                                              coeff, kDelta);
+                    break;
+                case COLOR_YUV2RGB:
+                    Kernels::Device::yuv_to_rgb_or_bgr_adv<uchar3, eSwizzle::XYZW>
+                        <<<gridSize, blockSize, 0, stream>>>(ImageWrapper<uchar3>(input), ImageWrapper<uchar3>(output),
+                                                              coeff, kDelta);
+                    break;
+                default: throw Exception("Unsupported conversion code.", eStatusType::INVALID_COMBINATION);
+            }
+        } else if (IsSemiPlanarToInterleaved(conversionCode)) {
+            dim3 gridSize(DivUp(static_cast<int>(outWidth), blockSize.x), DivUp(static_cast<int>(outHeight), blockSize.y),
+                          static_cast<unsigned int>(outBatch));
+
+            if (outChannels == 3) {
+                if (bgr) {
+                    Kernels::Device::nv12_or_nv21_to_rgb_or_bgr_adv<eSwizzle::ZYXW, ImageWrapper<uchar1>,
+                                                                     ImageWrapper<uchar3>, uchar3>
+                        <<<gridSize, blockSize, 0, stream>>>(ImageWrapper<uchar1>(input), ImageWrapper<uchar3>(output),
+                                                              coeff, kDelta, uidx);
+                } else {
+                    Kernels::Device::nv12_or_nv21_to_rgb_or_bgr_adv<eSwizzle::XYZW, ImageWrapper<uchar1>,
+                                                                     ImageWrapper<uchar3>, uchar3>
+                        <<<gridSize, blockSize, 0, stream>>>(ImageWrapper<uchar1>(input), ImageWrapper<uchar3>(output),
+                                                              coeff, kDelta, uidx);
+                }
+            } else {
+                if (bgr) {
+                    Kernels::Device::nv12_or_nv21_to_rgb_or_bgr_adv<eSwizzle::ZYXW, ImageWrapper<uchar1>,
+                                                                     ImageWrapper<uchar4>, uchar4>
+                        <<<gridSize, blockSize, 0, stream>>>(ImageWrapper<uchar1>(input), ImageWrapper<uchar4>(output),
+                                                              coeff, kDelta, uidx);
+                } else {
+                    Kernels::Device::nv12_or_nv21_to_rgb_or_bgr_adv<eSwizzle::XYZW, ImageWrapper<uchar1>,
+                                                                     ImageWrapper<uchar4>, uchar4>
+                        <<<gridSize, blockSize, 0, stream>>>(ImageWrapper<uchar1>(input), ImageWrapper<uchar4>(output),
+                                                              coeff, kDelta, uidx);
+                }
+            }
+        } else {
+            dim3 gridSize(DivUp(static_cast<int>(inWidth), blockSize.x), DivUp(static_cast<int>(inHeight), blockSize.y),
+                          static_cast<unsigned int>(inBatch));
+
+            if (inChannels == 3) {
+                if (bgr) {
+                    Kernels::Device::rgb_or_bgr_to_nv12_or_nv21_adv<uchar3, eSwizzle::ZYXW>
+                        <<<gridSize, blockSize, 0, stream>>>(ImageWrapper<uchar3>(input), ImageWrapper<uchar1>(output),
+                                                              coeff, kDelta, uidx);
+                } else {
+                    Kernels::Device::rgb_or_bgr_to_nv12_or_nv21_adv<uchar3, eSwizzle::XYZW>
+                        <<<gridSize, blockSize, 0, stream>>>(ImageWrapper<uchar3>(input), ImageWrapper<uchar1>(output),
+                                                              coeff, kDelta, uidx);
+                }
+            } else {
+                if (bgr) {
+                    Kernels::Device::rgb_or_bgr_to_nv12_or_nv21_adv<uchar4, eSwizzle::ZYXW>
+                        <<<gridSize, blockSize, 0, stream>>>(ImageWrapper<uchar4>(input), ImageWrapper<uchar1>(output),
+                                                              coeff, kDelta, uidx);
+                } else {
+                    Kernels::Device::rgb_or_bgr_to_nv12_or_nv21_adv<uchar4, eSwizzle::XYZW>
+                        <<<gridSize, blockSize, 0, stream>>>(ImageWrapper<uchar4>(input), ImageWrapper<uchar1>(output),
+                                                              coeff, kDelta, uidx);
+                }
+            }
+        }
+    } else {
+        if (IsInterleaved444(conversionCode)) {
+            switch (conversionCode) {
+                case COLOR_BGR2YUV:
+                    Kernels::Host::rgb_or_bgr_to_yuv_adv<uchar3, eSwizzle::ZYXW>(ImageWrapper<uchar3>(input),
+                                                                                  ImageWrapper<uchar3>(output), coeff,
+                                                                                  kDelta);
+                    break;
+                case COLOR_RGB2YUV:
+                    Kernels::Host::rgb_or_bgr_to_yuv_adv<uchar3, eSwizzle::XYZW>(ImageWrapper<uchar3>(input),
+                                                                                  ImageWrapper<uchar3>(output), coeff,
+                                                                                  kDelta);
+                    break;
+                case COLOR_YUV2BGR:
+                    Kernels::Host::yuv_to_rgb_or_bgr_adv<uchar3, eSwizzle::ZYXW>(ImageWrapper<uchar3>(input),
+                                                                                  ImageWrapper<uchar3>(output), coeff,
+                                                                                  kDelta);
+                    break;
+                case COLOR_YUV2RGB:
+                    Kernels::Host::yuv_to_rgb_or_bgr_adv<uchar3, eSwizzle::XYZW>(ImageWrapper<uchar3>(input),
+                                                                                  ImageWrapper<uchar3>(output), coeff,
+                                                                                  kDelta);
+                    break;
+                default: throw Exception("Unsupported conversion code.", eStatusType::INVALID_COMBINATION);
+            }
+        } else if (IsSemiPlanarToInterleaved(conversionCode)) {
+            if (outChannels == 3) {
+                if (bgr) {
+                    Kernels::Host::nv12_or_nv21_to_rgb_or_bgr_adv<eSwizzle::ZYXW, ImageWrapper<uchar1>,
+                                                                   ImageWrapper<uchar3>, uchar3>(
+                        ImageWrapper<uchar1>(input), ImageWrapper<uchar3>(output), coeff, kDelta, uidx);
+                } else {
+                    Kernels::Host::nv12_or_nv21_to_rgb_or_bgr_adv<eSwizzle::XYZW, ImageWrapper<uchar1>,
+                                                                   ImageWrapper<uchar3>, uchar3>(
+                        ImageWrapper<uchar1>(input), ImageWrapper<uchar3>(output), coeff, kDelta, uidx);
+                }
+            } else {
+                if (bgr) {
+                    Kernels::Host::nv12_or_nv21_to_rgb_or_bgr_adv<eSwizzle::ZYXW, ImageWrapper<uchar1>,
+                                                                   ImageWrapper<uchar4>, uchar4>(
+                        ImageWrapper<uchar1>(input), ImageWrapper<uchar4>(output), coeff, kDelta, uidx);
+                } else {
+                    Kernels::Host::nv12_or_nv21_to_rgb_or_bgr_adv<eSwizzle::XYZW, ImageWrapper<uchar1>,
+                                                                   ImageWrapper<uchar4>, uchar4>(
+                        ImageWrapper<uchar1>(input), ImageWrapper<uchar4>(output), coeff, kDelta, uidx);
+                }
+            }
+        } else {
+            if (inChannels == 3) {
+                if (bgr) {
+                    Kernels::Host::rgb_or_bgr_to_nv12_or_nv21_adv<uchar3, eSwizzle::ZYXW>(
+                        ImageWrapper<uchar3>(input), ImageWrapper<uchar1>(output), coeff, kDelta, uidx);
+                } else {
+                    Kernels::Host::rgb_or_bgr_to_nv12_or_nv21_adv<uchar3, eSwizzle::XYZW>(
+                        ImageWrapper<uchar3>(input), ImageWrapper<uchar1>(output), coeff, kDelta, uidx);
+                }
+            } else {
+                if (bgr) {
+                    Kernels::Host::rgb_or_bgr_to_nv12_or_nv21_adv<uchar4, eSwizzle::ZYXW>(
+                        ImageWrapper<uchar4>(input), ImageWrapper<uchar1>(output), coeff, kDelta, uidx);
+                } else {
+                    Kernels::Host::rgb_or_bgr_to_nv12_or_nv21_adv<uchar4, eSwizzle::XYZW>(
+                        ImageWrapper<uchar4>(input), ImageWrapper<uchar1>(output), coeff, kDelta, uidx);
+                }
+            }
+        }
+    }
+}
+
+}  // namespace roccv

--- a/tests/pybind/CMakeLists.txt
+++ b/tests/pybind/CMakeLists.txt
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# Copyright (c) 2023 Advanced Micro Devices, Inc.
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,7 +23,7 @@
 # SOFTWARE.
 #
 ################################################################################
-cmake_minimum_required(VERSION 3.24)
+cmake_minimum_required(VERSION 3.15)
 
 project(roccv-pybind-test)
 
@@ -129,63 +129,70 @@ if(Python3_FOUND AND ROCCV_PYBIND_SCRIPTS)
   )
   set_property(TEST roccv_pybind_test_op_cvt_color PROPERTY ENVIRONMENT "PYTHONPATH=${ROCM_PATH}/lib:$PYTHONPATH")
 
-  # 11 - Test:OP -- Composite
+  # 11 - Test:OP -- Advanced Color Convert
+  add_test(NAME roccv_pybind_test_op_adv_cvt_color
+    COMMAND ${Python3_EXECUTABLE} -m pytest ${CMAKE_CURRENT_SOURCE_DIR}/python/test_op_adv_cvt_color.py ${PYTEST_FLAGS}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+  )
+  set_property(TEST roccv_pybind_test_op_adv_cvt_color PROPERTY ENVIRONMENT "PYTHONPATH=${ROCM_PATH}/lib:$PYTHONPATH")
+
+  # 12 - Test:OP -- Composite
   add_test(NAME roccv_pybind_test_op_composite
     COMMAND ${Python3_EXECUTABLE} -m pytest ${CMAKE_CURRENT_SOURCE_DIR}/python/test_op_composite.py ${PYTEST_FLAGS}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   )
   set_property(TEST roccv_pybind_test_op_composite PROPERTY ENVIRONMENT "PYTHONPATH=${ROCM_PATH}/lib:$PYTHONPATH")
 
-  # 12 - Test:OP -- Custom Crop
+  # 13 - Test:OP -- Custom Crop
   add_test(NAME roccv_pybind_test_op_custom_crop
     COMMAND ${Python3_EXECUTABLE} -m pytest ${CMAKE_CURRENT_SOURCE_DIR}/python/test_op_custom_crop.py ${PYTEST_FLAGS}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   )
   set_property(TEST roccv_pybind_test_op_custom_crop PROPERTY ENVIRONMENT "PYTHONPATH=${ROCM_PATH}/lib:$PYTHONPATH")
 
-  # 13 - Test:OP -- Flip
+  # 14 - Test:OP -- Flip
   add_test(NAME roccv_pybind_test_op_flip
     COMMAND ${Python3_EXECUTABLE} -m pytest ${CMAKE_CURRENT_SOURCE_DIR}/python/test_op_flip.py ${PYTEST_FLAGS}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   )
   set_property(TEST roccv_pybind_test_op_flip PROPERTY ENVIRONMENT "PYTHONPATH=${ROCM_PATH}/lib:$PYTHONPATH")
 
-  # 14 - Test:OP -- Gamma Contrast
+  # 15 - Test:OP -- Gamma Contrast
   add_test(NAME roccv_pybind_test_op_gamma_contrast
     COMMAND ${Python3_EXECUTABLE} -m pytest ${CMAKE_CURRENT_SOURCE_DIR}/python/test_op_gamma_contrast.py ${PYTEST_FLAGS}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   )
   set_property(TEST roccv_pybind_test_op_gamma_contrast PROPERTY ENVIRONMENT "PYTHONPATH=${ROCM_PATH}/lib:$PYTHONPATH")
 
-  # 15 - Test:OP -- Remap
+  # 16 - Test:OP -- Remap
   add_test(NAME roccv_pybind_test_op_remap
     COMMAND ${Python3_EXECUTABLE} -m pytest ${CMAKE_CURRENT_SOURCE_DIR}/python/test_op_remap.py ${PYTEST_FLAGS}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   )
   set_property(TEST roccv_pybind_test_op_remap PROPERTY ENVIRONMENT "PYTHONPATH=${ROCM_PATH}/lib:$PYTHONPATH")
 
-  # 16 - Test:OP -- Resize
+  # 17 - Test:OP -- Resize
   add_test(NAME roccv_pybind_test_op_resize
     COMMAND ${Python3_EXECUTABLE} -m pytest ${CMAKE_CURRENT_SOURCE_DIR}/python/test_op_resize.py ${PYTEST_FLAGS}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   )
   set_property(TEST roccv_pybind_test_op_resize PROPERTY ENVIRONMENT "PYTHONPATH=${ROCM_PATH}/lib:$PYTHONPATH")
 
-  # 17 - Test:OP -- Warp Affine
+  # 18 - Test:OP -- Warp Affine
   add_test(NAME roccv_pybind_test_op_warp_affine
     COMMAND ${Python3_EXECUTABLE} -m pytest ${CMAKE_CURRENT_SOURCE_DIR}/python/test_op_warp_affine.py ${PYTEST_FLAGS}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   )
   set_property(TEST roccv_pybind_test_op_warp_affine PROPERTY ENVIRONMENT "PYTHONPATH=${ROCM_PATH}/lib:$PYTHONPATH")
 
-  # 18 - Test:OP -- CopyMakeBorder
+  # 19 - Test:OP -- CopyMakeBorder
   add_test(NAME roccv_pybind_test_op_copy_make_border
     COMMAND ${Python3_EXECUTABLE} -m pytest ${CMAKE_CURRENT_SOURCE_DIR}/python/test_op_copy_make_border.py ${PYTEST_FLAGS}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   )
   set_property(TEST roccv_pybind_test_op_copy_make_border PROPERTY ENVIRONMENT "PYTHONPATH=${ROCM_PATH}/lib:$PYTHONPATH")
 
-  # 19 - Test:OP -- Center Crop
+  # 20 - Test:OP -- Center Crop
   add_test(NAME roccv_pybind_test_op_center_crop
     COMMAND ${Python3_EXECUTABLE} -m pytest ${CMAKE_CURRENT_SOURCE_DIR}/python/test_op_center_crop.py ${PYTEST_FLAGS}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}

--- a/tests/roccv/cpp/src/tests/operators/test_op_adv_cvt_color.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_adv_cvt_color.cpp
@@ -1,0 +1,335 @@
+/**
+Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#include <core/detail/casting.hpp>
+#include <core/hip_assert.h>
+#include <op_adv_cvt_color.hpp>
+
+#include <array>
+
+#include "test_helpers.hpp"
+
+using namespace roccv;
+using namespace roccv::tests;
+
+namespace {
+
+struct Coeff {
+    float r2y;
+    float g2y;
+    float b2y;
+    float b2u;
+    float r2v;
+
+    float v2r;
+    float u2g;
+    float v2g;
+    float u2b;
+};
+
+Coeff GetCoeff(eColorSpec spec) {
+    switch (spec) {
+        case BT601:
+            return {0.299f, 0.587f, 0.114f, 0.564334086f, 0.713266762f, 1.402f, -0.344f, -0.714f, 1.772f};
+        case BT709:
+            return {0.2126f, 0.7152f, 0.0722f, 0.538909248f, 0.63500127f, 1.5748f, -0.187324f, -0.468124f, 1.8556f};
+        case BT2020:
+            return {0.2627f, 0.6780f, 0.0593f, 0.531519082f, 0.678150007f, 1.4746f, -0.16455f, -0.57135f, 1.8814f};
+        default: throw std::runtime_error("Unsupported color spec");
+    }
+}
+
+bool IsSemiPlanarToInterleaved(eColorConversionCode code) {
+    switch (code) {
+        case COLOR_YUV2RGB_NV12:
+        case COLOR_YUV2BGR_NV12:
+        case COLOR_YUV2RGB_NV21:
+        case COLOR_YUV2BGR_NV21: return true;
+        default: return false;
+    }
+}
+
+bool IsInterleavedToSemiPlanar(eColorConversionCode code) {
+    switch (code) {
+        case COLOR_RGB2YUV_NV12:
+        case COLOR_BGR2YUV_NV12:
+        case COLOR_RGB2YUV_NV21:
+        case COLOR_BGR2YUV_NV21: return true;
+        default: return false;
+    }
+}
+
+bool IsInterleaved444(eColorConversionCode code) {
+    switch (code) {
+        case COLOR_RGB2YUV:
+        case COLOR_BGR2YUV:
+        case COLOR_YUV2RGB:
+        case COLOR_YUV2BGR: return true;
+        default: return false;
+    }
+}
+
+bool IsBGRCode(eColorConversionCode code) {
+    switch (code) {
+        case COLOR_BGR2YUV:
+        case COLOR_YUV2BGR:
+        case COLOR_YUV2BGR_NV12:
+        case COLOR_YUV2BGR_NV21:
+        case COLOR_BGR2YUV_NV12:
+        case COLOR_BGR2YUV_NV21: return true;
+        default: return false;
+    }
+}
+
+bool IsNV12Code(eColorConversionCode code) {
+    switch (code) {
+        case COLOR_YUV2RGB_NV12:
+        case COLOR_YUV2BGR_NV12:
+        case COLOR_RGB2YUV_NV12:
+        case COLOR_BGR2YUV_NV12: return true;
+        default: return false;
+    }
+}
+
+inline int idx3(int x, int y, int width, int c) {
+    return (y * width + x) * 3 + c;
+}
+
+std::vector<uint8_t> GoldenInterleaved444(const std::vector<uint8_t> &input, int samples, int width, int height,
+                                          eColorConversionCode code, eColorSpec spec) {
+    std::vector<uint8_t> output(input.size(), 0);
+    const Coeff coeff = GetCoeff(spec);
+
+    for (int n = 0; n < samples; n++) {
+        int batchOffset = n * width * height * 3;
+
+        for (int y = 0; y < height; y++) {
+            for (int x = 0; x < width; x++) {
+                int i = batchOffset + idx3(x, y, width, 0);
+
+                switch (code) {
+                    case COLOR_RGB2YUV:
+                    case COLOR_BGR2YUV: {
+                        float r = input[i + (IsBGRCode(code) ? 2 : 0)];
+                        float g = input[i + 1];
+                        float b = input[i + (IsBGRCode(code) ? 0 : 2)];
+
+                        float yv = r * coeff.r2y + g * coeff.g2y + b * coeff.b2y;
+                        float u = (b - yv) * coeff.b2u + 128.0f;
+                        float v = (r - yv) * coeff.r2v + 128.0f;
+
+                        output[i + 0] = roccv::detail::SaturateCast<uint8_t>(yv);
+                        output[i + 1] = roccv::detail::SaturateCast<uint8_t>(u);
+                        output[i + 2] = roccv::detail::SaturateCast<uint8_t>(v);
+                        break;
+                    }
+                    case COLOR_YUV2RGB:
+                    case COLOR_YUV2BGR: {
+                        float yv = input[i + 0];
+                        float u = input[i + 1];
+                        float v = input[i + 2];
+
+                        float r = yv + (v - 128.0f) * coeff.v2r;
+                        float g = yv + (u - 128.0f) * coeff.u2g + (v - 128.0f) * coeff.v2g;
+                        float b = yv + (u - 128.0f) * coeff.u2b;
+
+                        output[i + (IsBGRCode(code) ? 0 : 2)] = roccv::detail::SaturateCast<uint8_t>(b);
+                        output[i + 1] = roccv::detail::SaturateCast<uint8_t>(g);
+                        output[i + (IsBGRCode(code) ? 2 : 0)] = roccv::detail::SaturateCast<uint8_t>(r);
+                        break;
+                    }
+                    default: throw std::runtime_error("Invalid interleaved code");
+                }
+            }
+        }
+    }
+
+    return output;
+}
+
+std::vector<uint8_t> GoldenInterleavedToSemiPlanar(const std::vector<uint8_t> &input, int samples, int width,
+                                                   int height, eColorConversionCode code, eColorSpec spec) {
+    std::vector<uint8_t> output(samples * width * height * 3 / 2, 0);
+    const Coeff coeff = GetCoeff(spec);
+    const bool bgr = IsBGRCode(code);
+    const int uidx = IsNV12Code(code) ? 0 : 1;
+
+    for (int n = 0; n < samples; n++) {
+        int rgbBase = n * width * height * 3;
+        int nvBase = n * width * height * 3 / 2;
+
+        for (int y = 0; y < height; y++) {
+            for (int x = 0; x < width; x++) {
+                int src = rgbBase + idx3(x, y, width, 0);
+                float r = input[src + (bgr ? 2 : 0)];
+                float g = input[src + 1];
+                float b = input[src + (bgr ? 0 : 2)];
+
+                float yv = r * coeff.r2y + g * coeff.g2y + b * coeff.b2y;
+                output[nvBase + y * width + x] = roccv::detail::SaturateCast<uint8_t>(yv);
+            }
+        }
+
+        for (int y = 0; y < height; y += 2) {
+            for (int x = 0; x < width; x += 2) {
+                float uSum = 0.0f;
+                float vSum = 0.0f;
+
+                for (int yy = 0; yy < 2; yy++) {
+                    for (int xx = 0; xx < 2; xx++) {
+                        int src = rgbBase + idx3(x + xx, y + yy, width, 0);
+                        float r = input[src + (bgr ? 2 : 0)];
+                        float g = input[src + 1];
+                        float b = input[src + (bgr ? 0 : 2)];
+
+                        float yv = r * coeff.r2y + g * coeff.g2y + b * coeff.b2y;
+                        uSum += (b - yv) * coeff.b2u;
+                        vSum += (r - yv) * coeff.r2v;
+                    }
+                }
+
+                int uvRow = height + y / 2;
+                int uvCol = x;
+                output[nvBase + uvRow * width + uvCol + uidx] =
+                    roccv::detail::SaturateCast<uint8_t>(uSum * 0.25f + 128.0f);
+                output[nvBase + uvRow * width + uvCol + (1 - uidx)] =
+                    roccv::detail::SaturateCast<uint8_t>(vSum * 0.25f + 128.0f);
+            }
+        }
+    }
+
+    return output;
+}
+
+std::vector<uint8_t> GoldenSemiPlanarToInterleaved(const std::vector<uint8_t> &input, int samples, int width,
+                                                   int height, eColorConversionCode code, eColorSpec spec) {
+    std::vector<uint8_t> output(samples * width * height * 3, 0);
+    const Coeff coeff = GetCoeff(spec);
+    const bool bgr = IsBGRCode(code);
+    const int uidx = IsNV12Code(code) ? 0 : 1;
+
+    for (int n = 0; n < samples; n++) {
+        int rgbBase = n * width * height * 3;
+        int nvBase = n * width * height * 3 / 2;
+
+        for (int y = 0; y < height; y++) {
+            for (int x = 0; x < width; x++) {
+                float yv = input[nvBase + y * width + x];
+                int uvRow = height + y / 2;
+                int uvCol = x & ~1;
+                float u = input[nvBase + uvRow * width + uvCol + uidx];
+                float v = input[nvBase + uvRow * width + uvCol + (1 - uidx)];
+
+                float r = yv + (v - 128.0f) * coeff.v2r;
+                float g = yv + (u - 128.0f) * coeff.u2g + (v - 128.0f) * coeff.v2g;
+                float b = yv + (u - 128.0f) * coeff.u2b;
+
+                int dst = rgbBase + idx3(x, y, width, 0);
+                output[dst + (bgr ? 0 : 2)] = roccv::detail::SaturateCast<uint8_t>(b);
+                output[dst + 1] = roccv::detail::SaturateCast<uint8_t>(g);
+                output[dst + (bgr ? 2 : 0)] = roccv::detail::SaturateCast<uint8_t>(r);
+            }
+        }
+    }
+
+    return output;
+}
+
+void TestCorrectness(int samples, int width, int height, eColorConversionCode code, eColorSpec spec,
+                     eDeviceType device) {
+    Tensor inputTensor = IsSemiPlanarToInterleaved(code)
+                             ? Tensor(samples, {width, height * 3 / 2}, FMT_U8, device)
+                             : Tensor(samples, {width, height}, FMT_RGB8, device);
+
+    Tensor outputTensor = IsInterleavedToSemiPlanar(code)
+                              ? Tensor(samples, {width, height * 3 / 2}, FMT_U8, device)
+                              : Tensor(samples, {width, height}, FMT_RGB8, device);
+
+    std::vector<uint8_t> inputData(inputTensor.shape().size());
+    FillVector(inputData);
+    CopyVectorIntoTensor(inputTensor, inputData);
+
+    hipStream_t stream;
+    HIP_VALIDATE_NO_ERRORS(hipStreamCreate(&stream));
+
+    AdvCvtColor op;
+    op(stream, inputTensor, outputTensor, code, spec, device);
+
+    HIP_VALIDATE_NO_ERRORS(hipStreamSynchronize(stream));
+    HIP_VALIDATE_NO_ERRORS(hipStreamDestroy(stream));
+
+    std::vector<uint8_t> outputActual(outputTensor.shape().size());
+    CopyTensorIntoVector(outputActual, outputTensor);
+
+    std::vector<uint8_t> outputGolden;
+    if (IsInterleaved444(code)) {
+        outputGolden = GoldenInterleaved444(inputData, samples, width, height, code, spec);
+    } else if (IsInterleavedToSemiPlanar(code)) {
+        outputGolden = GoldenInterleavedToSemiPlanar(inputData, samples, width, height, code, spec);
+    } else {
+        outputGolden = GoldenSemiPlanarToInterleaved(inputData, samples, width, height, code, spec);
+    }
+
+    CompareVectorsNear(outputActual, outputGolden, 0.01);
+}
+
+}  // namespace
+
+int main(int argc, char **argv) {
+    TEST_CASES_BEGIN();
+
+    std::array<eColorSpec, 3> specs = {BT601, BT709, BT2020};
+
+    for (auto spec : specs) {
+        TEST_CASE(TestCorrectness(2, 64, 48, COLOR_RGB2YUV, spec, eDeviceType::GPU));
+        TEST_CASE(TestCorrectness(2, 64, 48, COLOR_BGR2YUV, spec, eDeviceType::GPU));
+        TEST_CASE(TestCorrectness(2, 64, 48, COLOR_YUV2RGB, spec, eDeviceType::GPU));
+        TEST_CASE(TestCorrectness(2, 64, 48, COLOR_YUV2BGR, spec, eDeviceType::GPU));
+
+        TEST_CASE(TestCorrectness(2, 64, 48, COLOR_RGB2YUV_NV12, spec, eDeviceType::GPU));
+        TEST_CASE(TestCorrectness(2, 64, 48, COLOR_BGR2YUV_NV12, spec, eDeviceType::GPU));
+        TEST_CASE(TestCorrectness(2, 64, 48, COLOR_RGB2YUV_NV21, spec, eDeviceType::GPU));
+        TEST_CASE(TestCorrectness(2, 64, 48, COLOR_BGR2YUV_NV21, spec, eDeviceType::GPU));
+
+        TEST_CASE(TestCorrectness(2, 64, 48, COLOR_YUV2RGB_NV12, spec, eDeviceType::GPU));
+        TEST_CASE(TestCorrectness(2, 64, 48, COLOR_YUV2BGR_NV12, spec, eDeviceType::GPU));
+        TEST_CASE(TestCorrectness(2, 64, 48, COLOR_YUV2RGB_NV21, spec, eDeviceType::GPU));
+        TEST_CASE(TestCorrectness(2, 64, 48, COLOR_YUV2BGR_NV21, spec, eDeviceType::GPU));
+
+        TEST_CASE(TestCorrectness(2, 64, 48, COLOR_RGB2YUV, spec, eDeviceType::CPU));
+        TEST_CASE(TestCorrectness(2, 64, 48, COLOR_BGR2YUV, spec, eDeviceType::CPU));
+        TEST_CASE(TestCorrectness(2, 64, 48, COLOR_YUV2RGB, spec, eDeviceType::CPU));
+        TEST_CASE(TestCorrectness(2, 64, 48, COLOR_YUV2BGR, spec, eDeviceType::CPU));
+
+        TEST_CASE(TestCorrectness(2, 64, 48, COLOR_RGB2YUV_NV12, spec, eDeviceType::CPU));
+        TEST_CASE(TestCorrectness(2, 64, 48, COLOR_BGR2YUV_NV12, spec, eDeviceType::CPU));
+        TEST_CASE(TestCorrectness(2, 64, 48, COLOR_RGB2YUV_NV21, spec, eDeviceType::CPU));
+        TEST_CASE(TestCorrectness(2, 64, 48, COLOR_BGR2YUV_NV21, spec, eDeviceType::CPU));
+
+        TEST_CASE(TestCorrectness(2, 64, 48, COLOR_YUV2RGB_NV12, spec, eDeviceType::CPU));
+        TEST_CASE(TestCorrectness(2, 64, 48, COLOR_YUV2BGR_NV12, spec, eDeviceType::CPU));
+        TEST_CASE(TestCorrectness(2, 64, 48, COLOR_YUV2RGB_NV21, spec, eDeviceType::CPU));
+        TEST_CASE(TestCorrectness(2, 64, 48, COLOR_YUV2BGR_NV21, spec, eDeviceType::CPU));
+    }
+
+    TEST_CASES_END();
+}

--- a/tests/roccv/python/test_op_adv_cvt_color.py
+++ b/tests/roccv/python/test_op_adv_cvt_color.py
@@ -1,0 +1,106 @@
+# ##############################################################################
+# Copyright (c)  - 2026 Advanced Micro Devices, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# ##############################################################################
+
+import pytest
+import rocpycv
+
+from test_helpers import generate_tensor, compare_tensors
+
+
+INTERLEAVED_444_CODES = [
+    rocpycv.eColorConversionCode.COLOR_RGB2YUV,
+    rocpycv.eColorConversionCode.COLOR_BGR2YUV,
+    rocpycv.eColorConversionCode.COLOR_YUV2RGB,
+    rocpycv.eColorConversionCode.COLOR_YUV2BGR,
+]
+
+INTERLEAVED_TO_SEMIPLANAR_CODES = [
+    rocpycv.eColorConversionCode.COLOR_RGB2YUV_NV12,
+    rocpycv.eColorConversionCode.COLOR_BGR2YUV_NV12,
+    rocpycv.eColorConversionCode.COLOR_RGB2YUV_NV21,
+    rocpycv.eColorConversionCode.COLOR_BGR2YUV_NV21,
+]
+
+SEMIPLANAR_TO_INTERLEAVED_CODES = [
+    rocpycv.eColorConversionCode.COLOR_YUV2RGB_NV12,
+    rocpycv.eColorConversionCode.COLOR_YUV2BGR_NV12,
+    rocpycv.eColorConversionCode.COLOR_YUV2RGB_NV21,
+    rocpycv.eColorConversionCode.COLOR_YUV2BGR_NV21,
+]
+
+SPECS = [
+    rocpycv.eColorSpec.BT601,
+    rocpycv.eColorSpec.BT709,
+    rocpycv.eColorSpec.BT2020,
+]
+
+
+@pytest.mark.parametrize("device", [rocpycv.eDeviceType.GPU, rocpycv.eDeviceType.CPU])
+@pytest.mark.parametrize("dtype", [rocpycv.eDataType.U8])
+@pytest.mark.parametrize("spec", SPECS)
+@pytest.mark.parametrize("code", INTERLEAVED_444_CODES)
+@pytest.mark.parametrize("samples,width,height", [[1, 64, 48], [2, 128, 72]])
+def test_op_advcvtcolor_interleaved444(samples, height, width, code, spec, dtype, device):
+    input_tensor = generate_tensor(samples, width, height, 3, dtype, device)
+    output_golden = rocpycv.Tensor([samples, height, width, 3], rocpycv.eTensorLayout.NHWC, dtype, device)
+
+    stream = rocpycv.Stream()
+    output = rocpycv.advcvtcolor(input_tensor, code, spec, stream, device)
+    rocpycv.advcvtcolor_into(output_golden, input_tensor, code, spec, stream, device)
+    stream.synchronize()
+
+    compare_tensors(output, output_golden)
+
+
+@pytest.mark.parametrize("device", [rocpycv.eDeviceType.GPU, rocpycv.eDeviceType.CPU])
+@pytest.mark.parametrize("dtype", [rocpycv.eDataType.U8])
+@pytest.mark.parametrize("spec", SPECS)
+@pytest.mark.parametrize("code", INTERLEAVED_TO_SEMIPLANAR_CODES)
+@pytest.mark.parametrize("samples,width,height", [[1, 64, 48], [2, 128, 72]])
+def test_op_advcvtcolor_interleaved_to_semiplanar(samples, height, width, code, spec, dtype, device):
+    input_tensor = generate_tensor(samples, width, height, 3, dtype, device)
+    output_golden = rocpycv.Tensor([samples, (height * 3) // 2, width, 1], rocpycv.eTensorLayout.NHWC, dtype, device)
+
+    stream = rocpycv.Stream()
+    output = rocpycv.advcvtcolor(input_tensor, code, spec, stream, device)
+    rocpycv.advcvtcolor_into(output_golden, input_tensor, code, spec, stream, device)
+    stream.synchronize()
+
+    compare_tensors(output, output_golden)
+
+
+@pytest.mark.parametrize("device", [rocpycv.eDeviceType.GPU, rocpycv.eDeviceType.CPU])
+@pytest.mark.parametrize("dtype", [rocpycv.eDataType.U8])
+@pytest.mark.parametrize("spec", SPECS)
+@pytest.mark.parametrize("code", SEMIPLANAR_TO_INTERLEAVED_CODES)
+@pytest.mark.parametrize("samples,width,height", [[1, 64, 48], [2, 128, 72]])
+def test_op_advcvtcolor_semiplanar_to_interleaved(samples, height, width, code, spec, dtype, device):
+    input_tensor = generate_tensor(samples, width, (height * 3) // 2, 1, dtype, device)
+    output_golden = rocpycv.Tensor([samples, height, width, 3], rocpycv.eTensorLayout.NHWC, dtype, device)
+
+    stream = rocpycv.Stream()
+    output = rocpycv.advcvtcolor(input_tensor, code, spec, stream, device)
+    rocpycv.advcvtcolor_into(output_golden, input_tensor, code, spec, stream, device)
+    stream.synchronize()
+
+    compare_tensors(output, output_golden)


### PR DESCRIPTION
## Motivation

Essam's initial implementation of the refactored Advanced Color Convert. 
Please see technical details for implementation summary.

## Technical Details

A new operator, roccv::AdvCvtColor, was implemented and integrated with rocCV conventions.

Main capabilities added:

Explicit color-space matrix selection by color spec:
- BT601
- BT709
- BT2020

**--- Supported conversion families ---**
Interleaved 4:4:4 conversions: 
- COLOR_RGB2YUV
- COLOR_BGR2YUV
- COLOR_YUV2RGB
- COLOR_YUV2BGR

Semi-planar 4:2:0 conversions: 
- COLOR_YUV2RGB_NV12
- COLOR_YUV2BGR_NV12
- COLOR_YUV2RGB_NV21
- COLOR_YUV2BGR_NV21
- COLOR_RGB2YUV_NV12
- COLOR_BGR2YUV_NV12
- COLOR_RGB2YUV_NV21
- COLOR_BGR2YUV_NV21

Execution backends:
- GPU (HIP kernels)
- CPU (host kernels with OpenMP-style pattern used by rocCV)

## Test Plan

Tests added for C++ and Python implementations of this operator.

## Test Result

C++ and Python tests all pass.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
