### PR TITLE
[Refactor] Refactored the remap operator to support all remap types

### DIFF
--- a/include/core/detail/internal_structs.hpp
+++ b/include/core/detail/internal_structs.hpp
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "core/detail/type_traits.hpp"
+#include <hip/hip_runtime.h>
 
 namespace roccv::detail {
     

--- a/include/core/detail/internal_structs.hpp
+++ b/include/core/detail/internal_structs.hpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#pragma once
+
+#include "core/detail/type_traits.hpp"
+
+namespace roccv::detail {
+    
+struct RemapParams
+{
+    float2 srcScale, mapScale, valScale, srcOffset;
+    float dstOffset;
+};
+
+} // namespace roccv::detail

--- a/include/core/image_format.hpp
+++ b/include/core/image_format.hpp
@@ -75,6 +75,9 @@ constexpr ImageFormat FMT_S32(eDataType::DATA_TYPE_S32, 1, eSwizzle::XYZW);
 // Single plane with one 32-bit floating point channel.
 constexpr ImageFormat FMT_F32(eDataType::DATA_TYPE_F32, 1, eSwizzle::XYZW);
 
+// Single plane with two 32-bit floating point channels.
+constexpr ImageFormat FMT_2F32(eDataType::DATA_TYPE_F32, 2, eSwizzle::XYZW);
+
 // Single plane with one 64-bit floating point channel.
 constexpr ImageFormat FMT_F64(eDataType::DATA_TYPE_F64, 1, eSwizzle::XYZW);
 

--- a/include/kernels/device/remap_device.hpp
+++ b/include/kernels/device/remap_device.hpp
@@ -22,21 +22,38 @@ THE SOFTWARE.
 #pragma once
 
 #include <hip/hip_runtime.h>
-
+#include "core/detail/internal_structs.hpp"
 #include "operator_types.h"
 
 namespace Kernels {
 namespace Device {
+
+using namespace roccv::detail;
+    
 template <typename SrcWrapper, typename DstWrapper, typename MapWrapper>
-__global__ void remap(SrcWrapper input, DstWrapper output, MapWrapper map) {
+__global__ void remap(SrcWrapper input, DstWrapper output, MapWrapper map, bool alignCorners, int mapBatchSize, RemapParams params) {
     const int x = blockDim.x * blockIdx.x + threadIdx.x;
     const int y = blockDim.y * blockIdx.y + threadIdx.y;
     const int b = blockIdx.z;
 
+    float2 srcCoord = make_float2(0.f, 0.f);
+    float2 mapCoord = make_float2(0.f, 0.f);
+    float2 dstCoord = make_float2(0.f, 0.f);
+
     if (x >= output.width() || y >= output.height()) return;
+
+    dstCoord.x = static_cast<float>(x);
+    dstCoord.y = static_cast<float>(y);
+                
+    mapCoord.x = (dstCoord.x + params.dstOffset) * params.mapScale.x;
+    mapCoord.y = (dstCoord.y + params.dstOffset) * params.mapScale.y;
     
-    float2 mapCoordinates = map.at(b, y, x, 0);
-    output.at(b, y, x, 0) = input.at(b, mapCoordinates.y, mapCoordinates.x, 0);
+    float2 mapValue = map.at((mapBatchSize == 1 ? 0 : b), mapCoord.y, mapCoord.x, 0);
+
+    srcCoord.x = dstCoord.x * params.srcScale.x + mapValue.x * params.valScale.x + params.srcOffset.x;
+    srcCoord.y = dstCoord.y * params.srcScale.y + mapValue.y * params.valScale.y + params.srcOffset.y;
+
+    output.at(b, y, x, 0) = input.at(b, srcCoord.y, srcCoord.x, 0);
 }
 };  // namespace Device
 };  // namespace Kernels

--- a/include/kernels/device/remap_device.hpp
+++ b/include/kernels/device/remap_device.hpp
@@ -31,7 +31,7 @@ namespace Device {
 using namespace roccv::detail;
     
 template <typename SrcWrapper, typename DstWrapper, typename MapWrapper>
-__global__ void remap(SrcWrapper input, DstWrapper output, MapWrapper map, bool alignCorners, int mapBatchSize, RemapParams params) {
+__global__ void remap(SrcWrapper input, DstWrapper output, MapWrapper map, int mapBatchSize, RemapParams params) {
     const int x = blockDim.x * blockIdx.x + threadIdx.x;
     const int y = blockDim.y * blockIdx.y + threadIdx.y;
     const int b = blockIdx.z;

--- a/include/kernels/host/remap_host.hpp
+++ b/include/kernels/host/remap_host.hpp
@@ -32,7 +32,7 @@ namespace Host {
 using namespace roccv::detail;
     
 template <typename SrcWrapper, typename DstWrapper, typename MapWrapper>
-void remap(SrcWrapper input, DstWrapper output, MapWrapper map, bool alignCorners, int mapBatchSize, RemapParams params) {
+void remap(SrcWrapper input, DstWrapper output, MapWrapper map, int mapBatchSize, RemapParams params) {
     
     float2 srcCoord = make_float2(0.f, 0.f);
     float2 mapCoord = make_float2(0.f, 0.f);

--- a/include/kernels/host/remap_host.hpp
+++ b/include/kernels/host/remap_host.hpp
@@ -23,16 +23,37 @@ THE SOFTWARE.
 #pragma once
 
 #include <hip/hip_runtime.h>
+#include "core/detail/internal_structs.hpp"
+#include "operator_types.h"
 
 namespace Kernels {
 namespace Host {
+
+using namespace roccv::detail;
+    
 template <typename SrcWrapper, typename DstWrapper, typename MapWrapper>
-void remap(SrcWrapper input, DstWrapper output, MapWrapper map) {
+void remap(SrcWrapper input, DstWrapper output, MapWrapper map, bool alignCorners, int mapBatchSize, RemapParams params) {
+    
+    float2 srcCoord = make_float2(0.f, 0.f);
+    float2 mapCoord = make_float2(0.f, 0.f);
+    float2 dstCoord = make_float2(0.f, 0.f);
+    
     for (int b = 0; b < output.batches(); b++) {
         for (int y = 0; y < output.height(); y++) {
             for (int x = 0; x < output.width(); x++) {
-                float2 mapCoordinates = map.at(b, y, x, 0);
-                output.at(b, y, x, 0) = input.at(b, mapCoordinates.y, mapCoordinates.x, 0);
+                
+                dstCoord.x = static_cast<float>(x);
+                dstCoord.y = static_cast<float>(y);
+                
+                mapCoord.x = (dstCoord.x + params.dstOffset) * params.mapScale.x;
+                mapCoord.y = (dstCoord.y + params.dstOffset) * params.mapScale.y;
+                
+                float2 mapValue = map.at((mapBatchSize == 1 ? 0 : b), mapCoord.y, mapCoord.x, 0);
+
+                srcCoord.x = dstCoord.x * params.srcScale.x + mapValue.x * params.valScale.x + params.srcOffset.x;
+                srcCoord.y = dstCoord.y * params.srcScale.y + mapValue.y * params.valScale.y + params.srcOffset.y;
+
+                output.at(b, y, x, 0) = input.at(b, srcCoord.y, srcCoord.x, 0);
             }
         }
     }

--- a/include/op_remap.hpp
+++ b/include/op_remap.hpp
@@ -80,7 +80,7 @@ class Remap final : public IOperator {
      *      -------------- | -------------
      *       TensorLayout  | No
      *       DataType      | No
-     *       Channels      | No
+     *       Channels      | No (Map must have exactly 2 channels)
      *       Width         | No
      *       Height        | No
      *       Batch Size    | Yes or 1

--- a/include/op_remap.hpp
+++ b/include/op_remap.hpp
@@ -70,12 +70,25 @@ class Remap final : public IOperator {
      *       TensorLayout  | Yes
      *       DataType      | Yes
      *       Channels      | Yes
-     *       Width         | Yes
-     *       Height        | Yes
+     *       Width         | No
+     *       Height        | No
      *       Batch Size    | Yes
+     * 
+     * Input/Map dependency:
+     *
+     *       Property      |  Input == Map
+     *      -------------- | -------------
+     *       TensorLayout  | No
+     *       DataType      | No
+     *       Channels      | No
+     *       Width         | No
+     *       Height        | No
+     *       Batch Size    | Yes or 1
      *
      *  Currently supported remap types:
      *      - REMAP_ABSOLUTE
+     *      - REMAP_ABSOLUTE_NORMALIZED
+     *      - REMAP_RELATIVE_NORMALIZED
      *
      *
      * @param[in] stream The HIP stream to run this operation on.

--- a/src/op_remap.cpp
+++ b/src/op_remap.cpp
@@ -42,7 +42,7 @@ Remap::~Remap() {}
 
 RemapParams GetRemapParams(const int2 &srcSize, const int2 &dstSize, const int2 &mapSize, bool alignCorners, eRemapType mapValueType)
 {
-    RemapParams params;
+    RemapParams params{};
 
     switch(mapValueType) {
         case REMAP_ABSOLUTE:
@@ -66,6 +66,8 @@ RemapParams GetRemapParams(const int2 &srcSize, const int2 &dstSize, const int2 
             params.dstOffset = alignCorners ? 0.f : .5f;
             params.srcOffset = params.srcScale * params.dstOffset - params.dstOffset;
             break;
+        default:
+             throw Exception("Unsupported mapValueType passed to GetRemapParams", eStatusType::NOT_IMPLEMENTED);
     }
     return params;
 }
@@ -78,7 +80,7 @@ void dispatch_remap_mapInterp(hipStream_t stream, const Tensor &input, const Ten
     InterpolationWrapper<float2, B, M> wrappedMapTensor(map, make_float2(0, 0));
     InterpolationWrapper<T, B, I> inputWrapper(input, borderValue);
 
-    int mapBatchSize = map.shape(map.layout().batch_index());
+    int mapBatchSize = wrappedMapTensor.batches();
 
     int2 srcSize = make_int2(inputWrapper.width(), inputWrapper.height());
     int2 dstSize = make_int2(outputWrapper.width(), outputWrapper.height());
@@ -92,12 +94,12 @@ void dispatch_remap_mapInterp(hipStream_t stream, const Tensor &input, const Ten
             dim3 block(64, 16);
             dim3 grid((outputWrapper.width() + block.x - 1) / block.x, (outputWrapper.height() + block.y - 1) / block.y,
                       outputWrapper.batches());
-            Kernels::Device::remap<<<grid, block, 0, stream>>>(inputWrapper, outputWrapper, wrappedMapTensor, alignCorners, mapBatchSize, params);
+            Kernels::Device::remap<<<grid, block, 0, stream>>>(inputWrapper, outputWrapper, wrappedMapTensor, mapBatchSize, params);
             break;
         }
 
         case eDeviceType::CPU: {
-            Kernels::Host::remap(inputWrapper, outputWrapper, wrappedMapTensor, alignCorners, mapBatchSize, params);
+            Kernels::Host::remap(inputWrapper, outputWrapper, wrappedMapTensor, mapBatchSize, params);
             break;
         }
     }
@@ -197,8 +199,11 @@ void Remap::operator()(hipStream_t stream, const Tensor &input, const Tensor &ou
     CHECK_TENSOR_COMPARISON(input.layout() == output.layout());
     CHECK_TENSOR_COMPARISON(input.shape() == output.shape());
     CHECK_TENSOR_COMPARISON(map.layout() == output.layout());
+    CHECK_TENSOR_COMPARISON((map.shape(map.layout().batch_index()) == input.shape(input.layout().batch_index())) 
+                            || (map.shape(map.layout().batch_index()) == 1));
     
     CHECK_TENSOR_CHANNELS(input, 1, 3, 4);
+    CHECK_TENSOR_CHANNELS(map, 2);
 
     eDataType dtype = input.dtype().etype();
     int64_t channels = input.shape(input.layout().channels_index());

--- a/src/op_remap.cpp
+++ b/src/op_remap.cpp
@@ -28,23 +28,63 @@ THE SOFTWARE.
 #include "core/detail/casting.hpp"
 #include "core/detail/math/math.hpp"
 #include "core/detail/type_traits.hpp"
+#include "core/detail/internal_structs.hpp"
 #include "core/wrappers/image_wrapper.hpp"
 #include "core/wrappers/interpolation_wrapper.hpp"
 #include "kernels/device/remap_device.hpp"
 #include "kernels/host/remap_host.hpp"
 
+using namespace roccv::detail;
 namespace roccv {
 Remap::Remap() {}
 
 Remap::~Remap() {}
 
+RemapParams GetRemapParams(const int2 &srcSize, const int2 &dstSize, const int2 &mapSize, bool alignCorners, eRemapType mapValueType)
+{
+    RemapParams params;
+
+    switch(mapValueType) {
+        case REMAP_ABSOLUTE:
+            params.srcScale = make_float2(0.f, 0.f);
+            params.mapScale = StaticCast<float2>(mapSize) / StaticCast<float2>(dstSize);
+            params.valScale = make_float2(1.f, 1.f);
+            params.srcOffset = make_float2(0.f, 0.f);
+            params.dstOffset = 0.f;
+            break;
+        case REMAP_ABSOLUTE_NORMALIZED:
+            params.srcScale = make_float2(0.f, 0.f);
+            params.mapScale = StaticCast<float2>(mapSize) / StaticCast<float2>(dstSize);
+            params.valScale  = (StaticCast<float2>(srcSize) - (alignCorners ? 1.f : 0.f)) / 2.f;
+            params.srcOffset = params.valScale - (alignCorners ? 0.f : .5f);
+            params.dstOffset = 0.f;
+            break;
+        case REMAP_RELATIVE_NORMALIZED:
+            params.srcScale = StaticCast<float2>(srcSize) / StaticCast<float2>(dstSize);
+            params.mapScale = (StaticCast<float2>(mapSize) - 1.f) / StaticCast<float2>(dstSize);
+            params.valScale = StaticCast<float2>(srcSize) - 1.f;
+            params.dstOffset = alignCorners ? 0.f : .5f;
+            params.srcOffset = params.srcScale * params.dstOffset - params.dstOffset;
+            break;
+    }
+    return params;
+}
+
 template <typename T, eBorderType B, eInterpolationType I, eInterpolationType M>
 void dispatch_remap_mapInterp(hipStream_t stream, const Tensor &input, const Tensor &output, const Tensor &map,
-                              eRemapType mapValueType, bool alignCorners, T borderValue,
-                              eDeviceType device) {
+                              const eRemapType mapValueType, const bool alignCorners, const T borderValue,
+                              const eDeviceType device) {
     ImageWrapper<T> outputWrapper(output);
     InterpolationWrapper<float2, B, M> wrappedMapTensor(map, make_float2(0, 0));
     InterpolationWrapper<T, B, I> inputWrapper(input, borderValue);
+
+    int mapBatchSize = map.shape(map.layout().batch_index());
+
+    int2 srcSize = make_int2(inputWrapper.width(), inputWrapper.height());
+    int2 dstSize = make_int2(outputWrapper.width(), outputWrapper.height());
+    int2 mapSize = make_int2(wrappedMapTensor.width(), wrappedMapTensor.height());
+
+    RemapParams params = GetRemapParams(srcSize, dstSize, mapSize, alignCorners, mapValueType);
 
     // Launch CPU/GPU kernel depending on requested device type.
     switch (device) {
@@ -52,12 +92,12 @@ void dispatch_remap_mapInterp(hipStream_t stream, const Tensor &input, const Ten
             dim3 block(64, 16);
             dim3 grid((outputWrapper.width() + block.x - 1) / block.x, (outputWrapper.height() + block.y - 1) / block.y,
                       outputWrapper.batches());
-            Kernels::Device::remap<<<grid, block, 0, stream>>>(inputWrapper, outputWrapper, wrappedMapTensor);
+            Kernels::Device::remap<<<grid, block, 0, stream>>>(inputWrapper, outputWrapper, wrappedMapTensor, alignCorners, mapBatchSize, params);
             break;
         }
 
         case eDeviceType::CPU: {
-            Kernels::Host::remap(inputWrapper, outputWrapper, wrappedMapTensor);
+            Kernels::Host::remap(inputWrapper, outputWrapper, wrappedMapTensor, alignCorners, mapBatchSize, params);
             break;
         }
     }
@@ -65,11 +105,11 @@ void dispatch_remap_mapInterp(hipStream_t stream, const Tensor &input, const Ten
 
 template <typename T, eBorderType B, eInterpolationType I>
 void dispatch_remap_interp(hipStream_t stream, const Tensor &input, const Tensor &output, const Tensor &map,
-                           eInterpolationType mapInterpolation, eRemapType mapValueType,
-                           bool alignCorners, T borderValue, eDeviceType device) {
+                           const eInterpolationType mapInterpolation, const eRemapType mapValueType,
+                           const bool alignCorners, const T borderValue, const eDeviceType device) {
     // Select kernel dispatcher based on selected interpolation mode.
     // clang-format off
-    static const std::unordered_map<eInterpolationType, std::function<void(hipStream_t stream, const Tensor&, const Tensor&, const Tensor&, eRemapType, bool, T, eDeviceType)>>
+    static const std::unordered_map<eInterpolationType, std::function<void(hipStream_t stream, const Tensor&, const Tensor&, const Tensor&, const eRemapType, const bool, const T, const eDeviceType)>>
         funcs = {
             {eInterpolationType::INTERP_TYPE_NEAREST, dispatch_remap_mapInterp<T, B, I, eInterpolationType::INTERP_TYPE_NEAREST>},
             {eInterpolationType::INTERP_TYPE_LINEAR,  dispatch_remap_mapInterp<T, B, I, eInterpolationType::INTERP_TYPE_LINEAR>},
@@ -87,12 +127,12 @@ void dispatch_remap_interp(hipStream_t stream, const Tensor &input, const Tensor
 
 template <typename T, eBorderType B>
 void dispatch_remap_border_mode(hipStream_t stream, const Tensor &input, const Tensor &output, const Tensor &map,
-                                eInterpolationType inInterpolation, eInterpolationType mapInterpolation,
-                                eRemapType mapValueType, bool alignCorners, T borderValue,
-                                eDeviceType device) {
+                                const eInterpolationType inInterpolation, const eInterpolationType mapInterpolation,
+                                const eRemapType mapValueType, const bool alignCorners, const T borderValue,
+                                const eDeviceType device) {
     // Select kernel dispatcher based on selected interpolation mode.
     // clang-format off
-    static const std::unordered_map<eInterpolationType, std::function<void(hipStream_t stream, const Tensor&, const Tensor&, const Tensor&, eInterpolationType, eRemapType, bool, T, eDeviceType)>>
+    static const std::unordered_map<eInterpolationType, std::function<void(hipStream_t stream, const Tensor&, const Tensor&, const Tensor&, const eInterpolationType, const eRemapType, const bool, const T, const eDeviceType)>>
         funcs = {
             {eInterpolationType::INTERP_TYPE_NEAREST, dispatch_remap_interp<T, B, eInterpolationType::INTERP_TYPE_NEAREST>},
             {eInterpolationType::INTERP_TYPE_LINEAR,  dispatch_remap_interp<T, B, eInterpolationType::INTERP_TYPE_LINEAR>},
@@ -110,12 +150,12 @@ void dispatch_remap_border_mode(hipStream_t stream, const Tensor &input, const T
 
 template <typename T>
 void dispatch_remap_dtype(hipStream_t stream, const Tensor &input, const Tensor &output, const Tensor &map,
-                          eInterpolationType inInterpolation, eInterpolationType mapInterpolation,
-                          eRemapType mapValueType, bool alignCorners, eBorderType borderType,
-                          float4 borderValue, eDeviceType device) {
+                          const eInterpolationType inInterpolation, const eInterpolationType mapInterpolation,
+                          const eRemapType mapValueType, const bool alignCorners, const eBorderType borderType,
+                          const float4 borderValue, const eDeviceType device) {
     // Select kernel dispatcher based on requested border mode.
     // clang-format off
-    static const std::unordered_map<eBorderType, std::function<void(hipStream_t, const Tensor&, const Tensor&, const Tensor&, eInterpolationType, eInterpolationType, eRemapType, bool, T, eDeviceType)>>
+    static const std::unordered_map<eBorderType, std::function<void(hipStream_t, const Tensor&, const Tensor&, const Tensor&, const eInterpolationType, const eInterpolationType, const eRemapType, const bool, T, const eDeviceType)>>
         funcs = {
             {eBorderType::BORDER_TYPE_CONSTANT,     dispatch_remap_border_mode<T, eBorderType::BORDER_TYPE_CONSTANT>},
             {eBorderType::BORDER_TYPE_REPLICATE,    dispatch_remap_border_mode<T, eBorderType::BORDER_TYPE_REPLICATE>},
@@ -135,9 +175,9 @@ void dispatch_remap_dtype(hipStream_t stream, const Tensor &input, const Tensor 
 }
 
 void Remap::operator()(hipStream_t stream, const Tensor &input, const Tensor &output, const Tensor &map,
-                       eInterpolationType inInterpolation, eInterpolationType mapInterpolation,
-                       eRemapType mapValueType, bool alignCorners, eBorderType borderType,
-                       float4 borderValue, eDeviceType device) {
+                       const eInterpolationType inInterpolation, const eInterpolationType mapInterpolation,
+                       const eRemapType mapValueType, const bool alignCorners, const eBorderType borderType,
+                       const float4 borderValue, eDeviceType device) {
     // Verify that the tensors are located on the right device (CPU or GPU).
     CHECK_TENSOR_DEVICE(input, device);
     CHECK_TENSOR_DEVICE(output, device);
@@ -157,13 +197,7 @@ void Remap::operator()(hipStream_t stream, const Tensor &input, const Tensor &ou
     CHECK_TENSOR_COMPARISON(input.layout() == output.layout());
     CHECK_TENSOR_COMPARISON(input.shape() == output.shape());
     CHECK_TENSOR_COMPARISON(map.layout() == output.layout());
-
-    // If the input tensor has a batch index, check that the input and map batch sizes are the same
-    if (input.layout().batch_index() != -1) {
-        CHECK_TENSOR_COMPARISON(input.shape(input.layout().batch_index()) == map.shape(map.layout().batch_index()));
-    }
-    CHECK_TENSOR_COMPARISON(input.shape(input.layout().width_index()) == map.shape(map.layout().width_index()));
-    CHECK_TENSOR_COMPARISON(input.shape(input.layout().height_index()) == map.shape(map.layout().height_index()));
+    
     CHECK_TENSOR_CHANNELS(input, 1, 3, 4);
 
     eDataType dtype = input.dtype().etype();
@@ -171,7 +205,7 @@ void Remap::operator()(hipStream_t stream, const Tensor &input, const Tensor &ou
 
     // Select kernel dispatcher based on number of channels and a base datatype.
     // clang-format off
-    static const std::unordered_map<eDataType, std::array<std::function<void(hipStream_t, const Tensor &, const Tensor &, const Tensor &, eInterpolationType, eInterpolationType, eRemapType,  bool, eBorderType, float4, eDeviceType)>, 4>>
+    static const std::unordered_map<eDataType, std::array<std::function<void(hipStream_t, const Tensor &, const Tensor &, const Tensor &, const eInterpolationType, const eInterpolationType, const eRemapType,  const bool, const eBorderType, const float4, const eDeviceType)>, 4>>
         funcs = {
             {eDataType::DATA_TYPE_U8, {dispatch_remap_dtype<uchar1>, 0, dispatch_remap_dtype<uchar3>, dispatch_remap_dtype<uchar4>}},
         };

--- a/src/op_remap.cpp
+++ b/src/op_remap.cpp
@@ -197,7 +197,6 @@ void Remap::operator()(hipStream_t stream, const Tensor &input, const Tensor &ou
 
     // Ensure the layout and shapes for the input/output tensors match
     CHECK_TENSOR_COMPARISON(input.layout() == output.layout());
-    CHECK_TENSOR_COMPARISON(input.shape() == output.shape());
     CHECK_TENSOR_COMPARISON(map.layout() == output.layout());
     CHECK_TENSOR_COMPARISON((map.shape(map.layout().batch_index()) == input.shape(input.layout().batch_index())) 
                             || (map.shape(map.layout().batch_index()) == 1));

--- a/tests/roccv/cpp/src/tests/operators/test_op_remap.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_remap.cpp
@@ -235,7 +235,7 @@ void TestCorrectness(int batchSize, int mapBatchSize, int inWidth, int inHeight,
     hipStream_t stream;
     HIP_VALIDATE_NO_ERRORS(hipStreamCreate(&stream));
     Remap op;
-    op(stream, input, output, mapTensor, InterpType, MapInterpType, mapType, false, BorderType, borderValue, device);
+    op(stream, input, output, mapTensor, InterpType, MapInterpType, mapType, alignCorners, BorderType, borderValue, device);
     HIP_VALIDATE_NO_ERRORS(hipStreamSynchronize(stream));
     HIP_VALIDATE_NO_ERRORS(hipStreamDestroy(stream));
 
@@ -282,6 +282,34 @@ int main(int argc, char** argv) {
     TEST_CASE((TestCorrectness<uchar4, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
                                eInterpolationType::INTERP_TYPE_NEAREST>(
         1, 1, 480, 360, 480, 360, 480, 360, FMT_RGBA8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_RELATIVE_NORMALIZED, false, eDeviceType::GPU)));
+    
+    TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
+                               eInterpolationType::INTERP_TYPE_NEAREST>(
+        1, 1, 480, 360, 480, 360, 480, 360, FMT_U8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, true, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
+                               eInterpolationType::INTERP_TYPE_NEAREST>(
+        1, 1, 480, 360, 480, 360, 480, 360, FMT_U8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE_NORMALIZED, true, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
+                               eInterpolationType::INTERP_TYPE_NEAREST>(
+        1, 1, 480, 360, 480, 360, 480, 360, FMT_U8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_RELATIVE_NORMALIZED, true, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<uchar3, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
+                               eInterpolationType::INTERP_TYPE_NEAREST>(
+        1, 1, 480, 360, 480, 360, 480, 360, FMT_RGB8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, true, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<uchar3, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
+                               eInterpolationType::INTERP_TYPE_NEAREST>(
+        1, 1, 480, 360, 480, 360, 480, 360, FMT_RGB8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE_NORMALIZED, true, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<uchar3, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
+                               eInterpolationType::INTERP_TYPE_NEAREST>(
+        1, 1, 480, 360, 480, 360, 480, 360, FMT_RGB8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_RELATIVE_NORMALIZED, true, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<uchar4, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
+                               eInterpolationType::INTERP_TYPE_NEAREST>(
+        1, 1, 480, 360, 480, 360, 480, 360, FMT_RGBA8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, true, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<uchar4, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
+                               eInterpolationType::INTERP_TYPE_NEAREST>(
+        1, 1, 480, 360, 480, 360, 480, 360, FMT_RGBA8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE_NORMALIZED, true, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<uchar4, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
+                               eInterpolationType::INTERP_TYPE_NEAREST>(
+        1, 1, 480, 360, 480, 360, 480, 360, FMT_RGBA8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_RELATIVE_NORMALIZED, true, eDeviceType::GPU)));
 
     TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
                                eInterpolationType::INTERP_TYPE_NEAREST>(
@@ -289,7 +317,12 @@ int main(int argc, char** argv) {
     TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
                                eInterpolationType::INTERP_TYPE_NEAREST>(
         2, 2, 480, 360, 480, 360, 480, 360, FMT_U8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, false, eDeviceType::GPU)));
-    
+    TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
+                               eInterpolationType::INTERP_TYPE_NEAREST>(
+        2, 1, 480, 360, 480, 360, 480, 360, FMT_U8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, true, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
+                               eInterpolationType::INTERP_TYPE_NEAREST>(
+        2, 2, 480, 360, 480, 360, 480, 360, FMT_U8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, true, eDeviceType::GPU)));
 
     TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
                                eInterpolationType::INTERP_TYPE_NEAREST>(
@@ -321,10 +354,46 @@ int main(int argc, char** argv) {
 
     TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
                                eInterpolationType::INTERP_TYPE_NEAREST>(
+        1, 1, 480, 360, 480, 360, 480, 360, FMT_U8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, true, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
+                               eInterpolationType::INTERP_TYPE_NEAREST>(
+        1, 1, 480, 360, 480, 360, 480, 360, FMT_U8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE_NORMALIZED, true, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
+                               eInterpolationType::INTERP_TYPE_NEAREST>(
+        1, 1, 480, 360, 480, 360, 480, 360, FMT_U8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_RELATIVE_NORMALIZED, true, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uchar3, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
+                               eInterpolationType::INTERP_TYPE_NEAREST>(
+        1, 1, 480, 360, 480, 360, 480, 360, FMT_RGB8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, true, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uchar3, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
+                               eInterpolationType::INTERP_TYPE_NEAREST>(
+        1, 1, 480, 360, 480, 360, 480, 360, FMT_RGB8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE_NORMALIZED, true, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uchar3, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
+                               eInterpolationType::INTERP_TYPE_NEAREST>(
+        1, 1, 480, 360, 480, 360, 480, 360, FMT_RGB8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_RELATIVE_NORMALIZED, true, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uchar4, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
+                               eInterpolationType::INTERP_TYPE_NEAREST>(
+        1, 1, 480, 360, 480, 360, 480, 360, FMT_RGBA8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, true, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uchar4, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
+                               eInterpolationType::INTERP_TYPE_NEAREST>(
+        1, 1, 480, 360, 480, 360, 480, 360, FMT_RGBA8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE_NORMALIZED, true, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uchar4, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
+                               eInterpolationType::INTERP_TYPE_NEAREST>(
+        1, 1, 480, 360, 480, 360, 480, 360, FMT_RGBA8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_RELATIVE_NORMALIZED, true, eDeviceType::CPU)));
+
+    TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
+                               eInterpolationType::INTERP_TYPE_NEAREST>(
         2, 1, 480, 360, 480, 360, 480, 360, FMT_U8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, false, eDeviceType::CPU)));
     TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
                                eInterpolationType::INTERP_TYPE_NEAREST>(
         2, 2, 480, 360, 480, 360, 480, 360, FMT_U8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, false, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
+                               eInterpolationType::INTERP_TYPE_NEAREST>(
+        2, 1, 480, 360, 480, 360, 480, 360, FMT_U8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, true, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
+                               eInterpolationType::INTERP_TYPE_NEAREST>(
+        2, 2, 480, 360, 480, 360, 480, 360, FMT_U8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, true, eDeviceType::CPU)));
+
+
 
     TEST_CASES_END();
 }

--- a/tests/roccv/cpp/src/tests/operators/test_op_remap.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_remap.cpp
@@ -25,7 +25,7 @@ THE SOFTWARE.
 #include <core/wrappers/interpolation_wrapper.hpp>
 #include <iostream>
 #include <op_remap.hpp>
-
+#include "core/detail/internal_structs.hpp"
 #include "core/detail/casting.hpp"
 #include "core/detail/math/vectorized_type_math.hpp"
 #include "core/detail/type_traits.hpp"
@@ -38,6 +38,37 @@ using namespace roccv::detail;
 
 // Keep all non-entrypoint functions in an anonymous namespace to prevent redefinition errors across translation units.
 namespace {
+
+RemapParams GetRemapParams(const int2 &srcSize, const int2 &dstSize, const int2 &mapSize, bool alignCorners, eRemapType mapValueType)
+{
+    RemapParams params;
+
+    switch(mapValueType) {
+        case REMAP_ABSOLUTE:
+            params.srcScale = make_float2(0.f, 0.f);
+            params.mapScale = StaticCast<float2>(mapSize) / StaticCast<float2>(dstSize);
+            params.valScale = make_float2(1.f, 1.f);
+            params.srcOffset = make_float2(0.f, 0.f);
+            params.dstOffset = 0.f;
+            break;
+        case REMAP_ABSOLUTE_NORMALIZED:
+            params.srcScale = make_float2(0.f, 0.f);
+            params.mapScale = StaticCast<float2>(mapSize) / StaticCast<float2>(dstSize);
+            params.valScale  = (StaticCast<float2>(srcSize) - (alignCorners ? 1.f : 0.f)) / 2.f;
+            params.srcOffset = params.valScale - (alignCorners ? 0.f : .5f);
+            params.dstOffset = 0.f;
+            break;
+        case REMAP_RELATIVE_NORMALIZED:
+            params.srcScale = StaticCast<float2>(srcSize) / StaticCast<float2>(dstSize);
+            params.mapScale = (StaticCast<float2>(mapSize) - 1.f) / StaticCast<float2>(dstSize);
+            params.valScale = StaticCast<float2>(srcSize) - 1.f;
+            params.dstOffset = alignCorners ? 0.f : .5f;
+            params.srcOffset = params.srcScale * params.dstOffset - params.dstOffset;
+            break;
+    }
+    return params;
+}
+
 /**
  * @brief Verified golden C++ model for the Remap operation.
  *
@@ -56,28 +87,51 @@ namespace {
  */
 template <typename T, eBorderType BorderType, eInterpolationType InterpType, eInterpolationType MapInterpType,
           typename BT = detail::BaseType<T>>
-std::vector<BT> GoldenRemapAbsolute(std::vector<BT>& input, int32_t batchSize, int32_t width, int32_t height,
-                                    std::vector<float2>& mapData, float4 borderValue) {
-    // Create an output vector the same size as the input vector
-    std::vector<BT> output(input.size());
+std::vector<BT> GoldenRemap(std::vector<BT>& input, int32_t batchSize, int32_t mapBatchSize, int32_t inWidth, int32_t inHeight, int32_t outWidth, 
+                            int32_t outHeight, int32_t mapWidth, int32_t mapHeight, std::vector<float2>& mapData, eRemapType mapType, bool alignCorners, float4 borderValue) {
+    
+    int channels = detail::NumElements<T>;
+    int outputSize = batchSize * outWidth * outHeight * channels;
+    std::vector<BT> output(outputSize);
 
     // Create interpolation wrapper for input vector
     InterpolationWrapper<T, BorderType, InterpType> src((BorderWrapper<T, BorderType>(
-        ImageWrapper<T>(input, batchSize, width, height), detail::SaturateCast<T>(borderValue))));
+        ImageWrapper<T>(input, batchSize, inWidth, inHeight), detail::SaturateCast<T>(borderValue))));
 
     // Wrap the output vector for simplified data access
-    ImageWrapper<T> dst(output, batchSize, width, height);
+    ImageWrapper<T> dst(output, batchSize, outWidth, outHeight);
 
     // Create an interpolation wrapper for the map tensor
     // InterpolationWrapper<float2, BorderType, MapInterpType> wrappedMapTensor(map, make_float2(0, 0));
     InterpolationWrapper<float2, BorderType, MapInterpType> map((BorderWrapper<float2, BorderType>(
-        ImageWrapper<float2>(mapData.data(), batchSize, width, height), detail::SaturateCast<float2>(borderValue))));
+        ImageWrapper<float2>(mapData.data(), mapBatchSize, mapWidth, mapHeight), detail::SaturateCast<float2>(borderValue))));
 
-    for (int b = 0; b < batchSize; b++) {
-        for (int y = 0; y < height; y++) {
-            for (int x = 0; x < width; x++) {
-                float2 mapCoordinates = map.at(b, y, x, 0);
-                dst.at(b, y, x, 0) = src.at(b, mapCoordinates.y, mapCoordinates.x, 0);
+    int2 srcSize = make_int2(src.width(), src.height());
+    int2 dstSize = make_int2(dst.width(), dst.height());
+    int2 mapSize = make_int2(map.width(), map.height());
+
+    float2 srcCoord = make_float2(0.f, 0.f);
+    float2 mapCoord = make_float2(0.f, 0.f);
+    float2 dstCoord = make_float2(0.f, 0.f);
+
+    RemapParams params = GetRemapParams(srcSize, dstSize, mapSize, alignCorners, mapType);
+
+    for (int b = 0; b < dst.batches(); b++) {
+        for (int y = 0; y < dst.height(); y++) {
+            for (int x = 0; x < dst.width(); x++) {
+                
+                dstCoord.x = static_cast<float>(x);
+                dstCoord.y = static_cast<float>(y);
+                
+                mapCoord.x = (dstCoord.x + params.dstOffset) * params.mapScale.x;
+                mapCoord.y = (dstCoord.y + params.dstOffset) * params.mapScale.y;
+                
+                float2 mapValue = map.at((mapBatchSize == 1 ? 0 : b), mapCoord.y, mapCoord.x, 0);
+
+                srcCoord.x = dstCoord.x * params.srcScale.x + mapValue.x * params.valScale.x + params.srcOffset.x;
+                srcCoord.y = dstCoord.y * params.srcScale.y + mapValue.y * params.valScale.y + params.srcOffset.y;
+
+                dst.at(b, y, x, 0) = src.at(b, srcCoord.y, srcCoord.x, 0);
             }
         }
     }
@@ -94,20 +148,25 @@ std::vector<BT> GoldenRemapAbsolute(std::vector<BT>& input, int32_t batchSize, i
  * @tparam MapInterpType Interpolation mode to use for the map
  * @tparam BT Base type of the image's data.
  * @param batchSize Number of images within the batch.
- * @param width Width of the input image.
- * @param height Height of the input image.
+ * @param mapBatchSize Number of maps, either 1 or same as batchSize.
+ * @param inWidth Width of the input image.
+ * @param inHeight Height of the input image.
+ * @param outWidth Width of the output image.
+ * @param outHeight Height of the output image.
+ * @param mapWidth Width of the map.
+ * @param mapHeight Height of the map.
  * @param format Format of the images (must match with T).
  * @param borderValue Border value to use as a fallback when going out of bounds.
  * @param mapType Type of remap to do, REMAP_ABSOLUTE, REMAP_ABSOLUTE_NORMALIZED, REMAP_RELATIVE_NORMALIZED
- * @param device The device to run the roccv::WarpPerspective operator on.
+ * @param device The device to run the roccv::Remap operator on.
  */
 template <typename T, eBorderType BorderType, eInterpolationType InterpType, eInterpolationType MapInterpType,
           typename BT = detail::BaseType<T>>
-void TestCorrectness(int batchSize, int width, int height, ImageFormat format, float4 borderValue, eRemapType mapType,
-                     eDeviceType device) {
+void TestCorrectness(int batchSize, int mapBatchSize, int inWidth, int inHeight, int outWidth, int outHeight, int mapWidth, int mapHeight, ImageFormat format, float4 borderValue, eRemapType mapType,
+                     bool alignCorners, eDeviceType device) {
     // Create input and output tensor based on test parameters
-    Tensor input(batchSize, {width, height}, format, device);
-    Tensor output(batchSize, {width, height}, format, device);
+    Tensor input(batchSize, {inWidth, inHeight}, format, device);
+    Tensor output(batchSize, {outWidth, outHeight}, format, device);
 
     // Create a vector and fill it with random data.
     std::vector<BT> inputData(input.shape().size());
@@ -115,32 +174,59 @@ void TestCorrectness(int batchSize, int width, int height, ImageFormat format, f
 
     // Copy generated input data into input tensor
     CopyVectorIntoTensor(input, inputData);
+    
+    int mapSize = mapBatchSize * mapWidth * mapHeight;
 
-    std::vector<float> colRemapTable;
-    std::vector<float> rowRemapTable;
+    std::vector<float2> mapData(mapSize);
 
-    float halfWidth = width / 2;
-    for (int b = 0; b < batchSize; b++) {
-        for (int i = 0; i < height; i++) {
-            int j = 0;
-            for (; j < halfWidth; j++) {
-                rowRemapTable.push_back(i);
-                colRemapTable.push_back(halfWidth - j);
+    if (mapType == REMAP_ABSOLUTE) {
+        for (int b = 0; b < mapBatchSize; b++) {
+            for (int i = mapHeight - 1; i >= 0; i--) {
+                for (int j = 0; j < mapWidth; j++) {
+                    int idx = b * mapWidth * mapHeight + (mapHeight - 1 - i) * mapWidth + j;
+                    mapData[idx] = make_float2(j, i);  // Direct coordinate mapping
+                }
             }
-            for (; j < width; j++) {
-                rowRemapTable.push_back(i);
-                colRemapTable.push_back(j);
+        }
+    }
+    else if (mapType == REMAP_ABSOLUTE_NORMALIZED) {
+        for (int b = 0; b < mapBatchSize; b++) {
+            for (int y = 0; y < mapHeight; y++){
+                for (int x = 0; x < mapWidth; x++){
+                    float normX = ((2.0f * static_cast<float>(x)) / static_cast<float>(mapWidth - 1)) - 1.0f;
+                    float normY = ((2.0f * static_cast<float>(y)) / static_cast<float>(mapHeight - 1)) - 1.0f;
+
+                    float srcX = 0.0f - normX;
+                    float srcY = 0.0f - normY;
+
+                    int idx = b * mapWidth * mapHeight + y * mapWidth + x;
+                    mapData[idx] = make_float2(srcX, srcY);
+                }
+            }
+        }
+    }
+    else if (mapType == REMAP_RELATIVE_NORMALIZED) {
+        for (int b = 0; b < mapBatchSize; b++) {
+            for (int y = 0; y < mapHeight; y++){
+                for (int x = 0; x < mapWidth; x++){
+                    // Generate normalized coordinates in [-1, 1] range
+                    float normX = ((2.0f * static_cast<float>(x)) / static_cast<float>(mapWidth - 1)) - 1.0f;
+                    float normY = ((2.0f * static_cast<float>(y)) / static_cast<float>(mapHeight - 1)) - 1.0f;
+
+                    // For relative mode, map values represent offsets from the base position
+                    // Create a simple displacement pattern (e.g., horizontal flip offset)
+                    float offsetX = -normX;  // Reverses horizontal direction
+                    float offsetY = -normY;  // Reverses vertical direction
+
+                    int idx = b * mapWidth * mapHeight + y * mapWidth + x;
+                    mapData[idx] = make_float2(offsetX, offsetY);
+                }
             }
         }
     }
 
-    std::vector<float2> mapData(rowRemapTable.size());
-    for (int i = 0; i < rowRemapTable.size(); i++) {
-        mapData[i] = make_float2(colRemapTable[i], rowRemapTable[i]);
-    }
-
     // Create map tensor and fill it with mapData
-    TensorShape map_shape(TensorLayout(eTensorLayout::TENSOR_LAYOUT_NHWC), {batchSize, height, width, 2});
+    TensorShape map_shape(TensorLayout(eTensorLayout::TENSOR_LAYOUT_NHWC), {mapBatchSize, mapHeight, mapWidth, 2});
     DataType map_dtype(eDataType::DATA_TYPE_F32);
     Tensor mapTensor(map_shape, map_dtype, device);
 
@@ -157,8 +243,9 @@ void TestCorrectness(int batchSize, int width, int height, ImageFormat format, f
     std::vector<BT> result(output.shape().size());
     CopyTensorIntoVector(result, output);
 
-    std::vector<BT> ref = GoldenRemapAbsolute<T, BorderType, InterpType, MapInterpType>(inputData, batchSize, width,
-                                                                                        height, mapData, borderValue);
+    std::vector<BT> ref = GoldenRemap<T, BorderType, InterpType, MapInterpType>(inputData, batchSize, mapBatchSize, inWidth,
+                                                                                        inHeight, outWidth, outHeight, 
+                                                                                        mapWidth, mapHeight, mapData, mapType, alignCorners, borderValue);
 
     // Compare data in actual output versus the generated golden reference image
     CompareVectors(result, ref);
@@ -170,59 +257,74 @@ int main(int argc, char** argv) {
 
     TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
                                eInterpolationType::INTERP_TYPE_NEAREST>(
-        1, 480, 360, FMT_U8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<uchar3, eBorderType::BORDER_TYPE_REPLICATE, eInterpolationType::INTERP_TYPE_NEAREST,
-                               eInterpolationType::INTERP_TYPE_LINEAR>(
-        1, 480, 360, FMT_RGB8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<uchar4, eBorderType::BORDER_TYPE_REFLECT, eInterpolationType::INTERP_TYPE_NEAREST,
+        1, 1, 480, 360, 480, 360, 480, 360, FMT_U8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, false, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
                                eInterpolationType::INTERP_TYPE_NEAREST>(
-        1, 480, 360, FMT_RGBA8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_WRAP, eInterpolationType::INTERP_TYPE_NEAREST,
-                               eInterpolationType::INTERP_TYPE_LINEAR>(
-        3, 480, 360, FMT_U8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<uchar3, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_LINEAR,
+        1, 1, 480, 360, 480, 360, 480, 360, FMT_U8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE_NORMALIZED, false, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
                                eInterpolationType::INTERP_TYPE_NEAREST>(
-        1, 480, 360, FMT_RGB8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<uchar4, eBorderType::BORDER_TYPE_REPLICATE, eInterpolationType::INTERP_TYPE_NEAREST,
-                               eInterpolationType::INTERP_TYPE_LINEAR>(
-        1, 480, 360, FMT_RGBA8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_REFLECT101, eInterpolationType::INTERP_TYPE_LINEAR,
+        1, 1, 480, 360, 480, 360, 480, 360, FMT_U8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_RELATIVE_NORMALIZED, false, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<uchar3, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
                                eInterpolationType::INTERP_TYPE_NEAREST>(
-        5, 480, 360, FMT_U8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<uchar3, eBorderType::BORDER_TYPE_WRAP, eInterpolationType::INTERP_TYPE_NEAREST,
-                               eInterpolationType::INTERP_TYPE_LINEAR>(
-        5, 480, 360, FMT_RGB8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<uchar4, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_LINEAR,
+        1, 1, 480, 360, 480, 360, 480, 360, FMT_RGB8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, false, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<uchar3, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
                                eInterpolationType::INTERP_TYPE_NEAREST>(
-        5, 480, 360, FMT_RGBA8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, eDeviceType::GPU)));
+        1, 1, 480, 360, 480, 360, 480, 360, FMT_RGB8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE_NORMALIZED, false, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<uchar3, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
+                               eInterpolationType::INTERP_TYPE_NEAREST>(
+        1, 1, 480, 360, 480, 360, 480, 360, FMT_RGB8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_RELATIVE_NORMALIZED, false, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<uchar4, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
+                               eInterpolationType::INTERP_TYPE_NEAREST>(
+        1, 1, 480, 360, 480, 360, 480, 360, FMT_RGBA8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, false, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<uchar4, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
+                               eInterpolationType::INTERP_TYPE_NEAREST>(
+        1, 1, 480, 360, 480, 360, 480, 360, FMT_RGBA8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE_NORMALIZED, false, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<uchar4, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
+                               eInterpolationType::INTERP_TYPE_NEAREST>(
+        1, 1, 480, 360, 480, 360, 480, 360, FMT_RGBA8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_RELATIVE_NORMALIZED, false, eDeviceType::GPU)));
 
     TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
                                eInterpolationType::INTERP_TYPE_NEAREST>(
-        1, 480, 360, FMT_U8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<uchar3, eBorderType::BORDER_TYPE_REPLICATE, eInterpolationType::INTERP_TYPE_NEAREST,
-                               eInterpolationType::INTERP_TYPE_LINEAR>(
-        1, 480, 360, FMT_RGB8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<uchar4, eBorderType::BORDER_TYPE_REFLECT, eInterpolationType::INTERP_TYPE_NEAREST,
+        2, 1, 480, 360, 480, 360, 480, 360, FMT_U8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, false, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
                                eInterpolationType::INTERP_TYPE_NEAREST>(
-        1, 480, 360, FMT_RGBA8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_WRAP, eInterpolationType::INTERP_TYPE_NEAREST,
-                               eInterpolationType::INTERP_TYPE_LINEAR>(
-        3, 480, 360, FMT_U8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<uchar3, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_LINEAR,
+        2, 2, 480, 360, 480, 360, 480, 360, FMT_U8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, false, eDeviceType::GPU)));
+    
+
+    TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
                                eInterpolationType::INTERP_TYPE_NEAREST>(
-        3, 480, 360, FMT_RGB8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<uchar4, eBorderType::BORDER_TYPE_REPLICATE, eInterpolationType::INTERP_TYPE_NEAREST,
-                               eInterpolationType::INTERP_TYPE_LINEAR>(
-        3, 480, 360, FMT_RGBA8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_REFLECT101, eInterpolationType::INTERP_TYPE_LINEAR,
+        1, 1, 480, 360, 480, 360, 480, 360, FMT_U8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, false, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
                                eInterpolationType::INTERP_TYPE_NEAREST>(
-        5, 480, 360, FMT_U8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<uchar3, eBorderType::BORDER_TYPE_WRAP, eInterpolationType::INTERP_TYPE_NEAREST,
-                               eInterpolationType::INTERP_TYPE_LINEAR>(
-        5, 480, 360, FMT_RGB8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<uchar4, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_LINEAR,
+        1, 1, 480, 360, 480, 360, 480, 360, FMT_U8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE_NORMALIZED, false, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
                                eInterpolationType::INTERP_TYPE_NEAREST>(
-        5, 480, 360, FMT_RGBA8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, eDeviceType::CPU)));
+        1, 1, 480, 360, 480, 360, 480, 360, FMT_U8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_RELATIVE_NORMALIZED, false, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uchar3, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
+                               eInterpolationType::INTERP_TYPE_NEAREST>(
+        1, 1, 480, 360, 480, 360, 480, 360, FMT_RGB8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, false, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uchar3, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
+                               eInterpolationType::INTERP_TYPE_NEAREST>(
+        1, 1, 480, 360, 480, 360, 480, 360, FMT_RGB8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE_NORMALIZED, false, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uchar3, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
+                               eInterpolationType::INTERP_TYPE_NEAREST>(
+        1, 1, 480, 360, 480, 360, 480, 360, FMT_RGB8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_RELATIVE_NORMALIZED, false, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uchar4, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
+                               eInterpolationType::INTERP_TYPE_NEAREST>(
+        1, 1, 480, 360, 480, 360, 480, 360, FMT_RGBA8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, false, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uchar4, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
+                               eInterpolationType::INTERP_TYPE_NEAREST>(
+        1, 1, 480, 360, 480, 360, 480, 360, FMT_RGBA8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE_NORMALIZED, false, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uchar4, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
+                               eInterpolationType::INTERP_TYPE_NEAREST>(
+        1, 1, 480, 360, 480, 360, 480, 360, FMT_RGBA8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_RELATIVE_NORMALIZED, false, eDeviceType::CPU)));
+
+    TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
+                               eInterpolationType::INTERP_TYPE_NEAREST>(
+        2, 1, 480, 360, 480, 360, 480, 360, FMT_U8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, false, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
+                               eInterpolationType::INTERP_TYPE_NEAREST>(
+        2, 2, 480, 360, 480, 360, 480, 360, FMT_U8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, false, eDeviceType::CPU)));
 
     TEST_CASES_END();
 }

--- a/tests/roccv/python/test_op_remap.py
+++ b/tests/roccv/python/test_op_remap.py
@@ -33,7 +33,7 @@ from test_helpers import generate_tensor, compare_tensors
 @pytest.mark.parametrize("border_val", [[255, 0, 255, 0]])
 @pytest.mark.parametrize("interp", [rocpycv.eInterpolationType.NEAREST, rocpycv.eInterpolationType.LINEAR])
 @pytest.mark.parametrize("map_interp", [rocpycv.eInterpolationType.NEAREST, rocpycv.eInterpolationType.LINEAR])
-@pytest.mark.parametrize("map_type", [rocpycv.REMAP_ABSOLUTE])
+@pytest.mark.parametrize("map_type", [rocpycv.REMAP_ABSOLUTE, rocpycv.REMAP_ABSOLUTE_NORMALIZED, rocpycv.REMAP_RELATIVE_NORMALIZED])
 @pytest.mark.parametrize("align_corners", [False])
 @pytest.mark.parametrize("channels", [1, 3, 4])
 @pytest.mark.parametrize("samples, width, height", [
@@ -47,21 +47,50 @@ def test_op_remap(samples, width, height, channels, dtype, map_interp, interp, m
     output_golden = rocpycv.Tensor([samples, height, width, channels], rocpycv.eTensorLayout.NHWC, dtype, device)
 
 
-    map_list = []
-    for b in range(samples):
-        image_map_list = []
-        halfWidth = int(width / 2)
-        for y in range(height):
-            row_list = []
-            x = 0
-            while x < halfWidth:
-                row_list.append([halfWidth - x, y])
-                x += 1
-            while x < width:
-                row_list.append([x, y])
-                x += 1
-            image_map_list.append(row_list)
-        map_list.append(image_map_list)
+    if (map_type == rocpycv.REMAP_ABSOLUTE):
+        halfWidth = width // 2
+
+        y_coords, x_coords = np.meshgrid(np.arange(height), np.arange(width), indexing='ij')
+
+        x_map = x_coords.copy()
+        x_map[:, :halfWidth] = halfWidth - x_coords[:, :halfWidth]
+
+        map_single = np.stack([x_map, y_coords], axis=-1)
+
+        map_list = np.tile(map_single[np.newaxis, :, :, :], (samples, 1, 1, 1))
+    elif (map_type == rocpycv.REMAP_ABSOLUTE_NORMALIZED):
+
+        y_coords, x_coords = np.meshgrid(
+        np.arange(height), 
+        np.arange(width), 
+        indexing='ij'
+        )
+
+        normX = (2.0 * x_coords / (width - 1)) - 1.0
+        normY = (2.0 * y_coords / (height - 1)) - 1.0
+
+        srcX = -normX
+        srcY = -normY
+
+        map_single = np.stack([srcX, srcY], axis=-1)
+
+        map_list = np.tile(map_single[np.newaxis, :, :, :], (samples, 1, 1, 1)).astype(np.float32)
+    elif (map_type == rocpycv.REMAP_RELATIVE_NORMALIZED):
+        y_coords, x_coords = np.meshgrid(
+            np.arange(height),
+            np.arange(width),
+            indexing='ij'
+        )
+
+        normX = (2.0 * x_coords / (width - 1)) - 1.0
+        normY = (2.0 * y_coords / (height - 1)) - 1.0
+
+        offsetX = -normX
+        offsetY = -normY
+
+        map_single = np.stack([offsetX, offsetY], axis=-1)
+
+        map_list = np.tile(map_single[np.newaxis, :, :, :], (samples, 1, 1, 1)).astype(np.float32)
 
     map_np_array = np.array(map_list, np.float32)
     remap_tensor = rocpycv.from_dlpack(map_np_array, rocpycv.NHWC).copy_to(device)

--- a/tests/roccv/python/test_op_remap.py
+++ b/tests/roccv/python/test_op_remap.py
@@ -34,7 +34,7 @@ from test_helpers import generate_tensor, compare_tensors
 @pytest.mark.parametrize("interp", [rocpycv.eInterpolationType.NEAREST, rocpycv.eInterpolationType.LINEAR])
 @pytest.mark.parametrize("map_interp", [rocpycv.eInterpolationType.NEAREST, rocpycv.eInterpolationType.LINEAR])
 @pytest.mark.parametrize("map_type", [rocpycv.REMAP_ABSOLUTE, rocpycv.REMAP_ABSOLUTE_NORMALIZED, rocpycv.REMAP_RELATIVE_NORMALIZED])
-@pytest.mark.parametrize("align_corners", [False])
+@pytest.mark.parametrize("align_corners", [True, False])
 @pytest.mark.parametrize("channels", [1, 3, 4])
 @pytest.mark.parametrize("samples, width, height", [
     (1, 720, 480),


### PR DESCRIPTION
## Motivation

Refactored the remap operato to support REMAP_ABSOLUTE, REMAP_ABSOLUTE_NORMALIZED and REMAP_RELATIVE_NORMALIZED.

## Technical Details

Added support for all remap types to the host and device implementations of the remap operator. Remap parameters are computed and then passed into the host or device kernels.

## Test Plan

A C-Model is included that checks all three remap types on both CPU and GPU.
Tests for the Python implementation are also included.

## Test Result

All C++ and Python tests pass.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
