### PR TITLE
[Bugfix] Resolve -Wunused-parameter -Wdeprecated-copy-with-user-provided-copy warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,7 +114,7 @@ endif()
 message("-- ${BoldBlue}${PROJECT_NAME} Build Type -- ${CMAKE_BUILD_TYPE}${ColorReset}")
 
 # Set all warnings
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wno-sign-compare -Wno-unused-parameter -Wno-deprecated-copy-with-user-provided-copy")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wno-sign-compare -Wno-unused-parameter -Werror")
 
 # Enable LLVM code coverage if build type is Debug and ENABLE_CODE_COVERAGE is set.
 if(ENABLE_CODE_COVERAGE AND CMAKE_BUILD_TYPE MATCHES Debug)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,7 +114,7 @@ endif()
 message("-- ${BoldBlue}${PROJECT_NAME} Build Type -- ${CMAKE_BUILD_TYPE}${ColorReset}")
 
 # Set all warnings
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wno-sign-compare -Wno-unused-parameter -Werror")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wno-sign-compare")
 
 # Enable LLVM code coverage if build type is Debug and ENABLE_CODE_COVERAGE is set.
 if(ENABLE_CODE_COVERAGE AND CMAKE_BUILD_TYPE MATCHES Debug)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,12 +112,12 @@ endif()
 message("-- ${BoldBlue}${PROJECT_NAME} Build Type -- ${CMAKE_BUILD_TYPE}${ColorReset}")
 
 # Set all warnings
-# - Wall                -- Print all warnings
-# - Wextra              -- Print extra warnings
-# - Wno-sign-compare    -- Don't print warnings about comparing signed and unsigned integers
+# -Wall                -- Print all warnings
+# -Wextra              -- Print extra warnings
+# -Wno-sign-compare    -- Don't print warnings about comparing signed and unsigned integers
 # TODO: Resolve sign-compare warnings. Once all warnings are resolved, remove Wno-sign-compare and add -Werror
 # to prevent any new warnings from being introduced.
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wno-sign-compare")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wno-sign-compare -Werror")
 
 # Enable LLVM code coverage if build type is Debug and ENABLE_CODE_COVERAGE is set.
 if(ENABLE_CODE_COVERAGE AND CMAKE_BUILD_TYPE MATCHES Debug)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,18 +102,21 @@ endif()
 if(CMAKE_BUILD_TYPE MATCHES Debug)
 	# -O0 		-- Don't Optimize output file
 	# -g  		-- generate debugging information --- dwarf-4 for making valgrind work
-    # -Wall     -- Print all warnings
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O0 -gdwarf-4")
 else()
 	# -O3       -- Optimize output file
 	# -DNDEBUG  -- turn off asserts
 	# -fPIC     -- Generate position-independent code if possible
-    # -Wall     -- Print all warnings
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -DNDEBUG -fPIC")
 endif()
 message("-- ${BoldBlue}${PROJECT_NAME} Build Type -- ${CMAKE_BUILD_TYPE}${ColorReset}")
 
 # Set all warnings
+# - Wall                -- Print all warnings
+# - Wextra              -- Print extra warnings
+# - Wno-sign-compare    -- Don't print warnings about comparing signed and unsigned integers
+# TODO: Resolve sign-compare warnings. Once all warnings are resolved, remove Wno-sign-compare and add -Werror
+# to prevent any new warnings from being introduced.
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wno-sign-compare")
 
 # Enable LLVM code coverage if build type is Debug and ENABLE_CODE_COVERAGE is set.

