### PR TITLE
[Bugfix] Resolve -Wsign-compare warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,10 +114,7 @@ message("-- ${BoldBlue}${PROJECT_NAME} Build Type -- ${CMAKE_BUILD_TYPE}${ColorR
 # Set all warnings
 # -Wall                -- Print all warnings
 # -Wextra              -- Print extra warnings
-# -Wno-sign-compare    -- Don't print warnings about comparing signed and unsigned integers
-# TODO: Resolve sign-compare warnings. Once all warnings are resolved, remove Wno-sign-compare and add -Werror
-# to prevent any new warnings from being introduced.
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wno-sign-compare -Werror")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
 
 # Enable LLVM code coverage if build type is Debug and ENABLE_CODE_COVERAGE is set.
 if(ENABLE_CODE_COVERAGE AND CMAKE_BUILD_TYPE MATCHES Debug)

--- a/include/kernels/device/thresholding_device.hpp
+++ b/include/kernels/device/thresholding_device.hpp
@@ -23,28 +23,28 @@ THE SOFTWARE.
 #pragma once
 
 #include <hip/hip_runtime.h>
+
 #include <core/wrappers/generic_tensor_wrapper.hpp>
-#include "core/detail/type_traits.hpp"
+
 #include "core/detail/casting.hpp"
+#include "core/detail/type_traits.hpp"
 #include "operator_types.h"
 
 namespace Kernels {
 namespace Device {
 template <typename SrcWrapper, typename DstWrapper>
-__global__ void binary_generic(SrcWrapper input, DstWrapper output,
-                                roccv::GenericTensorWrapper<double> thresh,
-                                roccv::GenericTensorWrapper<double> maxVal,
-                                const int32_t maxBatchSize) {
+__global__ void binary_generic(SrcWrapper input, DstWrapper output, roccv::GenericTensorWrapper<double> thresh,
+                               roccv::GenericTensorWrapper<double> maxVal) {
     using namespace roccv::detail;
     const auto x_idx = threadIdx.x + blockIdx.x * blockDim.x;
     const auto y_idx = threadIdx.y + blockIdx.y * blockDim.y;
     const auto z_idx = threadIdx.z + blockIdx.z * blockDim.z;
-    
+
     using src_type = typename SrcWrapper::ValueType;
     using dst_type = typename DstWrapper::ValueType;
     using base_type = BaseType<dst_type>;
 
-    if (x_idx < output.width() && y_idx < output.height() && z_idx < maxBatchSize) {
+    if (x_idx < output.width() && y_idx < output.height()) {
         double th = thresh.at(z_idx);
         double mv = maxVal.at(z_idx);
         src_type inputVal = input.at(z_idx, y_idx, x_idx, 0);
@@ -59,20 +59,18 @@ __global__ void binary_generic(SrcWrapper input, DstWrapper output,
 }
 
 template <typename SrcWrapper, typename DstWrapper>
-__global__ void binary_inv_generic(SrcWrapper input, DstWrapper output,
-                                    roccv::GenericTensorWrapper<double> thresh,
-                                    roccv::GenericTensorWrapper<double> maxVal,
-                                    const int32_t maxBatchSize) {
+__global__ void binary_inv_generic(SrcWrapper input, DstWrapper output, roccv::GenericTensorWrapper<double> thresh,
+                                   roccv::GenericTensorWrapper<double> maxVal) {
     using namespace roccv::detail;
     const auto x_idx = threadIdx.x + blockIdx.x * blockDim.x;
     const auto y_idx = threadIdx.y + blockIdx.y * blockDim.y;
     const auto z_idx = threadIdx.z + blockIdx.z * blockDim.z;
-    
+
     using src_type = typename SrcWrapper::ValueType;
     using dst_type = typename DstWrapper::ValueType;
     using base_type = BaseType<dst_type>;
 
-    if (x_idx < output.width() && y_idx < output.height() && z_idx < maxBatchSize) {
+    if (x_idx < output.width() && y_idx < output.height()) {
         double th = thresh.at(z_idx);
         double mv = maxVal.at(z_idx);
         src_type inputVal = input.at(z_idx, y_idx, x_idx, 0);
@@ -87,19 +85,17 @@ __global__ void binary_inv_generic(SrcWrapper input, DstWrapper output,
 }
 
 template <typename SrcWrapper, typename DstWrapper>
-__global__ void trunc_generic(SrcWrapper input, DstWrapper output,
-                                roccv::GenericTensorWrapper<double> thresh,
-                                const int32_t maxBatchSize) {
+__global__ void trunc_generic(SrcWrapper input, DstWrapper output, roccv::GenericTensorWrapper<double> thresh) {
     using namespace roccv::detail;
     const auto x_idx = threadIdx.x + blockIdx.x * blockDim.x;
     const auto y_idx = threadIdx.y + blockIdx.y * blockDim.y;
     const auto z_idx = threadIdx.z + blockIdx.z * blockDim.z;
-    
+
     using src_type = typename SrcWrapper::ValueType;
     using dst_type = typename DstWrapper::ValueType;
     using base_type = BaseType<dst_type>;
 
-    if (x_idx < output.width() && y_idx < output.height() && z_idx < maxBatchSize) {
+    if (x_idx < output.width() && y_idx < output.height()) {
         double th = thresh.at(z_idx);
         src_type inputVal = input.at(z_idx, y_idx, x_idx, 0);
         dst_type outputVal;
@@ -113,19 +109,17 @@ __global__ void trunc_generic(SrcWrapper input, DstWrapper output,
 }
 
 template <typename SrcWrapper, typename DstWrapper>
-__global__ void tozero_generic(SrcWrapper input, DstWrapper output,
-                                roccv::GenericTensorWrapper<double> thresh,
-                                const int32_t maxBatchSize) {
+__global__ void tozero_generic(SrcWrapper input, DstWrapper output, roccv::GenericTensorWrapper<double> thresh) {
     using namespace roccv::detail;
     const auto x_idx = threadIdx.x + blockIdx.x * blockDim.x;
     const auto y_idx = threadIdx.y + blockIdx.y * blockDim.y;
     const auto z_idx = threadIdx.z + blockIdx.z * blockDim.z;
-    
+
     using src_type = typename SrcWrapper::ValueType;
     using dst_type = typename DstWrapper::ValueType;
     using base_type = BaseType<dst_type>;
 
-    if (x_idx < output.width() && y_idx < output.height() && z_idx < maxBatchSize) {
+    if (x_idx < output.width() && y_idx < output.height()) {
         double th = thresh.at(z_idx);
         src_type inputVal = input.at(z_idx, y_idx, x_idx, 0);
         dst_type outputVal;
@@ -139,20 +133,18 @@ __global__ void tozero_generic(SrcWrapper input, DstWrapper output,
 }
 
 template <typename SrcWrapper, typename DstWrapper>
-__global__ void tozeroinv_generic(SrcWrapper input, DstWrapper output,
-                                    roccv::GenericTensorWrapper<double> thresh,
-                                    const int32_t /* maxBatchSize */) {
+__global__ void tozeroinv_generic(SrcWrapper input, DstWrapper output, roccv::GenericTensorWrapper<double> thresh) {
     using namespace roccv::detail;
     const auto x_idx = threadIdx.x + blockIdx.x * blockDim.x;
     const auto y_idx = threadIdx.y + blockIdx.y * blockDim.y;
     const auto z_idx = threadIdx.z + blockIdx.z * blockDim.z;
-    
+
     using src_type = typename SrcWrapper::ValueType;
     using dst_type = typename DstWrapper::ValueType;
     using base_type = BaseType<dst_type>;
 
     if (x_idx >= output.width() || y_idx >= output.height()) return;
-    
+
     double th = thresh.at(z_idx);
     src_type inputVal = input.at(z_idx, y_idx, x_idx, 0);
     dst_type outputVal;
@@ -163,5 +155,5 @@ __global__ void tozeroinv_generic(SrcWrapper input, DstWrapper output,
     }
     output.at(z_idx, y_idx, x_idx, 0) = outputVal;
 }
-}   // namespace Device
-}   // namespace Kernels
+}  // namespace Device
+}  // namespace Kernels

--- a/include/kernels/host/thresholding_host.hpp
+++ b/include/kernels/host/thresholding_host.hpp
@@ -23,22 +23,24 @@ THE SOFTWARE.
 #pragma once
 
 #include <hip/hip_runtime.h>
+
 #include <core/wrappers/generic_tensor_wrapper.hpp>
-#include "core/detail/type_traits.hpp"
+
 #include "core/detail/casting.hpp"
+#include "core/detail/type_traits.hpp"
 #include "operator_types.h"
 
 namespace Kernels {
 namespace Host {
 template <typename SrcWrapper, typename DstWrapper>
 void binary_generic(SrcWrapper input, DstWrapper output, roccv::GenericTensorWrapper<double> thresh,
-                           roccv::GenericTensorWrapper<double> maxVal, const int32_t maxBatchSize) {
+                    roccv::GenericTensorWrapper<double> maxVal) {
     using namespace roccv::detail;
     using src_type = typename SrcWrapper::ValueType;
     using dst_type = typename DstWrapper::ValueType;
     using base_type = BaseType<dst_type>;
-    
-    for (int z_idx = 0; z_idx < maxBatchSize; z_idx++) {
+
+    for (int z_idx = 0; z_idx < output.batches(); z_idx++) {
         double th = thresh.at(z_idx);
         double mv = maxVal.at(z_idx);
         for (int y_idx = 0; y_idx < output.height(); y_idx++) {
@@ -58,13 +60,13 @@ void binary_generic(SrcWrapper input, DstWrapper output, roccv::GenericTensorWra
 
 template <typename SrcWrapper, typename DstWrapper>
 void binary_inv_generic(SrcWrapper input, DstWrapper output, roccv::GenericTensorWrapper<double> thresh,
-                           roccv::GenericTensorWrapper<double> maxVal, const int32_t maxBatchSize) {
+                        roccv::GenericTensorWrapper<double> maxVal) {
     using namespace roccv::detail;
     using src_type = typename SrcWrapper::ValueType;
     using dst_type = typename DstWrapper::ValueType;
     using base_type = BaseType<dst_type>;
-    
-    for (int z_idx = 0; z_idx < maxBatchSize; z_idx++) {
+
+    for (int z_idx = 0; z_idx < output.batches(); z_idx++) {
         double th = thresh.at(z_idx);
         double mv = maxVal.at(z_idx);
         for (int y_idx = 0; y_idx < output.height(); y_idx++) {
@@ -83,14 +85,13 @@ void binary_inv_generic(SrcWrapper input, DstWrapper output, roccv::GenericTenso
 }
 
 template <typename SrcWrapper, typename DstWrapper>
-void trunc_generic(SrcWrapper input, DstWrapper output, 
-                    roccv::GenericTensorWrapper<double> thresh, const int32_t maxBatchSize) {
+void trunc_generic(SrcWrapper input, DstWrapper output, roccv::GenericTensorWrapper<double> thresh) {
     using namespace roccv::detail;
     using src_type = typename SrcWrapper::ValueType;
     using dst_type = typename DstWrapper::ValueType;
     using base_type = BaseType<dst_type>;
-    
-    for (int z_idx = 0; z_idx < maxBatchSize; z_idx++) {
+
+    for (int z_idx = 0; z_idx < output.batches(); z_idx++) {
         double th = thresh.at(z_idx);
         for (int y_idx = 0; y_idx < output.height(); y_idx++) {
             for (int x_idx = 0; x_idx < output.width(); x_idx++) {
@@ -108,14 +109,13 @@ void trunc_generic(SrcWrapper input, DstWrapper output,
 }
 
 template <typename SrcWrapper, typename DstWrapper>
-void tozero_generic(SrcWrapper input, DstWrapper output, 
-                        roccv::GenericTensorWrapper<double> thresh, const int32_t maxBatchSize) {
+void tozero_generic(SrcWrapper input, DstWrapper output, roccv::GenericTensorWrapper<double> thresh) {
     using namespace roccv::detail;
     using src_type = typename SrcWrapper::ValueType;
     using dst_type = typename DstWrapper::ValueType;
     using base_type = BaseType<dst_type>;
-    
-    for (int z_idx = 0; z_idx < maxBatchSize; z_idx++) {
+
+    for (int z_idx = 0; z_idx < output.batches(); z_idx++) {
         double th = thresh.at(z_idx);
         for (int y_idx = 0; y_idx < output.height(); y_idx++) {
             for (int x_idx = 0; x_idx < output.width(); x_idx++) {
@@ -133,14 +133,13 @@ void tozero_generic(SrcWrapper input, DstWrapper output,
 }
 
 template <typename SrcWrapper, typename DstWrapper>
-void tozeroinv_generic(SrcWrapper input, DstWrapper output, 
-                        roccv::GenericTensorWrapper<double> thresh, const int32_t maxBatchSize) {
+void tozeroinv_generic(SrcWrapper input, DstWrapper output, roccv::GenericTensorWrapper<double> thresh) {
     using namespace roccv::detail;
     using src_type = typename SrcWrapper::ValueType;
     using dst_type = typename DstWrapper::ValueType;
     using base_type = BaseType<dst_type>;
-    
-    for (int z_idx = 0; z_idx < maxBatchSize; z_idx++) {
+
+    for (int z_idx = 0; z_idx < output.batches(); z_idx++) {
         double th = thresh.at(z_idx);
         for (int y_idx = 0; y_idx < output.height(); y_idx++) {
             for (int x_idx = 0; x_idx < output.width(); x_idx++) {

--- a/python/src/operators/py_op_warp_perspective.cpp
+++ b/python/src/operators/py_op_warp_perspective.cpp
@@ -40,7 +40,7 @@ PyTensor PyOpWarpPerspective::Execute(PyTensor& input, py::list xform, bool isIn
 
     // Copy list contents into perspective transform matrix
     PerspectiveTransform perspectiveTransform;
-    for (int i = 0; i < xform.size(); i++) {
+    for (size_t i = 0; i < xform.size(); i++) {
         perspectiveTransform[i] = xform[i].cast<float>();
     }
 
@@ -63,7 +63,7 @@ void PyOpWarpPerspective::ExecuteInto(PyTensor& output, PyTensor& input, py::lis
 
     // Copy list contents into perspective transform matrix
     PerspectiveTransform perspectiveTransform;
-    for (int i = 0; i < xform.size(); i++) {
+    for (size_t i = 0; i < xform.size(); i++) {
         perspectiveTransform[i] = xform[i].cast<float>();
     }
 

--- a/python/src/operators/py_op_warp_perspective.cpp
+++ b/python/src/operators/py_op_warp_perspective.cpp
@@ -35,7 +35,7 @@ PyTensor PyOpWarpPerspective::Execute(PyTensor& input, py::list xform, bool isIn
 
     // Ensure xform is of the correct size.
     if (xform.size() != 9) {
-        std::runtime_error("xform must be of size 9.");
+        throw std::runtime_error("xform must be of size 9.");
     }
 
     // Copy list contents into perspective transform matrix
@@ -58,7 +58,7 @@ void PyOpWarpPerspective::ExecuteInto(PyTensor& output, PyTensor& input, py::lis
 
     // Ensure xform is of the correct size.
     if (xform.size() != 9) {
-        std::runtime_error("xform must be of size 9.");
+        throw std::runtime_error("xform must be of size 9.");
     }
 
     // Copy list contents into perspective transform matrix

--- a/src/op_bilateral_filter.cpp
+++ b/src/op_bilateral_filter.cpp
@@ -102,7 +102,7 @@ void dispatch_bilateral_filter_border_mode(hipStream_t stream, const Tensor &inp
             prevHeight = rollingHeight;
             rollingHeight += factorH;
         }
-        for (int i = 0; i < threads.size(); i++) {
+        for (size_t i = 0; i < threads.size(); i++) {
             threads[i].join();
         }
     }

--- a/src/op_custom_crop.cpp
+++ b/src/op_custom_crop.cpp
@@ -62,8 +62,8 @@ void CustomCrop::operator()(hipStream_t stream, const Tensor& input, const Tenso
                            DATA_TYPE_S32, DATA_TYPE_F32, DATA_TYPE_F64);
     CHECK_TENSOR_CHANNELS(input, 1, 3, 4);
 
-    size_t batchSize = input.shape(input.layout().batch_index());
-    size_t channels = input.shape(input.layout().channels_index());
+    auto batchSize = input.shape(input.layout().batch_index());
+    auto channels = input.shape(input.layout().channels_index());
 
     CHECK_TENSOR_DEVICE(output, device);
     CHECK_TENSOR_COMPARISON(input.layout() == output.layout());

--- a/src/op_thresholding.cpp
+++ b/src/op_thresholding.cpp
@@ -127,11 +127,10 @@ void Threshold::operator()(hipStream_t stream, const Tensor &input, const Tensor
     CHECK_TENSOR_COMPARISON(input.layout() == output.layout());
     CHECK_TENSOR_COMPARISON(input.shape() == output.shape());
     CHECK_TENSOR_COMPARISON(input.dtype() == output.dtype());
-    CHECK_TENSOR_COMPARISON(output.shape(output.layout().batch_index()) == input.shape(input.layout().batch_index()));
-    CHECK_TENSOR_COMPARISON(output.shape(output.layout().channels_index()) ==
-                            input.shape(input.layout().channels_index()));
-    CHECK_TENSOR_COMPARISON(output.shape(output.layout().width_index()) == input.shape(input.layout().width_index()));
-    CHECK_TENSOR_COMPARISON(output.shape(output.layout().height_index()) == input.shape(input.layout().height_index()));
+
+    // Ensure the threshold and max value tensors have the same batch size as the input tensor.
+    CHECK_TENSOR_COMPARISON(thresh.shape("N") == input.shape("N"));
+    CHECK_TENSOR_COMPARISON(maxVal.shape("N") == input.shape("N"));
 
     // Select kernel dispatcher based on number of channels and a base datatype.
     // clang-format off

--- a/src/op_thresholding.cpp
+++ b/src/op_thresholding.cpp
@@ -26,8 +26,6 @@ THE SOFTWARE.
 #include <functional>
 
 #include "common/validation_helpers.hpp"
-#include "core/exception.hpp"
-#include "core/status_type.h"
 #include "core/wrappers/generic_tensor_wrapper.hpp"
 #include "core/wrappers/image_wrapper.hpp"
 #include "kernels/device/thresholding_device.hpp"
@@ -35,14 +33,16 @@ THE SOFTWARE.
 
 namespace roccv {
 Threshold::Threshold(eThresholdType threshType, int32_t maxBatchSize)
-    : m_threshType(threshType), m_maxBatchSize(maxBatchSize) {}
+    : m_threshType(threshType), m_maxBatchSize(maxBatchSize) {
+    // TODO: Determine if we still require m_maxBatchSize.
+    (void)m_maxBatchSize;
+}
 
 Threshold::~Threshold() {}
 
 template <typename T>
 void dispatch_threshold_dtype(hipStream_t stream, const Tensor &input, const Tensor &output, const Tensor &thresh,
-                              const Tensor &maxVal, eThresholdType m_threshType, int32_t m_maxBatchSize,
-                              eDeviceType device) {
+                              const Tensor &maxVal, eThresholdType m_threshType, eDeviceType device) {
     ImageWrapper<T> inputWrapper(input);
     ImageWrapper<T> outputWrapper(output);
 
@@ -51,30 +51,30 @@ void dispatch_threshold_dtype(hipStream_t stream, const Tensor &input, const Ten
 
     if (device == eDeviceType::GPU) {
         dim3 block(64, 16);
-        dim3 grid((width + block.x - 1) / block.x, (height + block.y - 1) / block.y, m_maxBatchSize);
+        dim3 grid((width + block.x - 1) / block.x, (height + block.y - 1) / block.y, outputWrapper.batches());
 
         switch (m_threshType) {
             case THRESH_BINARY:
-                Kernels::Device::binary_generic<<<grid, block, 0, stream>>>(
-                    inputWrapper, outputWrapper, GenericTensorWrapper<double>(thresh),
-                    GenericTensorWrapper<double>(maxVal), m_maxBatchSize);
+                Kernels::Device::binary_generic<<<grid, block, 0, stream>>>(inputWrapper, outputWrapper,
+                                                                            GenericTensorWrapper<double>(thresh),
+                                                                            GenericTensorWrapper<double>(maxVal));
                 break;
             case THRESH_BINARY_INV:
-                Kernels::Device::binary_inv_generic<<<grid, block, 0, stream>>>(
-                    inputWrapper, outputWrapper, GenericTensorWrapper<double>(thresh),
-                    GenericTensorWrapper<double>(maxVal), m_maxBatchSize);
+                Kernels::Device::binary_inv_generic<<<grid, block, 0, stream>>>(inputWrapper, outputWrapper,
+                                                                                GenericTensorWrapper<double>(thresh),
+                                                                                GenericTensorWrapper<double>(maxVal));
                 break;
             case THRESH_TRUNC:
-                Kernels::Device::trunc_generic<<<grid, block, 0, stream>>>(
-                    inputWrapper, outputWrapper, GenericTensorWrapper<double>(thresh), m_maxBatchSize);
+                Kernels::Device::trunc_generic<<<grid, block, 0, stream>>>(inputWrapper, outputWrapper,
+                                                                           GenericTensorWrapper<double>(thresh));
                 break;
             case THRESH_TOZERO:
-                Kernels::Device::tozero_generic<<<grid, block, 0, stream>>>(
-                    inputWrapper, outputWrapper, GenericTensorWrapper<double>(thresh), m_maxBatchSize);
+                Kernels::Device::tozero_generic<<<grid, block, 0, stream>>>(inputWrapper, outputWrapper,
+                                                                            GenericTensorWrapper<double>(thresh));
                 break;
             case THRESH_TOZERO_INV:
-                Kernels::Device::tozeroinv_generic<<<grid, block, 0, stream>>>(
-                    inputWrapper, outputWrapper, GenericTensorWrapper<double>(thresh), m_maxBatchSize);
+                Kernels::Device::tozeroinv_generic<<<grid, block, 0, stream>>>(inputWrapper, outputWrapper,
+                                                                               GenericTensorWrapper<double>(thresh));
                 break;
         }
 
@@ -82,23 +82,20 @@ void dispatch_threshold_dtype(hipStream_t stream, const Tensor &input, const Ten
         switch (m_threshType) {
             case THRESH_BINARY:
                 Kernels::Host::binary_generic(inputWrapper, outputWrapper, GenericTensorWrapper<double>(thresh),
-                                              GenericTensorWrapper<double>(maxVal), m_maxBatchSize);
+                                              GenericTensorWrapper<double>(maxVal));
                 break;
             case THRESH_BINARY_INV:
                 Kernels::Host::binary_inv_generic(inputWrapper, outputWrapper, GenericTensorWrapper<double>(thresh),
-                                                  GenericTensorWrapper<double>(maxVal), m_maxBatchSize);
+                                                  GenericTensorWrapper<double>(maxVal));
                 break;
             case THRESH_TRUNC:
-                Kernels::Host::trunc_generic(inputWrapper, outputWrapper, GenericTensorWrapper<double>(thresh),
-                                             m_maxBatchSize);
+                Kernels::Host::trunc_generic(inputWrapper, outputWrapper, GenericTensorWrapper<double>(thresh));
                 break;
             case THRESH_TOZERO:
-                Kernels::Host::tozero_generic(inputWrapper, outputWrapper, GenericTensorWrapper<double>(thresh),
-                                              m_maxBatchSize);
+                Kernels::Host::tozero_generic(inputWrapper, outputWrapper, GenericTensorWrapper<double>(thresh));
                 break;
             case THRESH_TOZERO_INV:
-                Kernels::Host::tozeroinv_generic(inputWrapper, outputWrapper, GenericTensorWrapper<double>(thresh),
-                                                 m_maxBatchSize);
+                Kernels::Host::tozeroinv_generic(inputWrapper, outputWrapper, GenericTensorWrapper<double>(thresh));
                 break;
         }
     }
@@ -135,12 +132,11 @@ void Threshold::operator()(hipStream_t stream, const Tensor &input, const Tensor
                             input.shape(input.layout().channels_index()));
     CHECK_TENSOR_COMPARISON(output.shape(output.layout().width_index()) == input.shape(input.layout().width_index()));
     CHECK_TENSOR_COMPARISON(output.shape(output.layout().height_index()) == input.shape(input.layout().height_index()));
-    CHECK_TENSOR_COMPARISON(m_maxBatchSize == input.shape(input.layout().batch_index()));
 
     // Select kernel dispatcher based on number of channels and a base datatype.
     // clang-format off
     static const std::unordered_map<
-    eDataType, std::array<std::function<void(hipStream_t, const Tensor &, const Tensor &, const Tensor &, const Tensor &, eThresholdType, int32_t, eDeviceType)>, 4>>
+    eDataType, std::array<std::function<void(hipStream_t, const Tensor &, const Tensor &, const Tensor &, const Tensor &, eThresholdType, eDeviceType)>, 4>>
         funcs = 
         {
             {eDataType::DATA_TYPE_U8, {dispatch_threshold_dtype<uchar1>, 0, dispatch_threshold_dtype<uchar3>, dispatch_threshold_dtype<uchar4>}},
@@ -152,6 +148,6 @@ void Threshold::operator()(hipStream_t stream, const Tensor &input, const Tensor
     // clang-format on
 
     auto func = funcs.at(input.dtype().etype())[input.shape(input.layout().channels_index()) - 1];
-    func(stream, input, output, thresh, maxVal, m_threshType, m_maxBatchSize, device);
+    func(stream, input, output, thresh, maxVal, m_threshType, device);
 }
 }  // namespace roccv

--- a/tests/roccv/cpp/include/test_helpers.hpp
+++ b/tests/roccv/cpp/include/test_helpers.hpp
@@ -142,7 +142,7 @@ namespace tests {
                                      " elements) differ in size.");                                               \
         }                                                                                                         \
                                                                                                                   \
-        for (int i = 0; i < actual.size(); i++) {                                                                 \
+        for (size_t i = 0; i < actual.size(); i++) {                                                              \
             if (actual[i] != expected[i]) {                                                                       \
                 throw std::runtime_error(ERROR_PREFIX + "Value at index " + std::to_string(i) +                   \
                                          " does not match! Actual value: " + std::to_string(actual[i]) +          \
@@ -241,7 +241,7 @@ eTestStatusType compareArray(const Tensor& tensor, std::vector<T>& expected_data
     }
 
     // Compare data between tensor data and image
-    for (int i = 0; i < expected_data.size(); i++) {
+    for (size_t i = 0; i < expected_data.size(); i++) {
         T expected = static_cast<T>(expected_data[i]);
         T actual = static_cast<T>(tensor_data_host[i]);
 
@@ -302,12 +302,12 @@ void FillVector(std::vector<T>& vec, uint32_t seed = 12345) {
     // Select real distribution if T is a floating point, integer distribution otherwise
     if constexpr (std::is_floating_point_v<T>) {
         std::uniform_real_distribution<T> dist(0.0f, 1.0f);
-        for (int i = 0; i < vec.size(); i++) {
+        for (size_t i = 0; i < vec.size(); i++) {
             vec[i] = dist(eng);
         }
     } else {
         std::uniform_int_distribution<T> dist(std::numeric_limits<T>().min(), std::numeric_limits<T>().max());
-        for (int i = 0; i < vec.size(); i++) {
+        for (size_t i = 0; i < vec.size(); i++) {
             vec[i] = dist(eng);
         }
     }
@@ -326,7 +326,7 @@ void FillVectorMask(std::vector<T>& vec, uint32_t seed = 12345) {
     std::mt19937 eng(seed);
 
     std::uniform_int_distribution<T> dist(0, 1);
-    for (int i = 0; i < vec.size(); i++) {
+    for (size_t i = 0; i < vec.size(); i++) {
         vec[i] = dist(eng);
     }
 }
@@ -485,7 +485,7 @@ std::array<int64_t, ROCCV_TENSOR_MAX_RANK> ComputePackedStrides(const std::array
                                                                 const DataType& dtype, int rank) {
     std::array<int64_t, ROCCV_TENSOR_MAX_RANK> strides;
     strides[rank - 1] = dtype.size();
-    for (int i = rank - 2; i >= 0; i--) {
+    for (size_t i = rank - 2; i >= 0; i--) {
         strides[i] = strides[i + 1] * shape[i + 1];
     }
     return strides;

--- a/tests/roccv/cpp/include/test_helpers.hpp
+++ b/tests/roccv/cpp/include/test_helpers.hpp
@@ -485,7 +485,7 @@ std::array<int64_t, ROCCV_TENSOR_MAX_RANK> ComputePackedStrides(const std::array
                                                                 const DataType& dtype, int rank) {
     std::array<int64_t, ROCCV_TENSOR_MAX_RANK> strides;
     strides[rank - 1] = dtype.size();
-    for (size_t i = rank - 2; i >= 0; i--) {
+    for (int i = rank - 2; i >= 0; i--) {
         strides[i] = strides[i + 1] * shape[i + 1];
     }
     return strides;

--- a/tests/roccv/cpp/src/tests/operators/test_op_bilateral_filter.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_bilateral_filter.cpp
@@ -134,7 +134,7 @@ void TestCorrectness(int batchSize, int width, int height, ImageFormat format, i
     std::vector<BT> inputData(input.shape().size());
     FillVector(inputData);
     if constexpr (std::is_floating_point_v<BT>) {
-        for (int i = 0; i < inputData.size(); i++) {
+        for (size_t i = 0; i < inputData.size(); i++) {
             inputData[i] *= static_cast<BT>(std::numeric_limits<ushort>::max());
         }
     }
@@ -196,7 +196,7 @@ int main(int argc, char** argv) {
                                                         eDeviceType::GPU)));
 
     TEST_CASE((TestCorrectness<char4, BORDER_TYPE_REFLECT101>(1, 64, 24, FMT_RGBAs8, 5, 60.0f, 3.0f,
-                                                           {100.0, 0.0, 100.0, 0.0}, eDeviceType::GPU)));
+                                                              {100.0, 0.0, 100.0, 0.0}, eDeviceType::GPU)));
     TEST_CASE((TestCorrectness<char4, BORDER_TYPE_CONSTANT>(5, 64, 24, FMT_RGBAs8, 5, 60.0f, 3.0f,
                                                             {100.0, 100.0, 100.0, 0.0}, eDeviceType::GPU)));
 
@@ -208,7 +208,7 @@ int main(int argc, char** argv) {
     TEST_CASE((TestCorrectness<ushort3, BORDER_TYPE_CONSTANT>(1, 20, 20, FMT_RGB16, 4, 500.0f, 3.0f,
                                                               {500.0, 600.0, 0.0, 0.0}, eDeviceType::GPU)));
     TEST_CASE((TestCorrectness<ushort3, BORDER_TYPE_REFLECT101>(2, 20, 20, FMT_RGB16, 4, 500.0f, 3.0f,
-                                                             {0.0, 0.0, 0.0, 0.0}, eDeviceType::GPU)));
+                                                                {0.0, 0.0, 0.0, 0.0}, eDeviceType::GPU)));
 
     TEST_CASE((TestCorrectness<ushort4, BORDER_TYPE_REFLECT>(1, 20, 20, FMT_RGBA16, 4, 600.0f, 3.0f,
                                                              {500.0, 600.0, 0.0, 0.0}, eDeviceType::GPU)));
@@ -297,7 +297,7 @@ int main(int argc, char** argv) {
                                                         eDeviceType::CPU)));
 
     TEST_CASE((TestCorrectness<char4, BORDER_TYPE_REFLECT101>(1, 64, 24, FMT_RGBAs8, 5, 60.0f, 3.0f,
-                                                           {100.0, 0.0, 100.0, 0.0}, eDeviceType::CPU)));
+                                                              {100.0, 0.0, 100.0, 0.0}, eDeviceType::CPU)));
     TEST_CASE((TestCorrectness<char4, BORDER_TYPE_CONSTANT>(5, 64, 24, FMT_RGBAs8, 5, 60.0f, 3.0f,
                                                             {100.0, 100.0, 100.0, 0.0}, eDeviceType::CPU)));
 
@@ -312,7 +312,7 @@ int main(int argc, char** argv) {
                                                              {0.0, 0.0, 0.0, 0.0}, eDeviceType::CPU)));
 
     TEST_CASE((TestCorrectness<ushort4, BORDER_TYPE_REFLECT101>(1, 20, 20, FMT_RGBA16, 4, 600.0f, 3.0f,
-                                                             {500.0, 600.0, 0.0, 0.0}, eDeviceType::CPU)));
+                                                                {500.0, 600.0, 0.0, 0.0}, eDeviceType::CPU)));
     TEST_CASE((TestCorrectness<ushort4, BORDER_TYPE_WRAP>(2, 20, 20, FMT_RGBA16, 4, 500.0f, 3.0f, {0.0, 0.0, 0.0, 0.0},
                                                           eDeviceType::CPU)));
 

--- a/tests/roccv/cpp/src/tests/operators/test_op_normalize.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_normalize.cpp
@@ -48,9 +48,9 @@ namespace {
  * @param[in] scale Scale vector used for scaling individual pixel value.
  * @param[in] scaleSize Size of the scale vector.
  * @param[in] scaleFormat Scale array format.
- * @param[in] globalShift The value shift applid on all pixels.
- * @param[in] globalScale The scaling factor applid on all pixels.
- * @param[in] epsilon The quantity added to the standard deviaton in normalization using standard deviation (Z-score
+ * @param[in] globalShift The value shift applied on all pixels.
+ * @param[in] globalScale The scaling factor applied on all pixels.
+ * @param[in] epsilon The quantity added to the standard deviation in normalization using standard deviation (Z-score
  * normalization or standardization).
  * @param[in] scaleIsStdDev The scaling factor is standard deviation.
  * @return None.

--- a/tests/roccv/cpp/src/tests/operators/test_op_normalize.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_normalize.cpp
@@ -24,6 +24,7 @@ THE SOFTWARE.
 #include <core/detail/type_traits.hpp>
 #include <core/wrappers/image_wrapper.hpp>
 #include <op_normalize.hpp>
+
 #include "test_helpers.hpp"
 
 using namespace roccv;
@@ -49,12 +50,16 @@ namespace {
  * @param[in] scaleFormat Scale array format.
  * @param[in] globalShift The value shift applid on all pixels.
  * @param[in] globalScale The scaling factor applid on all pixels.
- * @param[in] epsilon The quantity added to the standard deviaton in normalization using standard deviation (Z-score normalization or standardization).
+ * @param[in] epsilon The quantity added to the standard deviaton in normalization using standard deviation (Z-score
+ * normalization or standardization).
  * @param[in] scaleIsStdDev The scaling factor is standard deviation.
  * @return None.
  */
 template <typename T, typename BT = detail::BaseType<T>>
-void GenerateGoldenNormalize(std::vector<BT>& input, std::vector<BT>& output, Size2D imageSize, ImageFormat imgFormat, std::vector<float>& base, Size2D baseSize, ImageFormat baseFormat, std::vector<float>& scale, Size2D scaleSize, ImageFormat scaleFormat, float globalShift, float globalScale, float epsilon, bool scaleIsStdDev) {
+void GenerateGoldenNormalize(std::vector<BT>& input, std::vector<BT>& output, Size2D imageSize, ImageFormat imgFormat,
+                             std::vector<float>& base, Size2D baseSize, ImageFormat baseFormat,
+                             std::vector<float>& scale, Size2D scaleSize, ImageFormat scaleFormat, float globalShift,
+                             float globalScale, float epsilon, bool scaleIsStdDev) {
     for (int y = 0; y < imageSize.h; y++) {
         int base_y = baseSize.h == 1 ? 0 : y;
         int scale_y = scaleSize.h == 1 ? 0 : y;
@@ -64,12 +69,19 @@ void GenerateGoldenNormalize(std::vector<BT>& input, std::vector<BT>& output, Si
             for (int c = 0; c < imgFormat.channels(); c++) {
                 int base_c = (baseFormat.channels() == 1 ? 0 : c);
                 int scale_c = (scaleFormat.channels() == 1 ? 0 : c);
-                float scaleFactor = scale.at(scale_y * scaleSize.w * scaleFormat.channels() + scale_x * scaleFormat.channels() + scale_c);
+                float scaleFactor = scale.at(scale_y * scaleSize.w * scaleFormat.channels() +
+                                             scale_x * scaleFormat.channels() + scale_c);
                 if (scaleIsStdDev) {
                     scaleFactor = 1.0 / std::sqrt(scaleFactor * scaleFactor + epsilon);
                 }
-                float result = (StaticCast<float>(input.at(y * imageSize.w * imgFormat.channels() + x * imgFormat.channels() + c)) - base.at(base_y * baseSize.w * baseFormat.channels() + base_x * baseFormat.channels() + base_c)) * scaleFactor * globalScale + globalShift;
-                output.at(y * imageSize.w * imgFormat.channels() + x * imgFormat.channels() + c) = SaturateCast<BT>(result);
+                float result =
+                    (StaticCast<float>(
+                         input.at(y * imageSize.w * imgFormat.channels() + x * imgFormat.channels() + c)) -
+                     base.at(base_y * baseSize.w * baseFormat.channels() + base_x * baseFormat.channels() + base_c)) *
+                        scaleFactor * globalScale +
+                    globalShift;
+                output.at(y * imageSize.w * imgFormat.channels() + x * imgFormat.channels() + c) =
+                    SaturateCast<BT>(result);
             }
         }
     }
@@ -83,16 +95,20 @@ void GenerateGoldenNormalize(std::vector<BT>& input, std::vector<BT>& output, Si
  * @param[in] batchSize Number of images in the batch.
  * @param[in] imgSize Image size.
  * @param[in] imgFormat Image format.
- * @param[in] isScalarBase Flag to indicate if the base parameter is scalar or array with the same dimension as input image
- * @param[in] isScalarScale Flag to indicate if the scale parameter is scalar or array with the same dimension as input image
+ * @param[in] isScalarBase Flag to indicate if the base parameter is scalar or array with the same dimension as input
+ * image
+ * @param[in] isScalarScale Flag to indicate if the scale parameter is scalar or array with the same dimension as input
+ * image
  * @param[in] globalShift The value shift applid on all pixels.
  * @param[in] globalScale The scaling factor applid on all pixels.
- * @param[in] epsilon The quantity added to the standard deviaton in normalization using standard deviation (Z-score normalization or standardization).
+ * @param[in] epsilon The quantity added to the standard deviaton in normalization using standard deviation (Z-score
+ * normalization or standardization).
  * @param[in] flags The indicator for if the scaling factor is standard deviation.
  * @param[in] device Device this correctness test should be run on.
  */
 template <typename T, typename BT = detail::BaseType<T>>
-void TestCorrectness(int batchSize, Size2D imgSize, ImageFormat imgFormat, bool isScalarBase, bool isScalarScale, float globalShift, float globalScale, float epsilon, uint32_t flags, eDeviceType device) {
+void TestCorrectness(int batchSize, Size2D imgSize, ImageFormat imgFormat, bool isScalarBase, bool isScalarScale,
+                     float globalShift, float globalScale, float epsilon, uint32_t flags, eDeviceType device) {
     Tensor input(batchSize, imgSize, imgFormat, device);
     Tensor output(batchSize, imgSize, imgFormat, device);
     Size2D baseSize, scaleSize;
@@ -123,7 +139,7 @@ void TestCorrectness(int batchSize, Size2D imgSize, ImageFormat imgFormat, bool 
     Tensor baseTensor(baseBatchSize, baseSize, baseFormat, device);
     std::vector<float> baseData(baseTensor.shape().size());
     FillVector(baseData, 2);
-    for (int i = 0; i < baseTensor.shape().size(); i++) {
+    for (size_t i = 0; i < baseTensor.shape().size(); i++) {
         baseData[i] *= static_cast<float>(std::numeric_limits<BT>::max());
     }
     CopyVectorIntoTensor(baseTensor, baseData);
@@ -146,7 +162,7 @@ void TestCorrectness(int batchSize, Size2D imgSize, ImageFormat imgFormat, bool 
     Tensor scaleTensor(scaleBatchSize, scaleSize, scaleFormat, device);
     std::vector<float> scaleData(scaleTensor.shape().size());
     FillVector(scaleData, 3);
-    for (int i = 0; i < scaleTensor.shape().size(); i++) {
+    for (size_t i = 0; i < scaleTensor.shape().size(); i++) {
         scaleData[i] *= static_cast<float>(std::numeric_limits<BT>::max());
     }
     CopyVectorIntoTensor(scaleTensor, scaleData);
@@ -187,7 +203,9 @@ void TestCorrectness(int batchSize, Size2D imgSize, ImageFormat imgFormat, bool 
             std::copy(scaleData.begin() + offset, scaleData.begin() + offset + imageVectorSize, scaleImageData.begin());
         }
 
-        GenerateGoldenNormalize<T>(inputImage, ref, imgSize, imgFormat, baseImageData, baseSize, baseFormat, scaleImageData, scaleSize, scaleFormat, globalShift, globalScale, epsilon, (flags & ROCCV_NORMALIZE_SCALE_IS_STDDEV));
+        GenerateGoldenNormalize<T>(inputImage, ref, imgSize, imgFormat, baseImageData, baseSize, baseFormat,
+                                   scaleImageData, scaleSize, scaleFormat, globalShift, globalScale, epsilon,
+                                   (flags & ROCCV_NORMALIZE_SCALE_IS_STDDEV));
 
         // Compare data in actual output versus the generated golden reference image
         std::copy(result.begin() + offset, result.begin() + offset + imageVectorSize, resultImage.begin());
@@ -195,7 +213,7 @@ void TestCorrectness(int batchSize, Size2D imgSize, ImageFormat imgFormat, bool 
     }
 }
 
-}
+}  // namespace
 
 int main(int argc, char** argv) {
     (void)argc;
@@ -204,89 +222,117 @@ int main(int argc, char** argv) {
 
     // GPU correctness tests
     TEST_CASE(TestCorrectness<uchar>(1, {20, 23}, FMT_U8, true, true, 1.0f, 1.2f, 0.1f, 0, eDeviceType::GPU));
-    TEST_CASE(TestCorrectness<uchar>(3, {33, 23}, FMT_U8, false, false, 1.0f, 1.2f, 0.1f, ROCCV_NORMALIZE_SCALE_IS_STDDEV, eDeviceType::GPU));
+    TEST_CASE(TestCorrectness<uchar>(3, {33, 23}, FMT_U8, false, false, 1.0f, 1.2f, 0.1f,
+                                     ROCCV_NORMALIZE_SCALE_IS_STDDEV, eDeviceType::GPU));
 
     TEST_CASE(TestCorrectness<uchar3>(1, {200, 200}, FMT_RGB8, false, true, 1.0f, 1.2f, 0.1f, 0, eDeviceType::GPU));
-    TEST_CASE(TestCorrectness<uchar3>(2, {100, 25}, FMT_RGB8, true, true, 1.0f, 1.2f, 0.1f, ROCCV_NORMALIZE_SCALE_IS_STDDEV, eDeviceType::GPU))
+    TEST_CASE(TestCorrectness<uchar3>(2, {100, 25}, FMT_RGB8, true, true, 1.0f, 1.2f, 0.1f,
+                                      ROCCV_NORMALIZE_SCALE_IS_STDDEV, eDeviceType::GPU))
 
     TEST_CASE(TestCorrectness<uchar4>(1, {55, 27}, FMT_RGBA8, true, true, 1.0f, 1.2f, 0.1f, 0, eDeviceType::GPU));
-    TEST_CASE(TestCorrectness<uchar4>(4, {155, 27}, FMT_RGBA8, false, false, 1.0f, 1.2f, 0.1f, ROCCV_NORMALIZE_SCALE_IS_STDDEV, eDeviceType::GPU));
+    TEST_CASE(TestCorrectness<uchar4>(4, {155, 27}, FMT_RGBA8, false, false, 1.0f, 1.2f, 0.1f,
+                                      ROCCV_NORMALIZE_SCALE_IS_STDDEV, eDeviceType::GPU));
 
     TEST_CASE(TestCorrectness<char1>(5, {201, 20}, FMT_S8, true, false, 0.1f, 1.2f, 0.1f, 0, eDeviceType::GPU));
-    TEST_CASE(TestCorrectness<char1>(2, {201, 20}, FMT_S8, true, true, 0.1f, 1.2f, 0.1f, ROCCV_NORMALIZE_SCALE_IS_STDDEV, eDeviceType::GPU));
+    TEST_CASE(TestCorrectness<char1>(2, {201, 20}, FMT_S8, true, true, 0.1f, 1.2f, 0.1f,
+                                     ROCCV_NORMALIZE_SCALE_IS_STDDEV, eDeviceType::GPU));
 
     TEST_CASE(TestCorrectness<char3>(1, {22, 23}, FMT_RGBs8, true, true, 1.0f, 1.2f, 0.1f, 0, eDeviceType::GPU));
-    TEST_CASE(TestCorrectness<char3>(3, {22, 23}, FMT_RGBs8, false, false, 1.0f, 1.2f, 0.1f, ROCCV_NORMALIZE_SCALE_IS_STDDEV, eDeviceType::GPU));
+    TEST_CASE(TestCorrectness<char3>(3, {22, 23}, FMT_RGBs8, false, false, 1.0f, 1.2f, 0.1f,
+                                     ROCCV_NORMALIZE_SCALE_IS_STDDEV, eDeviceType::GPU));
 
     TEST_CASE(TestCorrectness<char4>(1, {52, 42}, FMT_RGBAs8, true, false, 1.0f, 1.2f, 0.1f, 0, eDeviceType::GPU));
-    TEST_CASE(TestCorrectness<char4>(7, {25, 25}, FMT_RGBAs8, false, false, 1.0f, 1.2f, 0.1f, ROCCV_NORMALIZE_SCALE_IS_STDDEV, eDeviceType::GPU));
+    TEST_CASE(TestCorrectness<char4>(7, {25, 25}, FMT_RGBAs8, false, false, 1.0f, 1.2f, 0.1f,
+                                     ROCCV_NORMALIZE_SCALE_IS_STDDEV, eDeviceType::GPU));
 
     TEST_CASE(TestCorrectness<ushort1>(1, {200, 200}, FMT_U16, true, false, 1.0f, 1.2f, 0.1f, 0, eDeviceType::GPU));
-    TEST_CASE(TestCorrectness<ushort1>(2, {250, 200}, FMT_U16, false, true, 1.1f, 1.0f, 0.3f, ROCCV_NORMALIZE_SCALE_IS_STDDEV, eDeviceType::GPU));
+    TEST_CASE(TestCorrectness<ushort1>(2, {250, 200}, FMT_U16, false, true, 1.1f, 1.0f, 0.3f,
+                                       ROCCV_NORMALIZE_SCALE_IS_STDDEV, eDeviceType::GPU));
 
-    TEST_CASE(TestCorrectness<ushort3>(1, {9, 8}, FMT_RGB16, true, false, 1.0f, 1.1f, 0.1f, ROCCV_NORMALIZE_SCALE_IS_STDDEV, eDeviceType::GPU));
+    TEST_CASE(TestCorrectness<ushort3>(1, {9, 8}, FMT_RGB16, true, false, 1.0f, 1.1f, 0.1f,
+                                       ROCCV_NORMALIZE_SCALE_IS_STDDEV, eDeviceType::GPU));
     TEST_CASE(TestCorrectness<ushort3>(3, {19, 8}, FMT_RGB16, true, false, 1.0f, 1.1f, 0.1f, 0, eDeviceType::GPU));
 
     TEST_CASE(TestCorrectness<ushort4>(1, {29, 23}, FMT_RGBA16, true, true, 1.0f, 1.1f, 0.1f, 0, eDeviceType::GPU));
-    TEST_CASE(TestCorrectness<ushort4>(5, {22, 25}, FMT_RGBA16, false, true, 1.0f, 1.1f, 0.1f, ROCCV_NORMALIZE_SCALE_IS_STDDEV, eDeviceType::GPU));
+    TEST_CASE(TestCorrectness<ushort4>(5, {22, 25}, FMT_RGBA16, false, true, 1.0f, 1.1f, 0.1f,
+                                       ROCCV_NORMALIZE_SCALE_IS_STDDEV, eDeviceType::GPU));
 
     TEST_CASE(TestCorrectness<short1>(1, {54, 22}, FMT_S16, false, true, 1.0f, 1.1f, 0.1f, 0, eDeviceType::GPU));
-    TEST_CASE(TestCorrectness<short1>(2, {54, 22}, FMT_S16, false, true, 1.0f, 1.1f, 1.3f, ROCCV_NORMALIZE_SCALE_IS_STDDEV, eDeviceType::GPU));
+    TEST_CASE(TestCorrectness<short1>(2, {54, 22}, FMT_S16, false, true, 1.0f, 1.1f, 1.3f,
+                                      ROCCV_NORMALIZE_SCALE_IS_STDDEV, eDeviceType::GPU));
 
     TEST_CASE(TestCorrectness<int1>(2, {100, 200}, FMT_S32, false, true, 1.0f, 1.1f, 0.1f, 0, eDeviceType::GPU));
-    TEST_CASE(TestCorrectness<int1>(4, {100, 200}, FMT_S32, false, true, 1.0f, 1.1f, 0.1f, ROCCV_NORMALIZE_SCALE_IS_STDDEV, eDeviceType::GPU));
+    TEST_CASE(TestCorrectness<int1>(4, {100, 200}, FMT_S32, false, true, 1.0f, 1.1f, 0.1f,
+                                    ROCCV_NORMALIZE_SCALE_IS_STDDEV, eDeviceType::GPU));
 
     TEST_CASE(TestCorrectness<float1>(2, {20, 2}, FMT_F32, false, true, 1.0f, 1.1f, 0.1f, 0, eDeviceType::GPU));
-    TEST_CASE(TestCorrectness<float1>(1, {22, 25}, FMT_F32, false, false, 1.0f, 1.1f, 0.1f, ROCCV_NORMALIZE_SCALE_IS_STDDEV, eDeviceType::GPU));
+    TEST_CASE(TestCorrectness<float1>(1, {22, 25}, FMT_F32, false, false, 1.0f, 1.1f, 0.1f,
+                                      ROCCV_NORMALIZE_SCALE_IS_STDDEV, eDeviceType::GPU));
 
     TEST_CASE(TestCorrectness<float3>(1, {222, 22}, FMT_RGBf32, false, true, 1.0f, 1.1f, 0.1f, 0, eDeviceType::GPU));
-    TEST_CASE(TestCorrectness<float3>(20, {22, 20}, FMT_RGBf32, false, true, 1.0f, 1.1f, 0.1f, ROCCV_NORMALIZE_SCALE_IS_STDDEV, eDeviceType::GPU));
+    TEST_CASE(TestCorrectness<float3>(20, {22, 20}, FMT_RGBf32, false, true, 1.0f, 1.1f, 0.1f,
+                                      ROCCV_NORMALIZE_SCALE_IS_STDDEV, eDeviceType::GPU));
 
     TEST_CASE(TestCorrectness<float4>(1, {22, 29}, FMT_RGBAf32, true, true, 1.0f, 1.1f, 0.1f, 0, eDeviceType::GPU));
-    TEST_CASE(TestCorrectness<float4>(2, {22, 24}, FMT_RGBAf32, false, false, 1.0f, 1.1f, 0.1f, ROCCV_NORMALIZE_SCALE_IS_STDDEV, eDeviceType::GPU));
+    TEST_CASE(TestCorrectness<float4>(2, {22, 24}, FMT_RGBAf32, false, false, 1.0f, 1.1f, 0.1f,
+                                      ROCCV_NORMALIZE_SCALE_IS_STDDEV, eDeviceType::GPU));
 
     // CPU correctness tests
     TEST_CASE(TestCorrectness<uchar>(1, {20, 23}, FMT_U8, true, true, 1.0f, 1.2f, 0.1f, 0, eDeviceType::CPU));
-    TEST_CASE(TestCorrectness<uchar>(3, {33, 23}, FMT_U8, false, false, 1.0f, 1.2f, 0.1f, ROCCV_NORMALIZE_SCALE_IS_STDDEV, eDeviceType::CPU));
+    TEST_CASE(TestCorrectness<uchar>(3, {33, 23}, FMT_U8, false, false, 1.0f, 1.2f, 0.1f,
+                                     ROCCV_NORMALIZE_SCALE_IS_STDDEV, eDeviceType::CPU));
 
     TEST_CASE(TestCorrectness<uchar3>(1, {200, 200}, FMT_RGB8, false, true, 1.0f, 1.2f, 0.1f, 0, eDeviceType::CPU));
-    TEST_CASE(TestCorrectness<uchar3>(2, {100, 25}, FMT_RGB8, true, true, 1.0f, 1.2f, 0.1f, ROCCV_NORMALIZE_SCALE_IS_STDDEV, eDeviceType::CPU))
+    TEST_CASE(TestCorrectness<uchar3>(2, {100, 25}, FMT_RGB8, true, true, 1.0f, 1.2f, 0.1f,
+                                      ROCCV_NORMALIZE_SCALE_IS_STDDEV, eDeviceType::CPU))
 
     TEST_CASE(TestCorrectness<uchar4>(1, {55, 27}, FMT_RGBA8, true, true, 1.0f, 1.2f, 0.1f, 0, eDeviceType::CPU));
-    TEST_CASE(TestCorrectness<uchar4>(4, {155, 27}, FMT_RGBA8, false, false, 1.0f, 1.2f, 0.1f, ROCCV_NORMALIZE_SCALE_IS_STDDEV, eDeviceType::CPU));
+    TEST_CASE(TestCorrectness<uchar4>(4, {155, 27}, FMT_RGBA8, false, false, 1.0f, 1.2f, 0.1f,
+                                      ROCCV_NORMALIZE_SCALE_IS_STDDEV, eDeviceType::CPU));
 
     TEST_CASE(TestCorrectness<char1>(5, {201, 20}, FMT_S8, true, false, 0.1f, 1.2f, 0.1f, 0, eDeviceType::CPU));
-    TEST_CASE(TestCorrectness<char1>(2, {201, 20}, FMT_S8, true, true, 0.1f, 1.2f, 0.1f, ROCCV_NORMALIZE_SCALE_IS_STDDEV, eDeviceType::CPU));
+    TEST_CASE(TestCorrectness<char1>(2, {201, 20}, FMT_S8, true, true, 0.1f, 1.2f, 0.1f,
+                                     ROCCV_NORMALIZE_SCALE_IS_STDDEV, eDeviceType::CPU));
 
     TEST_CASE(TestCorrectness<char3>(1, {22, 23}, FMT_RGBs8, true, true, 1.0f, 1.2f, 0.1f, 0, eDeviceType::CPU));
-    TEST_CASE(TestCorrectness<char3>(3, {22, 23}, FMT_RGBs8, false, false, 1.0f, 1.2f, 0.1f, ROCCV_NORMALIZE_SCALE_IS_STDDEV, eDeviceType::CPU));
+    TEST_CASE(TestCorrectness<char3>(3, {22, 23}, FMT_RGBs8, false, false, 1.0f, 1.2f, 0.1f,
+                                     ROCCV_NORMALIZE_SCALE_IS_STDDEV, eDeviceType::CPU));
 
     TEST_CASE(TestCorrectness<char4>(1, {52, 42}, FMT_RGBAs8, true, false, 1.0f, 1.2f, 0.1f, 0, eDeviceType::CPU));
-    TEST_CASE(TestCorrectness<char4>(7, {25, 25}, FMT_RGBAs8, false, false, 1.0f, 1.2f, 0.1f, ROCCV_NORMALIZE_SCALE_IS_STDDEV, eDeviceType::CPU));
+    TEST_CASE(TestCorrectness<char4>(7, {25, 25}, FMT_RGBAs8, false, false, 1.0f, 1.2f, 0.1f,
+                                     ROCCV_NORMALIZE_SCALE_IS_STDDEV, eDeviceType::CPU));
 
     TEST_CASE(TestCorrectness<ushort1>(1, {200, 200}, FMT_U16, true, false, 1.0f, 1.2f, 0.1f, 0, eDeviceType::CPU));
-    TEST_CASE(TestCorrectness<ushort1>(2, {250, 200}, FMT_U16, false, true, 1.1f, 1.0f, 0.3f, ROCCV_NORMALIZE_SCALE_IS_STDDEV, eDeviceType::CPU));
+    TEST_CASE(TestCorrectness<ushort1>(2, {250, 200}, FMT_U16, false, true, 1.1f, 1.0f, 0.3f,
+                                       ROCCV_NORMALIZE_SCALE_IS_STDDEV, eDeviceType::CPU));
 
-    TEST_CASE(TestCorrectness<ushort3>(1, {9, 8}, FMT_RGB16, true, false, 1.0f, 1.1f, 0.1f, ROCCV_NORMALIZE_SCALE_IS_STDDEV, eDeviceType::CPU));
+    TEST_CASE(TestCorrectness<ushort3>(1, {9, 8}, FMT_RGB16, true, false, 1.0f, 1.1f, 0.1f,
+                                       ROCCV_NORMALIZE_SCALE_IS_STDDEV, eDeviceType::CPU));
     TEST_CASE(TestCorrectness<ushort3>(3, {19, 8}, FMT_RGB16, true, false, 1.0f, 1.1f, 0.1f, 0, eDeviceType::CPU));
 
     TEST_CASE(TestCorrectness<ushort4>(1, {29, 23}, FMT_RGBA16, true, true, 1.0f, 1.1f, 0.1f, 0, eDeviceType::CPU));
-    TEST_CASE(TestCorrectness<ushort4>(5, {22, 25}, FMT_RGBA16, false, true, 1.0f, 1.1f, 0.1f, ROCCV_NORMALIZE_SCALE_IS_STDDEV, eDeviceType::CPU));
+    TEST_CASE(TestCorrectness<ushort4>(5, {22, 25}, FMT_RGBA16, false, true, 1.0f, 1.1f, 0.1f,
+                                       ROCCV_NORMALIZE_SCALE_IS_STDDEV, eDeviceType::CPU));
 
     TEST_CASE(TestCorrectness<short1>(1, {54, 22}, FMT_S16, false, true, 1.0f, 1.1f, 0.1f, 0, eDeviceType::CPU));
-    TEST_CASE(TestCorrectness<short1>(2, {54, 22}, FMT_S16, false, true, 1.0f, 1.1f, 1.3f, ROCCV_NORMALIZE_SCALE_IS_STDDEV, eDeviceType::CPU));
+    TEST_CASE(TestCorrectness<short1>(2, {54, 22}, FMT_S16, false, true, 1.0f, 1.1f, 1.3f,
+                                      ROCCV_NORMALIZE_SCALE_IS_STDDEV, eDeviceType::CPU));
 
     TEST_CASE(TestCorrectness<int1>(2, {100, 200}, FMT_S32, false, true, 1.0f, 1.1f, 0.1f, 0, eDeviceType::CPU));
-    TEST_CASE(TestCorrectness<int1>(4, {100, 200}, FMT_S32, false, true, 1.0f, 1.1f, 0.1f, ROCCV_NORMALIZE_SCALE_IS_STDDEV, eDeviceType::CPU));
+    TEST_CASE(TestCorrectness<int1>(4, {100, 200}, FMT_S32, false, true, 1.0f, 1.1f, 0.1f,
+                                    ROCCV_NORMALIZE_SCALE_IS_STDDEV, eDeviceType::CPU));
 
     TEST_CASE(TestCorrectness<float1>(2, {20, 2}, FMT_F32, false, true, 1.0f, 1.1f, 0.1f, 0, eDeviceType::CPU));
-    TEST_CASE(TestCorrectness<float1>(1, {22, 25}, FMT_F32, false, false, 1.0f, 1.1f, 0.1f, ROCCV_NORMALIZE_SCALE_IS_STDDEV, eDeviceType::CPU));
+    TEST_CASE(TestCorrectness<float1>(1, {22, 25}, FMT_F32, false, false, 1.0f, 1.1f, 0.1f,
+                                      ROCCV_NORMALIZE_SCALE_IS_STDDEV, eDeviceType::CPU));
 
     TEST_CASE(TestCorrectness<float3>(1, {222, 22}, FMT_RGBf32, false, true, 1.0f, 1.1f, 0.1f, 0, eDeviceType::CPU));
-    TEST_CASE(TestCorrectness<float3>(20, {22, 20}, FMT_RGBf32, false, true, 1.0f, 1.1f, 0.1f, ROCCV_NORMALIZE_SCALE_IS_STDDEV, eDeviceType::CPU));
+    TEST_CASE(TestCorrectness<float3>(20, {22, 20}, FMT_RGBf32, false, true, 1.0f, 1.1f, 0.1f,
+                                      ROCCV_NORMALIZE_SCALE_IS_STDDEV, eDeviceType::CPU));
 
     TEST_CASE(TestCorrectness<float4>(1, {22, 29}, FMT_RGBAf32, true, true, 1.0f, 1.1f, 0.1f, 0, eDeviceType::CPU));
-    TEST_CASE(TestCorrectness<float4>(2, {22, 24}, FMT_RGBAf32, false, false, 1.0f, 1.1f, 0.1f, ROCCV_NORMALIZE_SCALE_IS_STDDEV, eDeviceType::CPU));
+    TEST_CASE(TestCorrectness<float4>(2, {22, 24}, FMT_RGBAf32, false, false, 1.0f, 1.1f, 0.1f,
+                                      ROCCV_NORMALIZE_SCALE_IS_STDDEV, eDeviceType::CPU));
 
     TEST_CASES_END();
 }


### PR DESCRIPTION
## Description
* Resolves #129 
* Resolves sign comparison warnings throughout the rocCV codebase.
* Removes the use of `maxBatchSize` in the Threshold operator, since this is already implied from the batch size of the input/output tensors. Further discussion should be had on the necessity of this parameter in `roccv::Threshold`'s constructor.

## Testing
* Ensure that no more warnings are thrown on a fresh build, including the core library and any subprojects that are built with it (benchmarks, python bindings, tests). No warnings appear to be thrown on a fresh build.

## Notes
* This must be rebased to point to develop as the head once #141 is merged into develop.
* Once this PR is successfully merged in, all warnings in the rocCV codebase should be resolved (`-Wall`, `-Wextra`).
