### PR TITLE
[Bugfix] Ensure radius defaults are applied when BilateralFilter diameter is <= 0

### DIFF
--- a/include/op_bilateral_filter.hpp
+++ b/include/op_bilateral_filter.hpp
@@ -78,7 +78,11 @@ class BilateralFilter final : public IOperator {
      * @param[in] stream The HIP stream to run this operation on.
      * @param[in] input Input tensor with image batch data
      * @param[out] output Output tensor for storing modified image batch data
-     * @param[in] diameter bilateral filter diameter.
+     * @param[in] diameter Bilateral filter neighborhood diameter. If @p diameter is
+     * greater than zero, the spatial radius is `diameter >> 1`. If @p diameter is
+     * less than or equal to zero, the radius is
+     * `static_cast<int>(std::roundf(sigmaSpace * 1.5f))` after clamping non-positive
+     * @p sigmaSpace to 1.0.
      * @param[in] sigmaColor Gaussian exponent for color difference, expected
      * to be positive, if it isn't, will be set to 1.0
      * @param[in] sigmaSpace Gaussian exponent for position difference expected

--- a/src/op_bilateral_filter.cpp
+++ b/src/op_bilateral_filter.cpp
@@ -23,6 +23,7 @@ THE SOFTWARE.
 
 #include <hip/hip_runtime.h>
 
+#include <cmath>
 #include <functional>
 #include <numeric>
 #include <unordered_map>
@@ -45,8 +46,6 @@ void dispatch_bilateral_filter_border_mode(hipStream_t stream, const Tensor &inp
     BorderWrapper<T, B> inputWrapper(input, borderValue);
     ImageWrapper<T> outputWrapper(output);
 
-    int radius = diameter >> 1;
-
     if (outputWrapper.channels() > 4 || outputWrapper.channels() < 1) {
         throw Exception("Invalid channel size: cannot be greater than 4 or less than 1.", eStatusType::OUT_OF_BOUNDS);
     }
@@ -62,9 +61,8 @@ void dispatch_bilateral_filter_border_mode(hipStream_t stream, const Tensor &inp
         sigmaSpace = 1.0f;
     }
 
-    if (radius <= 0) {
-        radius = std::round(sigmaSpace * 1.5f);
-    }
+    const int radius =
+        (diameter <= 0) ? static_cast<int>(std::roundf(sigmaSpace * 1.5f)) : (diameter >> 1);
 
     float spaceCoeff = -1 / (2 * sigmaSpace * sigmaSpace);
     float colorCoeff = -1 / (2 * sigmaColor * sigmaColor);

--- a/tests/roccv/cpp/src/tests/operators/test_op_bilateral_filter.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_bilateral_filter.cpp
@@ -175,6 +175,14 @@ int main(int argc, char** argv) {
     TEST_CASE((TestCorrectness<uchar, BORDER_TYPE_REPLICATE>(4, 20, 20, FMT_U8, 4, 50.0f, 3.0f, {0.0, 0.0, 0.0, 0.0},
                                                              eDeviceType::GPU)));
 
+    // diameter <= 0: radius = roundf(sigmaSpace * 1.5f); sigmaSpace 1.2 -> radius 2
+    TEST_CASE((TestCorrectness<uchar, BORDER_TYPE_CONSTANT>(1, 20, 20, FMT_U8, 0, 50.0f, 1.2f, {0.0, 0.0, 0.0, 0.0},
+                                                            eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<uchar3, BORDER_TYPE_REPLICATE>(2, 20, 20, FMT_RGB8, -1, 50.0f, 1.2f,
+                                                             {0.0, 0.0, 0.0, 0.0}, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<float1, BORDER_TYPE_WRAP>(1, 24, 24, FMT_F32, 0, 500.0f, 1.2f,
+                                                         {500.0, 500.0, 0.0, 0.0}, eDeviceType::GPU)));
+
     TEST_CASE((TestCorrectness<uchar3, BORDER_TYPE_CONSTANT>(1, 20, 20, FMT_RGB8, 4, 50.0f, 3.0f, {0.0, 0.0, 0.0, 0.0},
                                                              eDeviceType::GPU)));
     TEST_CASE((TestCorrectness<uchar3, BORDER_TYPE_REFLECT>(2, 20, 20, FMT_RGB8, 4, 50.0f, 5.0f,
@@ -275,6 +283,14 @@ int main(int argc, char** argv) {
                                                             eDeviceType::CPU)));
     TEST_CASE((TestCorrectness<uchar, BORDER_TYPE_REPLICATE>(4, 20, 20, FMT_U8, 4, 50.0f, 3.0f, {0.0, 0.0, 0.0, 0.0},
                                                              eDeviceType::CPU)));
+
+    // diameter <= 0: radius = roundf(sigmaSpace * 1.5f); sigmaSpace 1.2 -> radius 2
+    TEST_CASE((TestCorrectness<uchar, BORDER_TYPE_CONSTANT>(1, 20, 20, FMT_U8, 0, 50.0f, 1.2f, {0.0, 0.0, 0.0, 0.0},
+                                                            eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uchar3, BORDER_TYPE_REPLICATE>(2, 20, 20, FMT_RGB8, -1, 50.0f, 1.2f,
+                                                             {0.0, 0.0, 0.0, 0.0}, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<float1, BORDER_TYPE_WRAP>(1, 24, 24, FMT_F32, 0, 500.0f, 1.2f,
+                                                         {500.0, 500.0, 0.0, 0.0}, eDeviceType::CPU)));
 
     TEST_CASE((TestCorrectness<uchar3, BORDER_TYPE_CONSTANT>(1, 20, 20, FMT_RGB8, 4, 50.0f, 3.0f, {0.0, 0.0, 0.0, 0.0},
                                                              eDeviceType::CPU)));

--- a/tests/roccv/python/test_op_bilateral_filter.py
+++ b/tests/roccv/python/test_op_bilateral_filter.py
@@ -32,7 +32,9 @@ from test_helpers import compare_tensors, generate_tensor
 @pytest.mark.parametrize("border_mode", [rocpycv.eBorderType.CONSTANT])
 @pytest.mark.parametrize("border_val", [[0, 0, 0, 1]])
 @pytest.mark.parametrize("diameter,sigma_color,sigma_space", [
-    (3, 1.0, 1.0)
+    (3, 1.0, 1.0),
+    (0, 50.0, 1.2),
+    (-1, 50.0, 1.2),
 ])
 @pytest.mark.parametrize("channels", [1, 3, 4])
 @pytest.mark.parametrize("samples,height,width", [


### PR DESCRIPTION
## Description
* Fixes a bug in BilateralFilter where default radius was applied when radius was <= 0, not diameter.
* Adds test cases with the diameter set to <= 0 to ensure that the behavior is as intended.