--- a/include/core/detail/math/math.hpp
+++ b/include/core/detail/math/math.hpp
@@ -177,7 +177,7 @@ class Matrix {
 
 // Determinant calculations
 template <class T>
-constexpr __host__ __device__ T det(const Matrix<T, 0, 0> &m) {
+constexpr __host__ __device__ T det(const Matrix<T, 0, 0> &) {
     return T{1};
 }
 

--- a/include/core/tensor_shape.hpp
+++ b/include/core/tensor_shape.hpp
@@ -118,6 +118,7 @@ class TensorShape {
     // Operators
     int64_t operator[](int32_t i) const;
     int64_t operator[](std::string_view dimension) const;
+    TensorShape(const TensorShape &) = default;
     TensorShape &operator=(const TensorShape &other);
     bool operator==(const TensorShape &rhs) const;
     bool operator!=(const TensorShape &rhs) const;

--- a/include/kernels/device/bilateral_filter_device.hpp
+++ b/include/kernels/device/bilateral_filter_device.hpp
@@ -23,22 +23,19 @@ THE SOFTWARE.
 #pragma once
 
 #include <hip/hip_runtime.h>
-#include "kernels/kernel_helpers.hpp"
-#include "core/wrappers/interpolation_wrapper.hpp"
-#include "operator_types.h"
 
-#include "core/detail/type_traits.hpp"
 #include "core/detail/casting.hpp"
+#include "core/detail/type_traits.hpp"
 #include "core/detail/vector_utils.hpp"
+#include "kernels/kernel_helpers.hpp"
 
 namespace Kernels {
 namespace Device {
-                                                   
+
 template <typename T, typename SrcWrapper, typename DstWrapper>
-__global__ void bilateral_filter(SrcWrapper input, DstWrapper output, int radius,
-                                 float /* sigmaColor */, float /* sigmaSpace */, float spaceCoeff, float colorCoeff) {
+__global__ void bilateral_filter(SrcWrapper input, DstWrapper output, int radius, float spaceCoeff, float colorCoeff) {
     using namespace roccv::detail;
-    using worktype = MakeType<float,NumElements<T>>;
+    using worktype = MakeType<float, NumElements<T>>;
     const int idx = (threadIdx.x + blockIdx.x * blockDim.x) * 2;
     const int idy = (threadIdx.y + blockIdx.y * blockDim.y) * 2;
     const int idz = blockIdx.z;
@@ -59,7 +56,6 @@ __global__ void bilateral_filter(SrcWrapper input, DstWrapper output, int radius
 
     int sqrRadius = radius * radius;
 
-    
     worktype num0 = SetAll<worktype>(0);
     worktype num1 = SetAll<worktype>(0);
     worktype num2 = SetAll<worktype>(0);
@@ -73,8 +69,7 @@ __global__ void bilateral_filter(SrcWrapper input, DstWrapper output, int radius
             int t2 = abs(c - (idx + 1)), t3 = abs(r - (idy + 1));
             float4 sqrD{t0 * t0 + t1 * t1, t2 * t2 + t1 * t1, t0 * t0 + t3 * t3, t3 * t3 + t2 * t2};
 
-            if (!(sqrD.x <= sqrRadius || sqrD.y <= sqrRadius ||
-                  sqrD.z <= sqrRadius || sqrD.w <= sqrRadius)) {
+            if (!(sqrD.x <= sqrRadius || sqrD.y <= sqrRadius || sqrD.z <= sqrRadius || sqrD.w <= sqrRadius)) {
                 continue;
             }
 
@@ -136,4 +131,4 @@ __global__ void bilateral_filter(SrcWrapper input, DstWrapper output, int radius
     }
 }
 }  // namespace Device
-}  // namespace Kernel
+}  // namespace Kernels

--- a/include/kernels/device/bilateral_filter_device.hpp
+++ b/include/kernels/device/bilateral_filter_device.hpp
@@ -36,7 +36,7 @@ namespace Device {
                                                    
 template <typename T, typename SrcWrapper, typename DstWrapper>
 __global__ void bilateral_filter(SrcWrapper input, DstWrapper output, int radius,
-                                 float sigmaColor, float sigmaSpace, float spaceCoeff, float colorCoeff) {
+                                 float /* sigmaColor */, float /* sigmaSpace */, float spaceCoeff, float colorCoeff) {
     using namespace roccv::detail;
     using worktype = MakeType<float,NumElements<T>>;
     const int idx = (threadIdx.x + blockIdx.x * blockDim.x) * 2;

--- a/include/kernels/device/thresholding_device.hpp
+++ b/include/kernels/device/thresholding_device.hpp
@@ -141,7 +141,7 @@ __global__ void tozero_generic(SrcWrapper input, DstWrapper output,
 template <typename SrcWrapper, typename DstWrapper>
 __global__ void tozeroinv_generic(SrcWrapper input, DstWrapper output,
                                     roccv::GenericTensorWrapper<double> thresh,
-                                    const int32_t maxBatchSize) {
+                                    const int32_t /* maxBatchSize */) {
     using namespace roccv::detail;
     const auto x_idx = threadIdx.x + blockIdx.x * blockDim.x;
     const auto y_idx = threadIdx.y + blockIdx.y * blockDim.y;

--- a/include/kernels/host/bilateral_filter_host.hpp
+++ b/include/kernels/host/bilateral_filter_host.hpp
@@ -23,22 +23,20 @@ THE SOFTWARE.
 #pragma once
 
 #include <hip/hip_runtime.h>
-#include "kernels/kernel_helpers.hpp"
-#include "operator_types.h"
 
-#include "core/detail/type_traits.hpp"
 #include "core/detail/casting.hpp"
+#include "core/detail/type_traits.hpp"
 #include "core/detail/vector_utils.hpp"
+#include "kernels/kernel_helpers.hpp"
 
 namespace Kernels {
 namespace Host {
-                                      
+
 template <typename T, typename SrcWrapper, typename DstWrapper>
-void bilateral_filter(SrcWrapper input, DstWrapper output, int radius, float /* sigmaColor */,
-                      float /* sigmaSpace */, int height, int width, int prevHeight, int prevWidth, 
-                      float spaceCoeff, float colorCoeff) {
+void bilateral_filter(SrcWrapper input, DstWrapper output, int radius, int height, int width, int prevHeight,
+                      int prevWidth, float spaceCoeff, float colorCoeff) {
     using namespace roccv::detail;
-    using worktype = MakeType<float,NumElements<T>>;
+    using worktype = MakeType<float, NumElements<T>>;
     for (int idz = 0; idz < output.batches(); idz++) {
         for (int idy = prevHeight; idy < height; idy += 2) {
             for (int idx = prevWidth; idx < width; idx += 2) {
@@ -47,7 +45,6 @@ void bilateral_filter(SrcWrapper input, DstWrapper output, int radius, float /* 
                 int3 coord2{idx, idy + 1, idz};
                 int3 coord3{idx + 1, idy + 1, idz};
 
-                
                 worktype center0 = StaticCast<worktype>(input.at(coord0.z, coord0.y, coord0.x, 0));
                 worktype center1 = StaticCast<worktype>(input.at(coord1.z, coord1.y, coord1.x, 0));
                 worktype center2 = StaticCast<worktype>(input.at(coord2.z, coord2.y, coord2.x, 0));
@@ -68,8 +65,8 @@ void bilateral_filter(SrcWrapper input, DstWrapper output, int radius, float /* 
                         int t2 = abs(c - (idx + 1)), t3 = abs(r - (idy + 1));
                         float4 sqrD{t0 * t0 + t1 * t1, t2 * t2 + t1 * t1, t0 * t0 + t3 * t3, t3 * t3 + t2 * t2};
 
-                        if (!(sqrD.x <= sqrRadius || sqrD.y <= sqrRadius ||
-                              sqrD.z <= sqrRadius || sqrD.w <= sqrRadius)) {
+                        if (!(sqrD.x <= sqrRadius || sqrD.y <= sqrRadius || sqrD.z <= sqrRadius ||
+                              sqrD.w <= sqrRadius)) {
                             continue;
                         }
 
@@ -79,8 +76,7 @@ void bilateral_filter(SrcWrapper input, DstWrapper output, int radius, float /* 
                         if (sqrD.x <= sqrRadius) {
                             float eSpace = sqrD.x * spaceCoeff;
                             float oneNormSize = norm1(curr - center0);
-                            float eColor =
-                                oneNormSize * oneNormSize * colorCoeff;
+                            float eColor = oneNormSize * oneNormSize * colorCoeff;
                             float weight = exp(eSpace + eColor);
                             den.x += weight;
                             num0 += weight * curr;
@@ -89,8 +85,7 @@ void bilateral_filter(SrcWrapper input, DstWrapper output, int radius, float /* 
                         if (sqrD.y <= sqrRadius) {
                             float eSpace = sqrD.y * spaceCoeff;
                             float oneNormSize = norm1(curr - center1);
-                            float eColor =
-                                oneNormSize * oneNormSize * colorCoeff;
+                            float eColor = oneNormSize * oneNormSize * colorCoeff;
                             float weight = exp(eSpace + eColor);
                             den.y += weight;
                             num1 += (weight * curr);
@@ -99,8 +94,7 @@ void bilateral_filter(SrcWrapper input, DstWrapper output, int radius, float /* 
                         if (sqrD.z <= sqrRadius) {
                             float eSpace = sqrD.z * spaceCoeff;
                             float oneNormSize = norm1(curr - center2);
-                            float eColor =
-                                oneNormSize * oneNormSize * colorCoeff;
+                            float eColor = oneNormSize * oneNormSize * colorCoeff;
                             float weight = exp(eSpace + eColor);
                             den.z += weight;
                             num2 += (weight * curr);
@@ -109,8 +103,7 @@ void bilateral_filter(SrcWrapper input, DstWrapper output, int radius, float /* 
                         if (sqrD.w <= sqrRadius) {
                             float eSpace = sqrD.w * spaceCoeff;
                             float oneNormSize = norm1(curr - center3);
-                            float eColor =
-                                oneNormSize * oneNormSize * colorCoeff;
+                            float eColor = oneNormSize * oneNormSize * colorCoeff;
                             float weight = exp(eSpace + eColor);
                             den.w += weight;
                             num3 += (weight * curr);

--- a/include/kernels/host/bilateral_filter_host.hpp
+++ b/include/kernels/host/bilateral_filter_host.hpp
@@ -34,8 +34,8 @@ namespace Kernels {
 namespace Host {
                                       
 template <typename T, typename SrcWrapper, typename DstWrapper>
-void bilateral_filter(SrcWrapper input, DstWrapper output, int radius, float sigmaColor,
-                      float sigmaSpace, int height, int width, int prevHeight, int prevWidth, 
+void bilateral_filter(SrcWrapper input, DstWrapper output, int radius, float /* sigmaColor */,
+                      float /* sigmaSpace */, int height, int width, int prevHeight, int prevWidth, 
                       float spaceCoeff, float colorCoeff) {
     using namespace roccv::detail;
     using worktype = MakeType<float,NumElements<T>>;

--- a/python/src/py_tensor.cpp
+++ b/python/src/py_tensor.cpp
@@ -128,7 +128,7 @@ std::shared_ptr<PyTensor> PyTensor::fromDLPack(pybind11::object src, eTensorLayo
     return std::make_shared<PyTensor>(tensor, dlManagedTensor);
 }
 
-py::capsule PyTensor::toDLPack(py::object stream) {
+py::capsule PyTensor::toDLPack(py::object /* stream */) {
     // Stream parameter is intentionally left unused to support Pytorch DLPack device conversions
 
     DLManagedTensor* dlTensor = createDLManagedTensor(m_tensor, shared_from_this());

--- a/src/op_bilateral_filter.cpp
+++ b/src/op_bilateral_filter.cpp
@@ -25,6 +25,7 @@ THE SOFTWARE.
 
 #include <functional>
 #include <numeric>
+#include <unordered_map>
 
 #include "common/validation_helpers.hpp"
 #include "core/detail/casting.hpp"

--- a/src/op_bilateral_filter.cpp
+++ b/src/op_bilateral_filter.cpp
@@ -24,14 +24,12 @@ THE SOFTWARE.
 #include <hip/hip_runtime.h>
 
 #include <functional>
-#include <iostream>
 #include <numeric>
 
-#include "common/array_wrapper.hpp"
 #include "common/validation_helpers.hpp"
 #include "core/detail/casting.hpp"
-#include "core/detail/math/math.hpp"
-#include "core/detail/type_traits.hpp"
+#include "core/wrappers/border_wrapper.hpp"
+#include "core/wrappers/image_wrapper.hpp"
 #include "kernels/device/bilateral_filter_device.hpp"
 #include "kernels/host/bilateral_filter_host.hpp"
 
@@ -42,8 +40,7 @@ BilateralFilter::~BilateralFilter() {}
 
 template <typename T, eBorderType B>
 void dispatch_bilateral_filter_border_mode(hipStream_t stream, const Tensor &input, const Tensor &output, int diameter,
-                                           float sigmaColor, float sigmaSpace, T borderValue,
-                                           eDeviceType device) {
+                                           float sigmaColor, float sigmaSpace, T borderValue, eDeviceType device) {
     BorderWrapper<T, B> inputWrapper(input, borderValue);
     ImageWrapper<T> outputWrapper(output);
 
@@ -78,8 +75,8 @@ void dispatch_bilateral_filter_border_mode(hipStream_t stream, const Tensor &inp
         uint32_t zGridSize = outputWrapper.batches();
         dim3 grid(xGridSize, yGridSize, zGridSize);
 
-        Kernels::Device::bilateral_filter<T><<<grid, block, 0, stream>>>(
-            inputWrapper, outputWrapper, radius, sigmaColor, sigmaSpace, spaceCoeff, colorCoeff);
+        Kernels::Device::bilateral_filter<T>
+            <<<grid, block, 0, stream>>>(inputWrapper, outputWrapper, radius, spaceCoeff, colorCoeff);
     } else if (device == eDeviceType::CPU) {
         int divisor = std::gcd(4, outputWrapper.height());  // greatest common divisor
         int dividend = std::gcd((numThreads / divisor), outputWrapper.width());
@@ -94,9 +91,8 @@ void dispatch_bilateral_filter_border_mode(hipStream_t stream, const Tensor &inp
         for (int j = 0; j < divisor; j++) {
             for (int i = 0; i < dividend; i++) {
                 threads.push_back(std::thread(Kernels::Host::bilateral_filter<T, BorderWrapper<T, B>, ImageWrapper<T>>,
-                                              inputWrapper, outputWrapper, radius, sigmaColor, sigmaSpace,
-                                              rollingHeight, rollingWidth, prevHeight, prevWidth, spaceCoeff,
-                                              colorCoeff));
+                                              inputWrapper, outputWrapper, radius, rollingHeight, rollingWidth,
+                                              prevHeight, prevWidth, spaceCoeff, colorCoeff));
                 prevWidth = rollingWidth;
                 rollingWidth += factorW;
             }
@@ -113,8 +109,8 @@ void dispatch_bilateral_filter_border_mode(hipStream_t stream, const Tensor &inp
 
 template <typename T>
 void dispatch_bilateral_filter_dtype(hipStream_t stream, const Tensor &input, const Tensor &output, int diameter,
-                                     float sigmaColor, float sigmaSpace, eBorderType borderMode,
-                                     float4 borderValue, eDeviceType device) {
+                                     float sigmaColor, float sigmaSpace, eBorderType borderMode, float4 borderValue,
+                                     eDeviceType device) {
     // Select kernel dispatcher based on requested border mode.
     // clang-format off
     static const std::unordered_map<eBorderType, std::function<void(hipStream_t, const Tensor&, const Tensor&, int, float, float, T, eDeviceType)>>
@@ -181,7 +177,5 @@ void BilateralFilter::operator()(hipStream_t stream, const roccv::Tensor &input,
     auto func = funcs.at(dtype)[channels - 1];
     if (func == 0) throw Exception("Not mapped to a defined function.", eStatusType::INVALID_OPERATION);
     func(stream, input, output, diameter, sigmaColor, sigmaSpace, borderMode, borderValue, device);
-
-    //////////////////////////////////////////////////////////////////////////////////////////////////////////
 }
 }  // namespace roccv

--- a/src/op_remap.cpp
+++ b/src/op_remap.cpp
@@ -40,7 +40,7 @@ Remap::~Remap() {}
 
 template <typename T, eBorderType B, eInterpolationType I, eInterpolationType M>
 void dispatch_remap_mapInterp(hipStream_t stream, const Tensor &input, const Tensor &output, const Tensor &map,
-                              eRemapType mapValueType, bool alignCorners, T borderValue,
+                              eRemapType /* mapValueType */, bool /* alignCorners */, T borderValue,
                               eDeviceType device) {
     ImageWrapper<T> outputWrapper(output);
     InterpolationWrapper<float2, B, M> wrappedMapTensor(map, make_float2(0, 0));

--- a/tests/roccv/cpp/src/tests/core/detail/test_default_allocator.cpp
+++ b/tests/roccv/cpp/src/tests/core/detail/test_default_allocator.cpp
@@ -79,6 +79,8 @@ void TestCorrectness() {
 }  // namespace
 
 int main(int argc, char** argv) {
+    (void)argc;
+    (void)argv;
     TEST_CASES_BEGIN();
 
     TEST_CASE(TestCorrectness());

--- a/tests/roccv/cpp/src/tests/core/detail/test_range_cast.cpp
+++ b/tests/roccv/cpp/src/tests/core/detail/test_range_cast.cpp
@@ -28,6 +28,8 @@ using namespace roccv::tests;
 using namespace roccv;
 
 int main(int argc, char **argv) {
+    (void)argc;
+    (void)argv;
     TEST_CASES_BEGIN();
 
     // clang-format off

--- a/tests/roccv/cpp/src/tests/core/detail/test_swizzling.cpp
+++ b/tests/roccv/cpp/src/tests/core/detail/test_swizzling.cpp
@@ -47,6 +47,8 @@ void TestCorrectness(T input, T expected) {
 }  // namespace
 
 int main(int argc, char **argv) {
+    (void)argc;
+    (void)argv;
     TEST_CASES_BEGIN();
 
     // ZYXW swizzling

--- a/tests/roccv/cpp/src/tests/core/tensor/test_tensor.cpp
+++ b/tests/roccv/cpp/src/tests/core/tensor/test_tensor.cpp
@@ -145,6 +145,8 @@ void TestTensorStrideCalculation(const TensorShape& shape, const DataType& dtype
 }  // namespace
 
 int main(int argc, char** argv) {
+    (void)argc;
+    (void)argv;
     TEST_CASES_BEGIN();
 
     // Negative tests

--- a/tests/roccv/cpp/src/tests/core/tensor/test_tensor_shape.cpp
+++ b/tests/roccv/cpp/src/tests/core/tensor/test_tensor_shape.cpp
@@ -121,6 +121,8 @@ void TestTensorShapeCorrectness() {
 }  // namespace
 
 int main(int argc, char** argv) {
+    (void)argc;
+    (void)argv;
     TEST_CASES_BEGIN();
 
     TEST_CASE(TestTensorShapeCorrectness());

--- a/tests/roccv/cpp/src/tests/core/wrappers/test_border_wrapper.cpp
+++ b/tests/roccv/cpp/src/tests/core/wrappers/test_border_wrapper.cpp
@@ -198,6 +198,8 @@ void TestCorrectness(float4 borderValue, int32_t batchSize, Size2D imageSize, in
 }  // namespace
 
 int main(int argc, char** argv) {
+    (void)argc;
+    (void)argv;
     TEST_CASES_BEGIN();
 
     // clang-format off

--- a/tests/roccv/cpp/src/tests/core/wrappers/test_image_wrapper.cpp
+++ b/tests/roccv/cpp/src/tests/core/wrappers/test_image_wrapper.cpp
@@ -70,6 +70,8 @@ void TestImageWrapperConstructor(int imageCount, Size2D imageSize, ImageFormat f
 }  // namespace
 
 int main(int argc, char** argv) {
+    (void)argc;
+    (void)argv;
     TEST_CASES_BEGIN();
 
     TEST_CASE(TestImageWrapperConstructor<uchar3>(2, {54, 67}, FMT_RGB8));

--- a/tests/roccv/cpp/src/tests/core/wrappers/test_interpolation_wrapper.cpp
+++ b/tests/roccv/cpp/src/tests/core/wrappers/test_interpolation_wrapper.cpp
@@ -229,6 +229,8 @@ void TestCorrectness(int64_t batchSize, Size2D imageSize, float4 borderValue, fl
 }  // namespace
 
 int main(int argc, char **argv) {
+    (void)argc;
+    (void)argv;
     TEST_CASES_BEGIN();
 
     // clang-format off

--- a/tests/roccv/cpp/src/tests/operators/test_op_adv_cvt_color.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_adv_cvt_color.cpp
@@ -20,11 +20,11 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-#include <core/detail/casting.hpp>
 #include <core/hip_assert.h>
-#include <op_adv_cvt_color.hpp>
 
 #include <array>
+#include <core/detail/casting.hpp>
+#include <op_adv_cvt_color.hpp>
 
 #include "test_helpers.hpp"
 
@@ -54,7 +54,8 @@ Coeff GetCoeff(eColorSpec spec) {
             return {0.2126f, 0.7152f, 0.0722f, 0.538909248f, 0.63500127f, 1.5748f, -0.187324f, -0.468124f, 1.8556f};
         case BT2020:
             return {0.2627f, 0.6780f, 0.0593f, 0.531519082f, 0.678150007f, 1.4746f, -0.16455f, -0.57135f, 1.8814f};
-        default: throw std::runtime_error("Unsupported color spec");
+        default:
+            throw std::runtime_error("Unsupported color spec");
     }
 }
 
@@ -63,8 +64,10 @@ bool IsSemiPlanarToInterleaved(eColorConversionCode code) {
         case COLOR_YUV2RGB_NV12:
         case COLOR_YUV2BGR_NV12:
         case COLOR_YUV2RGB_NV21:
-        case COLOR_YUV2BGR_NV21: return true;
-        default: return false;
+        case COLOR_YUV2BGR_NV21:
+            return true;
+        default:
+            return false;
     }
 }
 
@@ -73,8 +76,10 @@ bool IsInterleavedToSemiPlanar(eColorConversionCode code) {
         case COLOR_RGB2YUV_NV12:
         case COLOR_BGR2YUV_NV12:
         case COLOR_RGB2YUV_NV21:
-        case COLOR_BGR2YUV_NV21: return true;
-        default: return false;
+        case COLOR_BGR2YUV_NV21:
+            return true;
+        default:
+            return false;
     }
 }
 
@@ -83,8 +88,10 @@ bool IsInterleaved444(eColorConversionCode code) {
         case COLOR_RGB2YUV:
         case COLOR_BGR2YUV:
         case COLOR_YUV2RGB:
-        case COLOR_YUV2BGR: return true;
-        default: return false;
+        case COLOR_YUV2BGR:
+            return true;
+        default:
+            return false;
     }
 }
 
@@ -95,8 +102,10 @@ bool IsBGRCode(eColorConversionCode code) {
         case COLOR_YUV2BGR_NV12:
         case COLOR_YUV2BGR_NV21:
         case COLOR_BGR2YUV_NV12:
-        case COLOR_BGR2YUV_NV21: return true;
-        default: return false;
+        case COLOR_BGR2YUV_NV21:
+            return true;
+        default:
+            return false;
     }
 }
 
@@ -105,14 +114,14 @@ bool IsNV12Code(eColorConversionCode code) {
         case COLOR_YUV2RGB_NV12:
         case COLOR_YUV2BGR_NV12:
         case COLOR_RGB2YUV_NV12:
-        case COLOR_BGR2YUV_NV12: return true;
-        default: return false;
+        case COLOR_BGR2YUV_NV12:
+            return true;
+        default:
+            return false;
     }
 }
 
-inline int idx3(int x, int y, int width, int c) {
-    return (y * width + x) * 3 + c;
-}
+inline int idx3(int x, int y, int width, int c) { return (y * width + x) * 3 + c; }
 
 std::vector<uint8_t> GoldenInterleaved444(const std::vector<uint8_t> &input, int samples, int width, int height,
                                           eColorConversionCode code, eColorSpec spec) {
@@ -157,7 +166,8 @@ std::vector<uint8_t> GoldenInterleaved444(const std::vector<uint8_t> &input, int
                         output[i + (IsBGRCode(code) ? 2 : 0)] = roccv::detail::SaturateCast<uint8_t>(r);
                         break;
                     }
-                    default: throw std::runtime_error("Invalid interleaved code");
+                    default:
+                        throw std::runtime_error("Invalid interleaved code");
                 }
             }
         }
@@ -256,13 +266,11 @@ std::vector<uint8_t> GoldenSemiPlanarToInterleaved(const std::vector<uint8_t> &i
 
 void TestCorrectness(int samples, int width, int height, eColorConversionCode code, eColorSpec spec,
                      eDeviceType device) {
-    Tensor inputTensor = IsSemiPlanarToInterleaved(code)
-                             ? Tensor(samples, {width, height * 3 / 2}, FMT_U8, device)
-                             : Tensor(samples, {width, height}, FMT_RGB8, device);
+    Tensor inputTensor = IsSemiPlanarToInterleaved(code) ? Tensor(samples, {width, height * 3 / 2}, FMT_U8, device)
+                                                         : Tensor(samples, {width, height}, FMT_RGB8, device);
 
-    Tensor outputTensor = IsInterleavedToSemiPlanar(code)
-                              ? Tensor(samples, {width, height * 3 / 2}, FMT_U8, device)
-                              : Tensor(samples, {width, height}, FMT_RGB8, device);
+    Tensor outputTensor = IsInterleavedToSemiPlanar(code) ? Tensor(samples, {width, height * 3 / 2}, FMT_U8, device)
+                                                          : Tensor(samples, {width, height}, FMT_RGB8, device);
 
     std::vector<uint8_t> inputData(inputTensor.shape().size());
     FillVector(inputData);
@@ -295,6 +303,8 @@ void TestCorrectness(int samples, int width, int height, eColorConversionCode co
 }  // namespace
 
 int main(int argc, char **argv) {
+    (void)argc;
+    (void)argv;
     TEST_CASES_BEGIN();
 
     std::array<eColorSpec, 3> specs = {BT601, BT709, BT2020};

--- a/tests/roccv/cpp/src/tests/operators/test_op_bilateral_filter.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_bilateral_filter.cpp
@@ -165,6 +165,8 @@ void TestCorrectness(int batchSize, int width, int height, ImageFormat format, i
 }  // namespace
 
 int main(int argc, char** argv) {
+    (void)argc;
+    (void)argv;
     TEST_CASES_BEGIN();
 
     // GPU correctness tests

--- a/tests/roccv/cpp/src/tests/operators/test_op_bnd_box.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_bnd_box.cpp
@@ -177,6 +177,8 @@ void TestCorrectness(int batchSize, int width, int height, ImageFormat format, e
 }  // namespace
 
 int main(int argc, char **argv) {
+    (void)argc;
+    (void)argv;
     TEST_CASES_BEGIN();
 
     // GPU correctness tests

--- a/tests/roccv/cpp/src/tests/operators/test_op_center_crop.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_center_crop.cpp
@@ -144,6 +144,8 @@ void TestNegative() {
 }
 
 int main(int argc, char** argv) {
+    (void)argc;
+    (void)argv;
     TEST_CASES_BEGIN();
 
     // Test negative CenterCrop operator cases

--- a/tests/roccv/cpp/src/tests/operators/test_op_composite.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_composite.cpp
@@ -164,6 +164,8 @@ void TestCorrectness(int batchSize, int width, int height, ImageFormat fmt, Imag
 }  // namespace
 
 int main(int argc, char **argv) {
+    (void)argc;
+    (void)argv;
     TEST_CASES_BEGIN();
 
     // Test RGB8 input/output

--- a/tests/roccv/cpp/src/tests/operators/test_op_convert_to.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_convert_to.cpp
@@ -107,6 +107,8 @@ void TestCorrectness(int batchSize, int width, int height, ImageFormat inFormat,
 } // namespace
 
 int main(int argc, char** argv) {
+    (void)argc;
+    (void)argv;
     TEST_CASES_BEGIN();
 
     // CPU correctness tests

--- a/tests/roccv/cpp/src/tests/operators/test_op_copy_make_border.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_copy_make_border.cpp
@@ -126,6 +126,8 @@ void TestCorrectness(int batchSize, Size2D inputSize, Size2D outputSize, ImageFo
 }  // namespace
 
 int main(int argc, char** argv) {
+    (void)argc;
+    (void)argv;
     TEST_CASES_BEGIN();
 
     // clang-format off

--- a/tests/roccv/cpp/src/tests/operators/test_op_custom_crop.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_custom_crop.cpp
@@ -152,6 +152,8 @@ void TestNegative() {
 }  // namespace
 
 int main(int argc, char** argv) {
+    (void)argc;
+    (void)argv;
     TEST_CASES_BEGIN();
 
     // Test negative CustomCrop operator cases

--- a/tests/roccv/cpp/src/tests/operators/test_op_cvt_color.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_cvt_color.cpp
@@ -196,6 +196,8 @@ void TestCorrectness(int samples, int width, int height, ImageFormat inFmt, Imag
 }  // namespace
 
 int main(int argc, char** argv) {
+    (void)argc;
+    (void)argv;
     TEST_CASES_BEGIN();
 
     // // GPU correctness tests

--- a/tests/roccv/cpp/src/tests/operators/test_op_flip.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_flip.cpp
@@ -174,6 +174,8 @@ void TestNegativeFlip() {
 }  // namespace
 
 int main(int argc, char** argv) {
+    (void)argc;
+    (void)argv;
     TEST_CASES_BEGIN();
 
     // Test negative Flip operator cases

--- a/tests/roccv/cpp/src/tests/operators/test_op_gamma_contrast.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_gamma_contrast.cpp
@@ -125,6 +125,8 @@ void TestCorrectness(int batchSize, int width, int height, float gamma, ImageFor
 } // namespace
 
 int main(int argc, char** argv) {
+    (void)argc;
+    (void)argv;
     TEST_CASES_BEGIN();
 
     // GPU correctness tests

--- a/tests/roccv/cpp/src/tests/operators/test_op_histogram.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_histogram.cpp
@@ -182,6 +182,8 @@ void TestCorrectness(int batchSize, int width, int height, ImageFormat format, e
 }  // namespace
 
 int main(int argc, char** argv) {
+    (void)argc;
+    (void)argv;
     TEST_CASES_BEGIN();
 
     // GPU correctness tests

--- a/tests/roccv/cpp/src/tests/operators/test_op_non_max_suppression.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_non_max_suppression.cpp
@@ -197,6 +197,8 @@ void TestCorrectness(int batchSize, int numBoxes, float scoreThreshold, float io
 }  // namespace
 
 int main(int argc, char **argv) {
+    (void)argc;
+    (void)argv;
     TEST_CASES_BEGIN();
 
     // GPU conformance tests

--- a/tests/roccv/cpp/src/tests/operators/test_op_normalize.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_normalize.cpp
@@ -198,6 +198,8 @@ void TestCorrectness(int batchSize, Size2D imgSize, ImageFormat imgFormat, bool 
 }
 
 int main(int argc, char** argv) {
+    (void)argc;
+    (void)argv;
     TEST_CASES_BEGIN();
 
     // GPU correctness tests

--- a/tests/roccv/cpp/src/tests/operators/test_op_reformat.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_reformat.cpp
@@ -203,6 +203,8 @@ static void TestNegativeReformat() {
 }  // namespace
 
 int main(int argc, char** argv) {
+    (void)argc;
+    (void)argv;
     TEST_CASES_BEGIN();
 
     // clang-format off

--- a/tests/roccv/cpp/src/tests/operators/test_op_remap.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_remap.cpp
@@ -166,6 +166,8 @@ void TestCorrectness(int batchSize, int width, int height, ImageFormat format, f
 }  // namespace
 
 int main(int argc, char** argv) {
+    (void)argc;
+    (void)argv;
     TEST_CASES_BEGIN();
 
     TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,

--- a/tests/roccv/cpp/src/tests/operators/test_op_resize.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_resize.cpp
@@ -129,6 +129,8 @@ void TestCorrectness(int batchSize, Size2D inputSize, Size2D outputSize, ImageFo
 }  // namespace
 
 int main(int argc, char **argv) {
+    (void)argc;
+    (void)argv;
     TEST_CASES_BEGIN();
 
     // clang-format off

--- a/tests/roccv/cpp/src/tests/operators/test_op_rotate.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_rotate.cpp
@@ -153,6 +153,8 @@ void TestCorrectness(int batchSize, Size2D imageSize, ImageFormat format, double
 }  // namespace
 
 int main(int argc, char** argv) {
+    (void)argc;
+    (void)argv;
     TEST_CASES_BEGIN();
 
     // clang-format off

--- a/tests/roccv/cpp/src/tests/operators/test_op_thresholding.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_thresholding.cpp
@@ -275,6 +275,8 @@ void TestCorrectness(int batchSize, int width, int height, double threshVal, dou
 } // namespace
 
 int main(int argc, char** argv) {
+    (void)argc;
+    (void)argv;
     TEST_CASES_BEGIN();
 
     // GPU correctness tests    

--- a/tests/roccv/cpp/src/tests/operators/test_op_warp_affine.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_warp_affine.cpp
@@ -160,6 +160,8 @@ static const std::array<float, 6> MAT_SCALE =       {2.0f,  0, 0,     0, 1, 0};
 }  // namespace
 
 int main(int argc, char** argv) {
+    (void)argc;
+    (void)argv;
     TEST_CASES_BEGIN();
 
     // clang-format off

--- a/tests/roccv/cpp/src/tests/operators/test_op_warp_perspective.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_warp_perspective.cpp
@@ -156,6 +156,8 @@ static const std::array<float, 9> MAT_PERSPECTIVE_SKEW =    {1, 0,    0,  0,    
 }  // namespace
 
 int main(int argc, char** argv) {
+    (void)argc;
+    (void)argv;
     TEST_CASES_BEGIN();
 
     // clang-format off


### PR DESCRIPTION
## Description
* Refactors various parts of the codebase to ensure that warnings related to the `-Wextra` category are resolved. Once the remaining error category is resolved, `-Werror` must be added to prevent additional warnings from being introduced into the codebase.
* Resolves #130 
* Resolves #131 

## Testing
* Test that warnings aren't thrown by re-running the entire build and ensuring that no warnings are thrown during the build process with `-Wextra` enabled. In a local build with TheRock installed, no warnings are thrown with these changes.