### PR TITLE
Fix -Wignored-qualifiers compiler warnings

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,6 +43,11 @@ target_include_directories(${PROJECT_NAME}
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/roccv>
 )
 
+# Mark HIP includes as system to suppress warnings from ROCm headers
+target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC
+    $<BUILD_INTERFACE:${HIP_INCLUDE_DIRS}>
+)
+
 set_target_properties(${PROJECT_NAME} PROPERTIES VERSION ${PROJECT_VERSION} SOVERSION ${PROJECT_VERSION_MAJOR})
 set_target_properties(${PROJECT_NAME} PROPERTIES INSTALL_RPATH "$ORIGIN;$ORIGIN/rocm_sysdeps/lib;${ROCM_PATH}/lib/llvm/lib" BUILD_WITH_INSTALL_RPATH TRUE)
 


### PR DESCRIPTION
This PR marks HIP include directories as SYSTEM includes to prevent -Wignored-qualifiers warnings from ROCm header files.

Fixes #127 (Category 1 - 560+ warnings)

Changes:
- Added SYSTEM keyword to target_include_directories for HIP headers in src/CMakeLists.txt
- Warnings from /opt/rocm/include will now be properly suppressed
- rocCV's own code will still be checked for this warning

This is the proper fix (not suppression) that tells the compiler to not warn about issues in system headers.