### PR TITLE
[Feature] Add kernel-accessible ImageBatchVarShapeWrapper

### DIFF
--- a/include/core/wrappers/border_wrapper.hpp
+++ b/include/core/wrappers/border_wrapper.hpp
@@ -87,37 +87,33 @@ __device__ __host__ inline int64_t reflect101_border_coord_i64(int64_t coord, in
 }  // namespace detail
 
 /**
- * @brief Wrapper class for ImageWrapper. This extends the descriptors by defining behaviors for when tensor
- * coordinates go out of scope.
+ * @brief Wrapper class which adds border-handling behavior on top of an underlying image wrapper.
  *
- * @tparam T The underlying data type of the tensor.
+ * Templated on the wrapper type W (e.g. ImageWrapper<T>, VarShapeImageWrapper<T>) so the same border math
+ * serves both uniform-shape and variable-shape image batches. The pixel value type T is recovered from
+ * W::ValueType. W must expose: ValueType, at(n,h,w,c), width(n), height(n), batches(), channels().
+ *
  * @tparam BorderType The border type to use when coordinates are out of bounds.
+ * @tparam W          The underlying image wrapper type.
  */
-template <typename T, eBorderType BorderType>
+template <eBorderType BorderType, typename W>
 class BorderWrapper {
    public:
-    /**
-     * @brief Wraps an ImageWrapper and extends its capabilities to handle out of bounds coordinates.
-     *
-     * @param tensor The tensor to wrap.
-     * @param border_value The fallback border color to use when using a constant border mode.
-     */
-    BorderWrapper(const Tensor& tensor, T border_value) : m_desc(tensor), m_border_value(border_value) {}
+    using ValueType = typename W::ValueType;
 
     /**
-     * @brief Constructs a BorderWrapper from an existing ImageWrapper. Extends its capabilities to handle out of bound
-     * coordinates.
+     * @brief Constructs a BorderWrapper from an existing image wrapper. Extends its capabilities to handle out of
+     * bound coordinates.
      *
-     * @param image_wrapper The ImageWrapper to wrap around the BorderWrapper.
-     * @param border_value The fallback border color to use when using a constant border mode.
+     * @param image_wrapper The image wrapper to wrap.
+     * @param border_value  The fallback border color to use when using a constant border mode.
      */
-    BorderWrapper(ImageWrapper<T> image_wrapper, T border_value)
-        : m_desc(image_wrapper), m_border_value(border_value) {}
+    BorderWrapper(W image_wrapper, ValueType border_value) : m_desc(image_wrapper), m_border_value(border_value) {}
 
     /**
      * @brief Sample the underlying image with no border logic. Caller must ensure coordinates are in-range.
      */
-    __device__ __host__ inline const T at_inbounds(int64_t n, int64_t h, int64_t w, int64_t c) const {
+    __device__ __host__ inline const ValueType at_inbounds(int64_t n, int64_t h, int64_t w, int64_t c) const {
         return m_desc.at(n, h, w, c);
     }
 
@@ -131,11 +127,14 @@ class BorderWrapper {
      * @param c The channel index.
      * @return A reference to the underlying data or a fallback border value of type T.
      */
-    __device__ __host__ const T at(int64_t n, int64_t h, int64_t w, int64_t c) const {
+    __device__ __host__ const ValueType at(int64_t n, int64_t h, int64_t w, int64_t c) const {
+        const int64_t imgWidth = width(n);
+        const int64_t imgHeight = height(n);
+
         // Constant border type implementation. This is a special case which doesn't remap values, but rather returns
         // the provided constant value.
         if constexpr (BorderType == eBorderType::BORDER_TYPE_CONSTANT) {
-            if (w < 0 || w >= width() || h < 0 || h >= height())
+            if (w < 0 || w >= imgWidth || h < 0 || h >= imgHeight)
                 return m_border_value;
             else
                 return m_desc.at(n, h, w, c);
@@ -145,13 +144,12 @@ class BorderWrapper {
         // required at image borders. While this may cause branch divergence, a good bulk of the pixels should fall
         // within image bounds and will take the same branch. This is preferred over having to do expensive calculations
         // for EVERY pixel in the image (most of which do not require said calculations).
-        if (w >= 0 && w < width() && h >= 0 && h < height()) {
+        if (w >= 0 && w < imgWidth && h >= 0 && h < imgHeight) {
             return m_desc.at(n, h, w, c);
         }
 
         // Otherwise, do some additional calculations to map the provided x and y coordinates to be within bounds.
         int64_t x = w, y = h;
-        int64_t imgWidth = width(), imgHeight = height();
 
         // Reflect border type implementation. (Note: This is NOT REFLECT101, pixels at the border will be duplicated as
         // is the intended behavior for this border mode.)
@@ -185,18 +183,20 @@ class BorderWrapper {
     }
 
     /**
-     * @brief Retrives the height of the images.
+     * @brief Retrives the height of the image at batch index n.
      *
+     * @param n Batch index. Ignored when W is a uniform-shape wrapper.
      * @return Image height.
      */
-    __device__ __host__ inline int64_t height() const { return m_desc.height(); }
+    __device__ __host__ inline int64_t height(int64_t n = 0) const { return m_desc.height(n); }
 
     /**
-     * @brief Retrieves the width of the image.
+     * @brief Retrieves the width of the image at batch index n.
      *
+     * @param n Batch index. Ignored when W is a uniform-shape wrapper.
      * @return Image width.
      */
-    __device__ __host__ inline int64_t width() const { return m_desc.width(); }
+    __device__ __host__ inline int64_t width(int64_t n = 0) const { return m_desc.width(n); }
 
     /**
      * @brief Retrieves the number of batches in the image tensor.
@@ -213,7 +213,7 @@ class BorderWrapper {
     __device__ __host__ inline int64_t channels() const { return m_desc.channels(); }
 
    private:
-    ImageWrapper<T> m_desc;
-    T m_border_value;
+    W m_desc;
+    ValueType m_border_value;
 };
 }  // namespace roccv

--- a/include/core/wrappers/border_wrapper.hpp
+++ b/include/core/wrappers/border_wrapper.hpp
@@ -22,7 +22,7 @@
 #pragma once
 
 #include "core/detail/sampling_helpers.hpp"
-#include "core/wrappers/image_wrapper.hpp"
+#include "core/wrappers/tensor_wrapper.hpp"
 #include "operator_types.h"
 
 namespace roccv {
@@ -89,7 +89,7 @@ __device__ __host__ inline int64_t reflect101_border_coord_i64(int64_t coord, in
 /**
  * @brief Wrapper class which adds border-handling behavior on top of an underlying image wrapper.
  *
- * Templated on the wrapper type W (e.g. ImageWrapper<T>, VarShapeImageWrapper<T>) so the same border math
+ * Templated on the wrapper type W (e.g. TensorWrapper<T>, ImageBatchVarShapeWrapper<T>) so the same border math
  * serves both uniform-shape and variable-shape image batches. The pixel value type T is recovered from
  * W::ValueType. W must expose: ValueType, at(n,h,w,c), width(n), height(n), batches(), channels().
  *

--- a/include/core/wrappers/border_wrapper.hpp
+++ b/include/core/wrappers/border_wrapper.hpp
@@ -100,6 +100,8 @@ template <eBorderType BorderType, typename W>
 class BorderWrapper {
    public:
     using ValueType = typename W::ValueType;
+    using WrapperType = W;
+    static constexpr eBorderType kBorderType = BorderType;
 
     /**
      * @brief Constructs a BorderWrapper from an existing image wrapper. Extends its capabilities to handle out of
@@ -216,4 +218,18 @@ class BorderWrapper {
     W m_desc;
     ValueType m_border_value;
 };
+
+/**
+ * @brief Factory for BorderWrapper. Deduces the underlying wrapper type W from the argument so callers
+ * only need to spell the border-mode policy explicitly.
+ *
+ * @tparam B The border mode to apply.
+ * @param wrap        The underlying image wrapper.
+ * @param borderValue Fallback value used when B is BORDER_TYPE_CONSTANT.
+ */
+template <eBorderType B, typename W>
+auto MakeBorderWrapper(W wrap, typename W::ValueType borderValue) {
+    return BorderWrapper<B, W>(wrap, borderValue);
+}
+
 }  // namespace roccv

--- a/include/core/wrappers/image_batch_var_shape_wrapper.hpp
+++ b/include/core/wrappers/image_batch_var_shape_wrapper.hpp
@@ -33,8 +33,8 @@
 namespace roccv {
 
 /**
- * @brief VarShapeImageWrapper is a non-owning, kernel-friendly view over an ImageBatchVarShape's
- * device-side descriptor table. It satisfies the same wrapper concept as ImageWrapper<T>
+ * @brief ImageBatchVarShapeWrapper is a non-owning, kernel-friendly view over an ImageBatchVarShape's
+ * device-side descriptor table. It satisfies the same wrapper concept as TensorWrapper<T>
  * (ValueType, at(n,h,w,c), width(n), height(n), batches(), channels()) so it composes with
  * BorderWrapper / InterpolationWrapper unchanged.
  *
@@ -48,19 +48,19 @@ namespace roccv {
  * @tparam T The datatype of an individual pixel (e.g. uchar1, uchar3, uchar4, float1, float4).
  */
 template <typename T>
-class VarShapeImageWrapper {
+class ImageBatchVarShapeWrapper {
    public:
     using ValueType = T;
     using BaseType = detail::BaseType<T>;
 
-    VarShapeImageWrapper() = default;
+    ImageBatchVarShapeWrapper() = default;
 
     /**
-     * @brief Creates a VarShapeImageWrapper from a GPU-resident varshape batch data snapshot.
+     * @brief Creates a ImageBatchVarShapeWrapper from a GPU-resident varshape batch data snapshot.
      *
      * @param data The exported descriptor table from ImageBatchVarShape::exportData(stream).
      */
-    __host__ VarShapeImageWrapper(const ImageBatchVarShapeDataStridedHip& data)
+    __host__ ImageBatchVarShapeWrapper(const ImageBatchVarShapeDataStridedHip& data)
         : m_imageList(data.imageList()), m_numImages(data.numImages()) {
 #ifndef NDEBUG
         // ImageBatchVarShape rejects multi-plane at pushBack; assert here as a belt-and-braces
@@ -68,7 +68,7 @@ class VarShapeImageWrapper {
         const ImageFormat* formats = data.hostFormatList();
         for (int32_t i = 0; i < m_numImages; ++i) {
             assert(formats[i].channels() == detail::NumElements<T> &&
-                   "VarShapeImageWrapper<T>: per-image channel count must match NumElements<T>");
+                   "ImageBatchVarShapeWrapper<T>: per-image channel count must match NumElements<T>");
         }
 #endif
     }
@@ -109,7 +109,7 @@ class VarShapeImageWrapper {
    private:
     __device__ __host__ inline T* doGetPtr(int64_t n, int64_t h, int64_t w, int64_t c) const {
         // Single-plane interleaved NHWC layout: pixel stride is sizeof(T), channel stride is
-        // sizeof(BaseType). Match ImageWrapper<T>::at semantics — returns a T* offset to (h, w)
+        // sizeof(BaseType). Match TensorWrapper<T>::at semantics — returns a T* offset to (h, w)
         // and additionally shifted by c channels.
         const ImagePlaneStrided& p = m_imageList[n].planes[0];
         unsigned char* addr =

--- a/include/core/wrappers/image_batch_var_shape_wrapper.hpp
+++ b/include/core/wrappers/image_batch_var_shape_wrapper.hpp
@@ -34,16 +34,18 @@ namespace roccv {
 
 /**
  * @brief ImageBatchVarShapeWrapper is a non-owning, kernel-friendly view over an ImageBatchVarShape's
- * device-side descriptor table. It satisfies the same wrapper concept as TensorWrapper<T>
+ * descriptor table. It satisfies the same wrapper concept as TensorWrapper<T>
  * (ValueType, at(n,h,w,c), width(n), height(n), batches(), channels()) so it composes with
  * BorderWrapper / InterpolationWrapper unchanged.
  *
  * Single-plane interleaved (NHWC-style) only — ImageBatchVarShape rejects multi-plane images
  * at pushBack, and channel count is derived from T via detail::NumElements<T>.
  *
- * Pointer residency: m_imageList is a device pointer for an ImageBatchVarShapeDataStridedHip;
- * every at()/width()/height() call dereferences it, so this wrapper is only safe to use from
- * device code (or host code that has the descriptor table host-side).
+ * Pointer residency follows the snapshot it is built from: for a GPU batch
+ * (ImageBatchVarShapeDataStridedHip) m_imageList is a device pointer, so the wrapper is usable from
+ * device code; for a CPU batch (ImageBatchVarShapeDataStridedHost) it is a host pointer, usable from
+ * host code. Every at()/width()/height() call dereferences it, so the caller must run the wrapper on
+ * the side matching the snapshot's residency.
  *
  * @tparam T The datatype of an individual pixel (e.g. uchar1, uchar3, uchar4, float1, float4).
  */
@@ -56,22 +58,15 @@ class ImageBatchVarShapeWrapper {
     ImageBatchVarShapeWrapper() = default;
 
     /**
-     * @brief Creates a ImageBatchVarShapeWrapper from a GPU-resident varshape batch data snapshot.
+     * @brief Creates a ImageBatchVarShapeWrapper from a varshape batch data snapshot.
+     *
+     * Accepts either residency through the common ImageBatchVarShapeDataStrided base — a GPU
+     * (...Hip) snapshot yields a device-usable wrapper, a CPU (...Host) snapshot a host-usable one.
      *
      * @param data The exported descriptor table from ImageBatchVarShape::exportData(stream).
      */
-    __host__ ImageBatchVarShapeWrapper(const ImageBatchVarShapeDataStridedHip& data)
-        : m_imageList(data.imageList()), m_numImages(data.numImages()) {
-#ifndef NDEBUG
-        // ImageBatchVarShape rejects multi-plane at pushBack; assert here as a belt-and-braces
-        // check in case a future producer relaxes that.
-        const ImageFormat* formats = data.hostFormatList();
-        for (int32_t i = 0; i < m_numImages; ++i) {
-            assert(formats[i].channels() == detail::NumElements<T> &&
-                   "ImageBatchVarShapeWrapper<T>: per-image channel count must match NumElements<T>");
-        }
-#endif
-    }
+    __host__ ImageBatchVarShapeWrapper(const ImageBatchVarShapeDataStrided& data)
+        : m_imageList(data.imageList()), m_numImages(data.numImages()) {}
 
     /**
      * @brief Returns a reference to data at given image-batch coordinates.

--- a/include/core/wrappers/image_wrapper.hpp
+++ b/include/core/wrappers/image_wrapper.hpp
@@ -42,6 +42,8 @@ class ImageWrapper {
     using ValueType = T;
     using BaseType = detail::BaseType<T>;
 
+    ImageWrapper() = default;
+
     /**
      * @brief Creates an ImageWrapper from a Tensor.
      *
@@ -139,16 +141,22 @@ class ImageWrapper {
     /**
      * @brief Retrives the height of the images.
      *
+     * @param n Batch index. Ignored for uniform-shape ImageWrapper; included so the signature matches
+     *          VarShapeImageWrapper, allowing both to satisfy the wrapper concept consumed by
+     *          BorderWrapper / InterpolationWrapper.
      * @return Image height.
      */
-    __device__ __host__ inline int64_t height() const { return shape.h; }
+    __device__ __host__ inline int64_t height(int64_t /*n*/ = 0) const { return shape.h; }
 
     /**
      * @brief Retrieves the width of the image.
      *
+     * @param n Batch index. Ignored for uniform-shape ImageWrapper; included so the signature matches
+     *          VarShapeImageWrapper, allowing both to satisfy the wrapper concept consumed by
+     *          BorderWrapper / InterpolationWrapper.
      * @return Image width.
      */
-    __device__ __host__ inline int64_t width() const { return shape.w; }
+    __device__ __host__ inline int64_t width(int64_t /*n*/ = 0) const { return shape.w; }
 
     /**
      * @brief Retrieves the number of batches in the image tensor.

--- a/include/core/wrappers/interpolation_wrapper.hpp
+++ b/include/core/wrappers/interpolation_wrapper.hpp
@@ -29,34 +29,28 @@
 
 namespace roccv {
 /**
- * @brief A kernel-friendly wrapper which provides interpolation logic based on the given
- * coordinates. This tensor wrapper is typically only used for input tensors and does not provide write access to its
- * underlying data.
+ * @brief A kernel-friendly wrapper which provides interpolation logic on top of an underlying image wrapper.
  *
- * @tparam T Underlying data type of the tensor data.
- * @tparam C Number of channels in data type.
+ * Templated on the wrapper type W (e.g. ImageWrapper<T>, VarShapeImageWrapper<T>) so the same interpolation math
+ * serves both uniform-shape and variable-shape image batches. The pixel value type T is recovered from
+ * W::ValueType. Read-only access; do not use for output tensors.
+ *
  * @tparam B Border type to use for interpolation.
  * @tparam I Interpolation type to use.
+ * @tparam W The underlying image wrapper type. Must expose ValueType, at(n,h,w,c), width(n), height(n).
  */
-template <typename T, eBorderType B, eInterpolationType I>
+template <eBorderType B, eInterpolationType I, typename W>
 class InterpolationWrapper {
    public:
-    /**
-     * @brief Wraps a roccv::Tensor in an InterpolationWrapper to provide pixel interpolation when accessing
-     * non-integer coordinate mappings.
-     *
-     * @param tensor The tensor to wrap.
-     * @param border_value A fallback border value to use in the case of a constant border mode.
-     */
-    InterpolationWrapper(const Tensor& tensor, T border_value) : m_desc(tensor, border_value) {}
+    using ValueType = typename W::ValueType;
 
     /**
-     * @brief Wraps a BorderWrapper in an Interpolation wrapper. Extends capabilities to interpolate pixel values when
-     * given non-integer coordinates.
+     * @brief Wraps a BorderWrapper in an InterpolationWrapper. Extends capabilities to interpolate pixel values
+     * when given non-integer coordinates.
      *
      * @param borderWrapper The BorderWrapper to wrap.
      */
-    InterpolationWrapper(BorderWrapper<T, B> borderWrapper) : m_desc(borderWrapper) {}
+    InterpolationWrapper(BorderWrapper<B, W> borderWrapper) : m_desc(borderWrapper) {}
 
     /**
      * @brief This function calculates the weighting coefficients for the Catmull-Rom cubic interpolation.
@@ -81,7 +75,7 @@ class InterpolationWrapper {
      * @param w Width coordinates.
      * @return An interpolated value.
      */
-    inline __device__ __host__ const T at(int64_t n, float h, float w, int64_t c) const {
+    inline __device__ __host__ ValueType at(int64_t n, float h, float w, int64_t c) const {
         if constexpr (I == eInterpolationType::INTERP_TYPE_NEAREST) {
             return m_desc.at(n, detail::interp_nearest_i64(h), detail::interp_nearest_i64(w), c);
         } else if constexpr (I == eInterpolationType::INTERP_TYPE_LINEAR) {
@@ -90,7 +84,7 @@ class InterpolationWrapper {
             // -     -
             // v3 -- v4
 
-            using WorkType = detail::MakeType<float, detail::NumElements<T>>;
+            using WorkType = detail::MakeType<float, detail::NumElements<ValueType>>;
 
             const int64_t x0 = detail::interp_floor_i64(w);
             const int64_t y0 = detail::interp_floor_i64(h);
@@ -109,7 +103,7 @@ class InterpolationWrapper {
                 auto q1 = v1 * omfx + v2 * fx;
                 auto q2 = v3 * omfx + v4 * fx;
                 auto q = q1 * omfy + q2 * fy;
-                return detail::RangeCast<T>(q);
+                return detail::RangeCast<ValueType>(q);
             }
 
             auto v1 = detail::RangeCast<WorkType>(m_desc.at(n, y0, x0, c));
@@ -121,10 +115,10 @@ class InterpolationWrapper {
             auto q2 = v3 * omfx + v4 * fx;
             auto q = q1 * omfy + q2 * fy;
 
-            return detail::RangeCast<T>(q);
+            return detail::RangeCast<ValueType>(q);
         } else if constexpr (I == eInterpolationType::INTERP_TYPE_CUBIC) {
             using namespace roccv::detail;
-            using WorkType = detail::MakeType<float, detail::NumElements<T>>;
+            using WorkType = detail::MakeType<float, detail::NumElements<ValueType>>;
 
             const int64_t int_x = detail::interp_floor_i64(w);
             const int64_t int_y = detail::interp_floor_i64(h);
@@ -168,16 +162,16 @@ class InterpolationWrapper {
                 }
             }
 
-            return detail::RangeCast<T>(sum);
+            return detail::RangeCast<ValueType>(sum);
         }
     }
 
-    __device__ __host__ inline int64_t height() const { return m_desc.height(); }
-    __device__ __host__ inline int64_t width() const { return m_desc.width(); }
+    __device__ __host__ inline int64_t height(int64_t n = 0) const { return m_desc.height(n); }
+    __device__ __host__ inline int64_t width(int64_t n = 0) const { return m_desc.width(n); }
     __device__ __host__ inline int64_t batches() const { return m_desc.batches(); }
     __device__ __host__ inline int64_t channels() const { return m_desc.channels(); }
 
    private:
-    BorderWrapper<T, B> m_desc;
+    BorderWrapper<B, W> m_desc;
 };
 }  // namespace roccv

--- a/include/core/wrappers/interpolation_wrapper.hpp
+++ b/include/core/wrappers/interpolation_wrapper.hpp
@@ -98,7 +98,7 @@ class InterpolationWrapper {
             const float omfx = 1.f - fx;
             const float omfy = 1.f - fy;
 
-            if (x0 >= 0 && y0 >= 0 && x1 < m_desc.width() && y1 < m_desc.height()) {
+            if (x0 >= 0 && y0 >= 0 && x1 < m_desc.width(n) && y1 < m_desc.height(n)) {
                 auto v1 = detail::RangeCast<WorkType>(m_desc.at_inbounds(n, y0, x0, c));
                 auto v2 = detail::RangeCast<WorkType>(m_desc.at_inbounds(n, y0, x1, c));
                 auto v3 = detail::RangeCast<WorkType>(m_desc.at_inbounds(n, y1, x0, c));
@@ -142,7 +142,7 @@ class InterpolationWrapper {
 
             WorkType sum = SetAll<WorkType>(0.0f);
             const bool cubic_fast =
-                int_x >= 1 && int_y >= 1 && (int_x + 2) < m_desc.width() && (int_y + 2) < m_desc.height();
+                int_x >= 1 && int_y >= 1 && (int_x + 2) < m_desc.width(n) && (int_y + 2) < m_desc.height(n);
             k = 0;
             if (cubic_fast) {
 #pragma unroll

--- a/include/core/wrappers/interpolation_wrapper.hpp
+++ b/include/core/wrappers/interpolation_wrapper.hpp
@@ -29,20 +29,23 @@
 
 namespace roccv {
 /**
- * @brief A kernel-friendly wrapper which provides interpolation logic on top of an underlying image wrapper.
+ * @brief A kernel-friendly wrapper which provides interpolation logic on top of a BorderWrapper.
  *
- * Templated on the wrapper type W (e.g. ImageWrapper<T>, VarShapeImageWrapper<T>) so the same interpolation math
- * serves both uniform-shape and variable-shape image batches. The pixel value type T is recovered from
- * W::ValueType. Read-only access; do not use for output tensors.
+ * Templated directly on the BorderWrapper type so the redundant border-mode and underlying-wrapper template
+ * parameters need only be spelled once (in the BorderWrapper type). Recover the border mode via
+ * BW::kBorderType and the underlying wrapper type via BW::WrapperType.
  *
- * @tparam B Border type to use for interpolation.
- * @tparam I Interpolation type to use.
- * @tparam W The underlying image wrapper type. Must expose ValueType, at(n,h,w,c), width(n), height(n).
+ * Read-only access; do not use for output tensors.
+ *
+ * @tparam I  Interpolation type to use.
+ * @tparam BW The BorderWrapper type to wrap. Must expose ValueType plus at(n,h,w,c), width(n), height(n).
  */
-template <eBorderType B, eInterpolationType I, typename W>
+template <eInterpolationType I, typename BW>
 class InterpolationWrapper {
    public:
-    using ValueType = typename W::ValueType;
+    using ValueType = typename BW::ValueType;
+    using BorderType = BW;
+    static constexpr eInterpolationType kInterpolationType = I;
 
     /**
      * @brief Wraps a BorderWrapper in an InterpolationWrapper. Extends capabilities to interpolate pixel values
@@ -50,7 +53,7 @@ class InterpolationWrapper {
      *
      * @param borderWrapper The BorderWrapper to wrap.
      */
-    InterpolationWrapper(BorderWrapper<B, W> borderWrapper) : m_desc(borderWrapper) {}
+    InterpolationWrapper(BW borderWrapper) : m_desc(borderWrapper) {}
 
     /**
      * @brief This function calculates the weighting coefficients for the Catmull-Rom cubic interpolation.
@@ -172,6 +175,19 @@ class InterpolationWrapper {
     __device__ __host__ inline int64_t channels() const { return m_desc.channels(); }
 
    private:
-    BorderWrapper<B, W> m_desc;
+    BW m_desc;
 };
+
+/**
+ * @brief Factory for InterpolationWrapper. Deduces the BorderWrapper type BW (and its border mode +
+ * underlying wrapper) from the argument; callers only need to spell the interpolation policy.
+ *
+ * @tparam I The interpolation type.
+ * @param borderWrap An already-constructed BorderWrapper (typically via MakeBorderWrapper<B>(...)).
+ */
+template <eInterpolationType I, typename BW>
+auto MakeInterpolationWrapper(BW borderWrap) {
+    return InterpolationWrapper<I, BW>(borderWrap);
+}
+
 }  // namespace roccv

--- a/include/core/wrappers/tensor_wrapper.hpp
+++ b/include/core/wrappers/tensor_wrapper.hpp
@@ -31,30 +31,30 @@
 namespace roccv {
 
 /**
- * @brief ImageWrapper is a non-owning wrapper for roccv::Tensors with a NHWC/NCHW/HWC layout. It provides
+ * @brief TensorWrapper is a non-owning wrapper for roccv::Tensors with a NHWC/NCHW/HWC layout. It provides
  * methods for accessing the underlying data within HIP kernels.
  *
  * @tparam T The datatype of the underlying tensor data.
  */
 template <typename T>
-class ImageWrapper {
+class TensorWrapper {
    public:
     using ValueType = T;
     using BaseType = detail::BaseType<T>;
 
-    ImageWrapper() = default;
+    TensorWrapper() = default;
 
     /**
-     * @brief Creates an ImageWrapper from a Tensor.
+     * @brief Creates an TensorWrapper from a Tensor.
      *
-     * @param tensor The Tensor to be represented by the ImageWrapper.
+     * @param tensor The Tensor to be represented by the TensorWrapper.
      */
-    ImageWrapper(const Tensor& tensor) {
+    TensorWrapper(const Tensor& tensor) {
         if (tensor.layout() != eTensorLayout::TENSOR_LAYOUT_NHWC &&
             tensor.layout() != eTensorLayout::TENSOR_LAYOUT_NCHW &&
             tensor.layout() != eTensorLayout::TENSOR_LAYOUT_HWC &&
             tensor.layout() != eTensorLayout::TENSOR_LAYOUT_CHW) {
-            throw Exception("The given tensor layout is not supported for ImageWrapper", eStatusType::NOT_IMPLEMENTED);
+            throw Exception("The given tensor layout is not supported for TensorWrapper", eStatusType::NOT_IMPLEMENTED);
         }
 
         // Copy tensor data into image tensor descriptor
@@ -73,14 +73,14 @@ class ImageWrapper {
     }
 
     /**
-     * @brief Creates an ImageWrapper from a vector.
+     * @brief Creates an TensorWrapper from a vector.
      *
      * @param input The input vector to wrap.
      * @param batchSize The number of images within the batch.
      * @param width The width of each image within the batch.
      * @param height The height of each image within the batch.
      */
-    ImageWrapper(std::vector<BaseType>& input, int32_t batchSize, int32_t width, int32_t height) {
+    TensorWrapper(std::vector<BaseType>& input, int32_t batchSize, int32_t width, int32_t height) {
         // Calculate strides based on input (byte-wise strides)
         stride.c = sizeof(BaseType);
         stride.w = stride.c * detail::NumElements<T>;
@@ -98,14 +98,14 @@ class ImageWrapper {
     }
 
     /**
-     * @brief Creates an ImageWrapper from a pointer.
+     * @brief Creates an TensorWrapper from a pointer.
      *
      * @param input The input pointer to wrap.
      * @param batchSize The number of images within the batch.
      * @param width The width of each image within the batch.
      * @param height The height of each image within the batch.
      */
-    ImageWrapper(void* input, int32_t batchSize, int32_t width, int32_t height) {
+    TensorWrapper(void* input, int32_t batchSize, int32_t width, int32_t height) {
         // Calculate strides based on input (byte-wise strides)
         stride.c = sizeof(BaseType);
         stride.w = stride.c * detail::NumElements<T>;
@@ -141,8 +141,8 @@ class ImageWrapper {
     /**
      * @brief Retrives the height of the images.
      *
-     * @param n Batch index. Ignored for uniform-shape ImageWrapper; included so the signature matches
-     *          VarShapeImageWrapper, allowing both to satisfy the wrapper concept consumed by
+     * @param n Batch index. Ignored for uniform-shape TensorWrapper; included so the signature matches
+     *          ImageBatchVarShapeWrapper, allowing both to satisfy the wrapper concept consumed by
      *          BorderWrapper / InterpolationWrapper.
      * @return Image height.
      */
@@ -151,8 +151,8 @@ class ImageWrapper {
     /**
      * @brief Retrieves the width of the image.
      *
-     * @param n Batch index. Ignored for uniform-shape ImageWrapper; included so the signature matches
-     *          VarShapeImageWrapper, allowing both to satisfy the wrapper concept consumed by
+     * @param n Batch index. Ignored for uniform-shape TensorWrapper; included so the signature matches
+     *          ImageBatchVarShapeWrapper, allowing both to satisfy the wrapper concept consumed by
      *          BorderWrapper / InterpolationWrapper.
      * @return Image width.
      */

--- a/include/core/wrappers/var_shape_image_wrapper.hpp
+++ b/include/core/wrappers/var_shape_image_wrapper.hpp
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#pragma once
+
+#include <hip/hip_runtime.h>
+
+#include <cassert>
+#include <cstdint>
+
+#include "core/detail/type_traits.hpp"
+#include "core/image_batch_data.hpp"
+#include "core/image_buffer.hpp"
+
+namespace roccv {
+
+/**
+ * @brief VarShapeImageWrapper is a non-owning, kernel-friendly view over an ImageBatchVarShape's
+ * device-side descriptor table. It satisfies the same wrapper concept as ImageWrapper<T>
+ * (ValueType, at(n,h,w,c), width(n), height(n), batches(), channels()) so it composes with
+ * BorderWrapper / InterpolationWrapper unchanged.
+ *
+ * Single-plane interleaved (NHWC-style) only — ImageBatchVarShape rejects multi-plane images
+ * at pushBack, and channel count is derived from T via detail::NumElements<T>.
+ *
+ * Pointer residency: m_imageList is a device pointer for an ImageBatchVarShapeDataStridedHip;
+ * every at()/width()/height() call dereferences it, so this wrapper is only safe to use from
+ * device code (or host code that has the descriptor table host-side).
+ *
+ * @tparam T The datatype of an individual pixel (e.g. uchar1, uchar3, uchar4, float1, float4).
+ */
+template <typename T>
+class VarShapeImageWrapper {
+   public:
+    using ValueType = T;
+    using BaseType = detail::BaseType<T>;
+
+    VarShapeImageWrapper() = default;
+
+    /**
+     * @brief Creates a VarShapeImageWrapper from a GPU-resident varshape batch data snapshot.
+     *
+     * @param data The exported descriptor table from ImageBatchVarShape::exportData(stream).
+     */
+    __host__ VarShapeImageWrapper(const ImageBatchVarShapeDataStridedHip& data)
+        : m_imageList(data.imageList()), m_numImages(data.numImages()) {
+#ifndef NDEBUG
+        // ImageBatchVarShape rejects multi-plane at pushBack; assert here as a belt-and-braces
+        // check in case a future producer relaxes that.
+        const ImageFormat* formats = data.hostFormatList();
+        for (int32_t i = 0; i < m_numImages; ++i) {
+            assert(formats[i].channels() == detail::NumElements<T> &&
+                   "VarShapeImageWrapper<T>: per-image channel count must match NumElements<T>");
+        }
+#endif
+    }
+
+    /**
+     * @brief Returns a reference to data at given image-batch coordinates.
+     *
+     * @param n Batch index.
+     * @param h Row index within image n.
+     * @param w Column index within image n.
+     * @param c Channel index within the pixel.
+     * @return A reference to the underlying pixel-channel value.
+     */
+    __device__ __host__ T& at(int64_t n, int64_t h, int64_t w, int64_t c) { return *doGetPtr(n, h, w, c); }
+
+    __device__ __host__ const T at(int64_t n, int64_t h, int64_t w, int64_t c) const { return *doGetPtr(n, h, w, c); }
+
+    /**
+     * @brief Width of the image at batch index n.
+     */
+    __device__ __host__ inline int64_t width(int64_t n) const { return m_imageList[n].planes[0].width; }
+
+    /**
+     * @brief Height of the image at batch index n.
+     */
+    __device__ __host__ inline int64_t height(int64_t n) const { return m_imageList[n].planes[0].height; }
+
+    /**
+     * @brief Number of images in the batch.
+     */
+    __device__ __host__ inline int64_t batches() const { return m_numImages; }
+
+    /**
+     * @brief Number of channels per pixel. Derived from T, identical across all images in v1.
+     */
+    __device__ __host__ inline int64_t channels() const { return detail::NumElements<T>; }
+
+   private:
+    __device__ __host__ inline T* doGetPtr(int64_t n, int64_t h, int64_t w, int64_t c) const {
+        // Single-plane interleaved NHWC layout: pixel stride is sizeof(T), channel stride is
+        // sizeof(BaseType). Match ImageWrapper<T>::at semantics — returns a T* offset to (h, w)
+        // and additionally shifted by c channels.
+        const ImagePlaneStrided& p = m_imageList[n].planes[0];
+        unsigned char* addr =
+            reinterpret_cast<unsigned char*>(p.basePtr) + h * p.rowStride + w * sizeof(T) + c * sizeof(BaseType);
+        return reinterpret_cast<T*>(addr);
+    }
+
+    const ImageBufferStrided* m_imageList = nullptr;
+    int32_t m_numImages = 0;
+};
+
+}  // namespace roccv

--- a/include/kernels/device/brightness_contrast_device.hpp
+++ b/include/kernels/device/brightness_contrast_device.hpp
@@ -26,7 +26,7 @@ THE SOFTWARE.
 
 #include "core/detail/casting.hpp"
 #include "core/detail/type_traits.hpp"
-#include "core/wrappers/image_wrapper.hpp"
+#include "core/wrappers/tensor_wrapper.hpp"
 
 namespace Kernels {
 namespace Device {

--- a/include/kernels/device/convert_to_device.hpp
+++ b/include/kernels/device/convert_to_device.hpp
@@ -26,7 +26,7 @@ THE SOFTWARE.
 
 #include "core/detail/casting.hpp"
 #include "core/detail/type_traits.hpp"
-#include "core/wrappers/image_wrapper.hpp"
+#include "core/wrappers/tensor_wrapper.hpp"
 
 namespace Kernels {
 namespace Device {

--- a/include/kernels/device/copy_make_border_device.hpp
+++ b/include/kernels/device/copy_make_border_device.hpp
@@ -29,9 +29,9 @@ namespace Device {
  * @brief GPU kernel for CopyMakeBorder operator.
  *
  * @tparam SrcDesc Must be a BorderWrapper.
- * @tparam DstDesc Must be a ImageWrapper.
+ * @tparam DstDesc Must be a TensorWrapper.
  * @param src A BorderWrapper containing information for the input tensor.
- * @param dst A ImageWrapper containing information for the output tensor.
+ * @param dst A TensorWrapper containing information for the output tensor.
  * @param top The top pixel coordinate on the y-axis where the border should start.
  * @param left The left-most pixel coordinate on the x-axis where the border should start.
  * @return __global__

--- a/include/kernels/device/reformat_device.hpp
+++ b/include/kernels/device/reformat_device.hpp
@@ -21,7 +21,7 @@
 
 #include <hip/hip_runtime.h>
 
-#include "core/wrappers/image_wrapper.hpp"
+#include "core/wrappers/tensor_wrapper.hpp"
 
 namespace Kernels::Device {
 
@@ -34,7 +34,7 @@ namespace Kernels::Device {
  * @param[out] output The output tensor.
  */
 template <int Channels, typename T>
-__global__ void reformat(roccv::ImageWrapper<T> input, roccv::ImageWrapper<T> output) {
+__global__ void reformat(roccv::TensorWrapper<T> input, roccv::TensorWrapper<T> output) {
     const int x = blockDim.x * blockIdx.x + threadIdx.x;
     const int y = blockDim.y * blockIdx.y + threadIdx.y;
     const int b = blockIdx.z;

--- a/include/kernels/host/brightness_contrast_host.hpp
+++ b/include/kernels/host/brightness_contrast_host.hpp
@@ -26,7 +26,7 @@ THE SOFTWARE.
 
 #include "core/detail/casting.hpp"
 #include "core/detail/type_traits.hpp"
-#include "core/wrappers/image_wrapper.hpp"
+#include "core/wrappers/tensor_wrapper.hpp"
 
 namespace Kernels {
 namespace Host {

--- a/include/kernels/host/convert_to_host.hpp
+++ b/include/kernels/host/convert_to_host.hpp
@@ -25,7 +25,7 @@ THE SOFTWARE.
 #include <hip/hip_runtime.h>
 #include "core/detail/casting.hpp"
 #include "core/detail/type_traits.hpp"
-#include "core/wrappers/image_wrapper.hpp"
+#include "core/wrappers/tensor_wrapper.hpp"
 
 namespace Kernels {
 namespace Host {

--- a/include/kernels/host/reformat_host.hpp
+++ b/include/kernels/host/reformat_host.hpp
@@ -23,7 +23,7 @@
 
 #include <hip/hip_runtime.h>
 
-#include "core/wrappers/image_wrapper.hpp"
+#include "core/wrappers/tensor_wrapper.hpp"
 
 namespace Kernels::Host {
 
@@ -36,7 +36,7 @@ namespace Kernels::Host {
  * @param[out] output The output tensor.
  */
 template <int Channels, typename T>
-void reformat(roccv::ImageWrapper<T> input, roccv::ImageWrapper<T> output) {
+void reformat(roccv::TensorWrapper<T> input, roccv::TensorWrapper<T> output) {
 #pragma omp parallel for
     for (int b = 0; b < output.batches(); b++) {
         for (int y = 0; y < output.height(); y++) {

--- a/src/core/tensor_storage.cpp
+++ b/src/core/tensor_storage.cpp
@@ -22,7 +22,6 @@
 #include "core/tensor_storage.hpp"
 
 #include "core/detail/context.hpp"
-#include "core/hip_assert.h"
 
 namespace roccv {
 TensorStorage::TensorStorage(void* data, eDeviceType device, eOwnership ownership)

--- a/src/op_adv_cvt_color.cpp
+++ b/src/op_adv_cvt_color.cpp
@@ -26,7 +26,7 @@ THE SOFTWARE.
 
 #include "common/validation_helpers.hpp"
 #include "core/tensor.hpp"
-#include "core/wrappers/image_wrapper.hpp"
+#include "core/wrappers/tensor_wrapper.hpp"
 #include "kernels/common/adv_cvt_color_coefficients.hpp"
 #include "kernels/device/adv_cvt_color_device.hpp"
 #include "kernels/host/adv_cvt_color_host.hpp"
@@ -189,22 +189,22 @@ void AdvCvtColor::operator()(hipStream_t stream, const Tensor &input, Tensor &ou
             switch (conversionCode) {
                 case COLOR_BGR2YUV:
                     Kernels::Device::rgb_or_bgr_to_yuv_adv<uchar3, eSwizzle::ZYXW>
-                        <<<gridSize, blockSize, 0, stream>>>(ImageWrapper<uchar3>(input), ImageWrapper<uchar3>(output),
+                        <<<gridSize, blockSize, 0, stream>>>(TensorWrapper<uchar3>(input), TensorWrapper<uchar3>(output),
                                                               coeff, kDelta);
                     break;
                 case COLOR_RGB2YUV:
                     Kernels::Device::rgb_or_bgr_to_yuv_adv<uchar3, eSwizzle::XYZW>
-                        <<<gridSize, blockSize, 0, stream>>>(ImageWrapper<uchar3>(input), ImageWrapper<uchar3>(output),
+                        <<<gridSize, blockSize, 0, stream>>>(TensorWrapper<uchar3>(input), TensorWrapper<uchar3>(output),
                                                               coeff, kDelta);
                     break;
                 case COLOR_YUV2BGR:
                     Kernels::Device::yuv_to_rgb_or_bgr_adv<uchar3, eSwizzle::ZYXW>
-                        <<<gridSize, blockSize, 0, stream>>>(ImageWrapper<uchar3>(input), ImageWrapper<uchar3>(output),
+                        <<<gridSize, blockSize, 0, stream>>>(TensorWrapper<uchar3>(input), TensorWrapper<uchar3>(output),
                                                               coeff, kDelta);
                     break;
                 case COLOR_YUV2RGB:
                     Kernels::Device::yuv_to_rgb_or_bgr_adv<uchar3, eSwizzle::XYZW>
-                        <<<gridSize, blockSize, 0, stream>>>(ImageWrapper<uchar3>(input), ImageWrapper<uchar3>(output),
+                        <<<gridSize, blockSize, 0, stream>>>(TensorWrapper<uchar3>(input), TensorWrapper<uchar3>(output),
                                                               coeff, kDelta);
                     break;
                 default: throw Exception("Unsupported conversion code.", eStatusType::INVALID_COMBINATION);
@@ -215,26 +215,26 @@ void AdvCvtColor::operator()(hipStream_t stream, const Tensor &input, Tensor &ou
 
             if (outChannels == 3) {
                 if (bgr) {
-                    Kernels::Device::nv12_or_nv21_to_rgb_or_bgr_adv<eSwizzle::ZYXW, ImageWrapper<uchar1>,
-                                                                     ImageWrapper<uchar3>, uchar3>
-                        <<<gridSize, blockSize, 0, stream>>>(ImageWrapper<uchar1>(input), ImageWrapper<uchar3>(output),
+                    Kernels::Device::nv12_or_nv21_to_rgb_or_bgr_adv<eSwizzle::ZYXW, TensorWrapper<uchar1>,
+                                                                     TensorWrapper<uchar3>, uchar3>
+                        <<<gridSize, blockSize, 0, stream>>>(TensorWrapper<uchar1>(input), TensorWrapper<uchar3>(output),
                                                               coeff, kDelta, uidx);
                 } else {
-                    Kernels::Device::nv12_or_nv21_to_rgb_or_bgr_adv<eSwizzle::XYZW, ImageWrapper<uchar1>,
-                                                                     ImageWrapper<uchar3>, uchar3>
-                        <<<gridSize, blockSize, 0, stream>>>(ImageWrapper<uchar1>(input), ImageWrapper<uchar3>(output),
+                    Kernels::Device::nv12_or_nv21_to_rgb_or_bgr_adv<eSwizzle::XYZW, TensorWrapper<uchar1>,
+                                                                     TensorWrapper<uchar3>, uchar3>
+                        <<<gridSize, blockSize, 0, stream>>>(TensorWrapper<uchar1>(input), TensorWrapper<uchar3>(output),
                                                               coeff, kDelta, uidx);
                 }
             } else {
                 if (bgr) {
-                    Kernels::Device::nv12_or_nv21_to_rgb_or_bgr_adv<eSwizzle::ZYXW, ImageWrapper<uchar1>,
-                                                                     ImageWrapper<uchar4>, uchar4>
-                        <<<gridSize, blockSize, 0, stream>>>(ImageWrapper<uchar1>(input), ImageWrapper<uchar4>(output),
+                    Kernels::Device::nv12_or_nv21_to_rgb_or_bgr_adv<eSwizzle::ZYXW, TensorWrapper<uchar1>,
+                                                                     TensorWrapper<uchar4>, uchar4>
+                        <<<gridSize, blockSize, 0, stream>>>(TensorWrapper<uchar1>(input), TensorWrapper<uchar4>(output),
                                                               coeff, kDelta, uidx);
                 } else {
-                    Kernels::Device::nv12_or_nv21_to_rgb_or_bgr_adv<eSwizzle::XYZW, ImageWrapper<uchar1>,
-                                                                     ImageWrapper<uchar4>, uchar4>
-                        <<<gridSize, blockSize, 0, stream>>>(ImageWrapper<uchar1>(input), ImageWrapper<uchar4>(output),
+                    Kernels::Device::nv12_or_nv21_to_rgb_or_bgr_adv<eSwizzle::XYZW, TensorWrapper<uchar1>,
+                                                                     TensorWrapper<uchar4>, uchar4>
+                        <<<gridSize, blockSize, 0, stream>>>(TensorWrapper<uchar1>(input), TensorWrapper<uchar4>(output),
                                                               coeff, kDelta, uidx);
                 }
             }
@@ -245,21 +245,21 @@ void AdvCvtColor::operator()(hipStream_t stream, const Tensor &input, Tensor &ou
             if (inChannels == 3) {
                 if (bgr) {
                     Kernels::Device::rgb_or_bgr_to_nv12_or_nv21_adv<uchar3, eSwizzle::ZYXW>
-                        <<<gridSize, blockSize, 0, stream>>>(ImageWrapper<uchar3>(input), ImageWrapper<uchar1>(output),
+                        <<<gridSize, blockSize, 0, stream>>>(TensorWrapper<uchar3>(input), TensorWrapper<uchar1>(output),
                                                               coeff, kDelta, uidx);
                 } else {
                     Kernels::Device::rgb_or_bgr_to_nv12_or_nv21_adv<uchar3, eSwizzle::XYZW>
-                        <<<gridSize, blockSize, 0, stream>>>(ImageWrapper<uchar3>(input), ImageWrapper<uchar1>(output),
+                        <<<gridSize, blockSize, 0, stream>>>(TensorWrapper<uchar3>(input), TensorWrapper<uchar1>(output),
                                                               coeff, kDelta, uidx);
                 }
             } else {
                 if (bgr) {
                     Kernels::Device::rgb_or_bgr_to_nv12_or_nv21_adv<uchar4, eSwizzle::ZYXW>
-                        <<<gridSize, blockSize, 0, stream>>>(ImageWrapper<uchar4>(input), ImageWrapper<uchar1>(output),
+                        <<<gridSize, blockSize, 0, stream>>>(TensorWrapper<uchar4>(input), TensorWrapper<uchar1>(output),
                                                               coeff, kDelta, uidx);
                 } else {
                     Kernels::Device::rgb_or_bgr_to_nv12_or_nv21_adv<uchar4, eSwizzle::XYZW>
-                        <<<gridSize, blockSize, 0, stream>>>(ImageWrapper<uchar4>(input), ImageWrapper<uchar1>(output),
+                        <<<gridSize, blockSize, 0, stream>>>(TensorWrapper<uchar4>(input), TensorWrapper<uchar1>(output),
                                                               coeff, kDelta, uidx);
                 }
             }
@@ -268,23 +268,23 @@ void AdvCvtColor::operator()(hipStream_t stream, const Tensor &input, Tensor &ou
         if (IsInterleaved444(conversionCode)) {
             switch (conversionCode) {
                 case COLOR_BGR2YUV:
-                    Kernels::Host::rgb_or_bgr_to_yuv_adv<uchar3, eSwizzle::ZYXW>(ImageWrapper<uchar3>(input),
-                                                                                  ImageWrapper<uchar3>(output), coeff,
+                    Kernels::Host::rgb_or_bgr_to_yuv_adv<uchar3, eSwizzle::ZYXW>(TensorWrapper<uchar3>(input),
+                                                                                  TensorWrapper<uchar3>(output), coeff,
                                                                                   kDelta);
                     break;
                 case COLOR_RGB2YUV:
-                    Kernels::Host::rgb_or_bgr_to_yuv_adv<uchar3, eSwizzle::XYZW>(ImageWrapper<uchar3>(input),
-                                                                                  ImageWrapper<uchar3>(output), coeff,
+                    Kernels::Host::rgb_or_bgr_to_yuv_adv<uchar3, eSwizzle::XYZW>(TensorWrapper<uchar3>(input),
+                                                                                  TensorWrapper<uchar3>(output), coeff,
                                                                                   kDelta);
                     break;
                 case COLOR_YUV2BGR:
-                    Kernels::Host::yuv_to_rgb_or_bgr_adv<uchar3, eSwizzle::ZYXW>(ImageWrapper<uchar3>(input),
-                                                                                  ImageWrapper<uchar3>(output), coeff,
+                    Kernels::Host::yuv_to_rgb_or_bgr_adv<uchar3, eSwizzle::ZYXW>(TensorWrapper<uchar3>(input),
+                                                                                  TensorWrapper<uchar3>(output), coeff,
                                                                                   kDelta);
                     break;
                 case COLOR_YUV2RGB:
-                    Kernels::Host::yuv_to_rgb_or_bgr_adv<uchar3, eSwizzle::XYZW>(ImageWrapper<uchar3>(input),
-                                                                                  ImageWrapper<uchar3>(output), coeff,
+                    Kernels::Host::yuv_to_rgb_or_bgr_adv<uchar3, eSwizzle::XYZW>(TensorWrapper<uchar3>(input),
+                                                                                  TensorWrapper<uchar3>(output), coeff,
                                                                                   kDelta);
                     break;
                 default: throw Exception("Unsupported conversion code.", eStatusType::INVALID_COMBINATION);
@@ -292,41 +292,41 @@ void AdvCvtColor::operator()(hipStream_t stream, const Tensor &input, Tensor &ou
         } else if (IsSemiPlanarToInterleaved(conversionCode)) {
             if (outChannels == 3) {
                 if (bgr) {
-                    Kernels::Host::nv12_or_nv21_to_rgb_or_bgr_adv<eSwizzle::ZYXW, ImageWrapper<uchar1>,
-                                                                   ImageWrapper<uchar3>, uchar3>(
-                        ImageWrapper<uchar1>(input), ImageWrapper<uchar3>(output), coeff, kDelta, uidx);
+                    Kernels::Host::nv12_or_nv21_to_rgb_or_bgr_adv<eSwizzle::ZYXW, TensorWrapper<uchar1>,
+                                                                   TensorWrapper<uchar3>, uchar3>(
+                        TensorWrapper<uchar1>(input), TensorWrapper<uchar3>(output), coeff, kDelta, uidx);
                 } else {
-                    Kernels::Host::nv12_or_nv21_to_rgb_or_bgr_adv<eSwizzle::XYZW, ImageWrapper<uchar1>,
-                                                                   ImageWrapper<uchar3>, uchar3>(
-                        ImageWrapper<uchar1>(input), ImageWrapper<uchar3>(output), coeff, kDelta, uidx);
+                    Kernels::Host::nv12_or_nv21_to_rgb_or_bgr_adv<eSwizzle::XYZW, TensorWrapper<uchar1>,
+                                                                   TensorWrapper<uchar3>, uchar3>(
+                        TensorWrapper<uchar1>(input), TensorWrapper<uchar3>(output), coeff, kDelta, uidx);
                 }
             } else {
                 if (bgr) {
-                    Kernels::Host::nv12_or_nv21_to_rgb_or_bgr_adv<eSwizzle::ZYXW, ImageWrapper<uchar1>,
-                                                                   ImageWrapper<uchar4>, uchar4>(
-                        ImageWrapper<uchar1>(input), ImageWrapper<uchar4>(output), coeff, kDelta, uidx);
+                    Kernels::Host::nv12_or_nv21_to_rgb_or_bgr_adv<eSwizzle::ZYXW, TensorWrapper<uchar1>,
+                                                                   TensorWrapper<uchar4>, uchar4>(
+                        TensorWrapper<uchar1>(input), TensorWrapper<uchar4>(output), coeff, kDelta, uidx);
                 } else {
-                    Kernels::Host::nv12_or_nv21_to_rgb_or_bgr_adv<eSwizzle::XYZW, ImageWrapper<uchar1>,
-                                                                   ImageWrapper<uchar4>, uchar4>(
-                        ImageWrapper<uchar1>(input), ImageWrapper<uchar4>(output), coeff, kDelta, uidx);
+                    Kernels::Host::nv12_or_nv21_to_rgb_or_bgr_adv<eSwizzle::XYZW, TensorWrapper<uchar1>,
+                                                                   TensorWrapper<uchar4>, uchar4>(
+                        TensorWrapper<uchar1>(input), TensorWrapper<uchar4>(output), coeff, kDelta, uidx);
                 }
             }
         } else {
             if (inChannels == 3) {
                 if (bgr) {
                     Kernels::Host::rgb_or_bgr_to_nv12_or_nv21_adv<uchar3, eSwizzle::ZYXW>(
-                        ImageWrapper<uchar3>(input), ImageWrapper<uchar1>(output), coeff, kDelta, uidx);
+                        TensorWrapper<uchar3>(input), TensorWrapper<uchar1>(output), coeff, kDelta, uidx);
                 } else {
                     Kernels::Host::rgb_or_bgr_to_nv12_or_nv21_adv<uchar3, eSwizzle::XYZW>(
-                        ImageWrapper<uchar3>(input), ImageWrapper<uchar1>(output), coeff, kDelta, uidx);
+                        TensorWrapper<uchar3>(input), TensorWrapper<uchar1>(output), coeff, kDelta, uidx);
                 }
             } else {
                 if (bgr) {
                     Kernels::Host::rgb_or_bgr_to_nv12_or_nv21_adv<uchar4, eSwizzle::ZYXW>(
-                        ImageWrapper<uchar4>(input), ImageWrapper<uchar1>(output), coeff, kDelta, uidx);
+                        TensorWrapper<uchar4>(input), TensorWrapper<uchar1>(output), coeff, kDelta, uidx);
                 } else {
                     Kernels::Host::rgb_or_bgr_to_nv12_or_nv21_adv<uchar4, eSwizzle::XYZW>(
-                        ImageWrapper<uchar4>(input), ImageWrapper<uchar1>(output), coeff, kDelta, uidx);
+                        TensorWrapper<uchar4>(input), TensorWrapper<uchar1>(output), coeff, kDelta, uidx);
                 }
             }
         }

--- a/src/op_bilateral_filter.cpp
+++ b/src/op_bilateral_filter.cpp
@@ -43,7 +43,7 @@ BilateralFilter::~BilateralFilter() {}
 template <typename T, eBorderType B>
 void dispatch_bilateral_filter_border_mode(hipStream_t stream, const Tensor &input, const Tensor &output, int diameter,
                                            float sigmaColor, float sigmaSpace, T borderValue, eDeviceType device) {
-    BorderWrapper<B, ImageWrapper<T>> inputWrapper(ImageWrapper<T>(input), borderValue);
+    auto inputWrapper = MakeBorderWrapper<B>(ImageWrapper<T>(input), borderValue);
     ImageWrapper<T> outputWrapper(output);
 
     if (outputWrapper.channels() > 4 || outputWrapper.channels() < 1) {
@@ -88,10 +88,9 @@ void dispatch_bilateral_filter_border_mode(hipStream_t stream, const Tensor &inp
 
         for (int j = 0; j < divisor; j++) {
             for (int i = 0; i < dividend; i++) {
-                threads.push_back(
-                    std::thread(Kernels::Host::bilateral_filter<T, BorderWrapper<B, ImageWrapper<T>>, ImageWrapper<T>>,
-                                inputWrapper, outputWrapper, radius, rollingHeight, rollingWidth, prevHeight, prevWidth,
-                                spaceCoeff, colorCoeff));
+                threads.push_back(std::thread(
+                    Kernels::Host::bilateral_filter<T, decltype(inputWrapper), ImageWrapper<T>>, inputWrapper,
+                    outputWrapper, radius, rollingHeight, rollingWidth, prevHeight, prevWidth, spaceCoeff, colorCoeff));
                 prevWidth = rollingWidth;
                 rollingWidth += factorW;
             }

--- a/src/op_bilateral_filter.cpp
+++ b/src/op_bilateral_filter.cpp
@@ -31,7 +31,7 @@ THE SOFTWARE.
 #include "common/validation_helpers.hpp"
 #include "core/detail/casting.hpp"
 #include "core/wrappers/border_wrapper.hpp"
-#include "core/wrappers/image_wrapper.hpp"
+#include "core/wrappers/tensor_wrapper.hpp"
 #include "kernels/device/bilateral_filter_device.hpp"
 #include "kernels/host/bilateral_filter_host.hpp"
 
@@ -43,8 +43,8 @@ BilateralFilter::~BilateralFilter() {}
 template <typename T, eBorderType B>
 void dispatch_bilateral_filter_border_mode(hipStream_t stream, const Tensor &input, const Tensor &output, int diameter,
                                            float sigmaColor, float sigmaSpace, T borderValue, eDeviceType device) {
-    auto inputWrapper = MakeBorderWrapper<B>(ImageWrapper<T>(input), borderValue);
-    ImageWrapper<T> outputWrapper(output);
+    auto inputWrapper = MakeBorderWrapper<B>(TensorWrapper<T>(input), borderValue);
+    TensorWrapper<T> outputWrapper(output);
 
     if (outputWrapper.channels() > 4 || outputWrapper.channels() < 1) {
         throw Exception("Invalid channel size: cannot be greater than 4 or less than 1.", eStatusType::OUT_OF_BOUNDS);
@@ -89,7 +89,7 @@ void dispatch_bilateral_filter_border_mode(hipStream_t stream, const Tensor &inp
         for (int j = 0; j < divisor; j++) {
             for (int i = 0; i < dividend; i++) {
                 threads.push_back(std::thread(
-                    Kernels::Host::bilateral_filter<T, decltype(inputWrapper), ImageWrapper<T>>, inputWrapper,
+                    Kernels::Host::bilateral_filter<T, decltype(inputWrapper), TensorWrapper<T>>, inputWrapper,
                     outputWrapper, radius, rollingHeight, rollingWidth, prevHeight, prevWidth, spaceCoeff, colorCoeff));
                 prevWidth = rollingWidth;
                 rollingWidth += factorW;

--- a/src/op_bilateral_filter.cpp
+++ b/src/op_bilateral_filter.cpp
@@ -43,7 +43,7 @@ BilateralFilter::~BilateralFilter() {}
 template <typename T, eBorderType B>
 void dispatch_bilateral_filter_border_mode(hipStream_t stream, const Tensor &input, const Tensor &output, int diameter,
                                            float sigmaColor, float sigmaSpace, T borderValue, eDeviceType device) {
-    BorderWrapper<T, B> inputWrapper(input, borderValue);
+    BorderWrapper<B, ImageWrapper<T>> inputWrapper(ImageWrapper<T>(input), borderValue);
     ImageWrapper<T> outputWrapper(output);
 
     if (outputWrapper.channels() > 4 || outputWrapper.channels() < 1) {
@@ -61,8 +61,7 @@ void dispatch_bilateral_filter_border_mode(hipStream_t stream, const Tensor &inp
         sigmaSpace = 1.0f;
     }
 
-    const int radius =
-        (diameter <= 0) ? static_cast<int>(std::roundf(sigmaSpace * 1.5f)) : (diameter >> 1);
+    const int radius = (diameter <= 0) ? static_cast<int>(std::roundf(sigmaSpace * 1.5f)) : (diameter >> 1);
 
     float spaceCoeff = -1 / (2 * sigmaSpace * sigmaSpace);
     float colorCoeff = -1 / (2 * sigmaColor * sigmaColor);
@@ -89,9 +88,10 @@ void dispatch_bilateral_filter_border_mode(hipStream_t stream, const Tensor &inp
 
         for (int j = 0; j < divisor; j++) {
             for (int i = 0; i < dividend; i++) {
-                threads.push_back(std::thread(Kernels::Host::bilateral_filter<T, BorderWrapper<T, B>, ImageWrapper<T>>,
-                                              inputWrapper, outputWrapper, radius, rollingHeight, rollingWidth,
-                                              prevHeight, prevWidth, spaceCoeff, colorCoeff));
+                threads.push_back(
+                    std::thread(Kernels::Host::bilateral_filter<T, BorderWrapper<B, ImageWrapper<T>>, ImageWrapper<T>>,
+                                inputWrapper, outputWrapper, radius, rollingHeight, rollingWidth, prevHeight, prevWidth,
+                                spaceCoeff, colorCoeff));
                 prevWidth = rollingWidth;
                 rollingWidth += factorW;
             }

--- a/src/op_bnd_box.cpp
+++ b/src/op_bnd_box.cpp
@@ -32,7 +32,7 @@ THE SOFTWARE.
 #include "common/validation_helpers.hpp"
 #include "core/detail/hip_utils.hpp"
 #include "core/tensor.hpp"
-#include "core/wrappers/image_wrapper.hpp"
+#include "core/wrappers/tensor_wrapper.hpp"
 #include "kernels/device/bnd_box_device.hpp"
 #include "kernels/host/bnd_box_host.hpp"
 
@@ -44,8 +44,8 @@ BndBox::~BndBox() {}
 template <bool has_alpha, typename T>
 void dispatch_bnd_box_dtype(hipStream_t stream, const Tensor &input, const Tensor &output,
                             std::shared_ptr<std::vector<Rect_t>> rects, eDeviceType device) {
-    ImageWrapper<T> inputWrapper(input);
-    ImageWrapper<T> outputWrapper(output);
+    TensorWrapper<T> inputWrapper(input);
+    TensorWrapper<T> outputWrapper(output);
 
     auto width = inputWrapper.width();
     auto height = inputWrapper.height();

--- a/src/op_brightness_contrast.cpp
+++ b/src/op_brightness_contrast.cpp
@@ -28,7 +28,7 @@ THE SOFTWARE.
 #include "common/validation_helpers.hpp"
 #include "core/detail/casting.hpp"
 #include "core/detail/type_traits.hpp"
-#include "core/wrappers/image_wrapper.hpp"
+#include "core/wrappers/tensor_wrapper.hpp"
 #include "kernels/device/brightness_contrast_device.hpp"
 #include "kernels/host/brightness_contrast_host.hpp"
 
@@ -88,8 +88,8 @@ void dispatch_brightness_contrast_channels(hipStream_t stream, const Tensor &inp
     using SRC_DT_NC = detail::MakeType<SRC_DT, NC>;
     using DST_DT_NC = detail::MakeType<DST_DT, NC>;
 
-    ImageWrapper<SRC_DT_NC> inputWrapper(input);
-    ImageWrapper<DST_DT_NC> outputWrapper(output);
+    TensorWrapper<SRC_DT_NC> inputWrapper(input);
+    TensorWrapper<DST_DT_NC> outputWrapper(output);
 
     // Launch CPU/GPU kernel depending on requested device type.
     switch (device) {

--- a/src/op_composite.cpp
+++ b/src/op_composite.cpp
@@ -24,7 +24,7 @@
 #include <functional>
 
 #include "common/validation_helpers.hpp"
-#include "core/wrappers/image_wrapper.hpp"
+#include "core/wrappers/tensor_wrapper.hpp"
 #include "kernels/device/composite_device.hpp"
 #include "kernels/host/composite_host.hpp"
 
@@ -33,10 +33,10 @@ namespace roccv {
 template <typename SrcType, typename DstType, typename MaskType>
 void dispatch_composite_masktype(hipStream_t stream, const Tensor& foreground, const Tensor& background,
                                  const Tensor& mask, const Tensor& output, eDeviceType device) {
-    ImageWrapper<SrcType> fgWrapper(foreground);
-    ImageWrapper<SrcType> bgWrapper(background);
-    ImageWrapper<MaskType> maskWrapper(mask);
-    ImageWrapper<DstType> outputWrapper(output);
+    TensorWrapper<SrcType> fgWrapper(foreground);
+    TensorWrapper<SrcType> bgWrapper(background);
+    TensorWrapper<MaskType> maskWrapper(mask);
+    TensorWrapper<DstType> outputWrapper(output);
 
     switch (device) {
         case eDeviceType::GPU: {

--- a/src/op_convert_to.cpp
+++ b/src/op_convert_to.cpp
@@ -24,7 +24,7 @@ THE SOFTWARE.
 #include <functional>
 
 #include <hip/hip_runtime.h>
-#include "core/wrappers/image_wrapper.hpp"
+#include "core/wrappers/tensor_wrapper.hpp"
 #include "common/validation_helpers.hpp"
 #include "core/detail/casting.hpp"
 #include "core/detail/type_traits.hpp"
@@ -40,8 +40,8 @@ void dispatch_convert_to_channels(hipStream_t stream, const Tensor &input, const
     using SRC_DT_NC = detail::MakeType<SRC_DT, NC>;
     using DST_DT_NC = detail::MakeType<DST_DT, NC>;
 
-    ImageWrapper<SRC_DT_NC> inputWrapper(input);
-    ImageWrapper<DST_DT_NC> outputWrapper(output);
+    TensorWrapper<SRC_DT_NC> inputWrapper(input);
+    TensorWrapper<DST_DT_NC> outputWrapper(output);
 
     using SRC_BT = detail::BaseType<SRC_DT>;
     using DST_BT = detail::BaseType<DST_DT>;

--- a/src/op_copy_make_border.cpp
+++ b/src/op_copy_make_border.cpp
@@ -38,7 +38,7 @@ namespace roccv {
 template <typename T, eBorderType BorderMode>
 void dispatch_copy_make_border_border_mode(hipStream_t stream, const Tensor& input, const Tensor& output, int32_t top,
                                            int32_t left, T border_value, eDeviceType device) {
-    BorderWrapper<BorderMode, ImageWrapper<T>> in_desc(ImageWrapper<T>(input), border_value);
+    auto in_desc = MakeBorderWrapper<BorderMode>(ImageWrapper<T>(input), border_value);
     ImageWrapper<T> out_desc(output);
 
     switch (device) {

--- a/src/op_copy_make_border.cpp
+++ b/src/op_copy_make_border.cpp
@@ -25,7 +25,7 @@
 
 #include "common/validation_helpers.hpp"
 #include "core/wrappers/border_wrapper.hpp"
-#include "core/wrappers/image_wrapper.hpp"
+#include "core/wrappers/tensor_wrapper.hpp"
 #include "core/wrappers/interpolation_wrapper.hpp"
 #include "kernels/device/copy_make_border_device.hpp"
 #include "kernels/host/copy_make_border_host.hpp"
@@ -38,8 +38,8 @@ namespace roccv {
 template <typename T, eBorderType BorderMode>
 void dispatch_copy_make_border_border_mode(hipStream_t stream, const Tensor& input, const Tensor& output, int32_t top,
                                            int32_t left, T border_value, eDeviceType device) {
-    auto in_desc = MakeBorderWrapper<BorderMode>(ImageWrapper<T>(input), border_value);
-    ImageWrapper<T> out_desc(output);
+    auto in_desc = MakeBorderWrapper<BorderMode>(TensorWrapper<T>(input), border_value);
+    TensorWrapper<T> out_desc(output);
 
     switch (device) {
         case eDeviceType::GPU: {

--- a/src/op_copy_make_border.cpp
+++ b/src/op_copy_make_border.cpp
@@ -38,7 +38,7 @@ namespace roccv {
 template <typename T, eBorderType BorderMode>
 void dispatch_copy_make_border_border_mode(hipStream_t stream, const Tensor& input, const Tensor& output, int32_t top,
                                            int32_t left, T border_value, eDeviceType device) {
-    BorderWrapper<T, BorderMode> in_desc(input, border_value);
+    BorderWrapper<BorderMode, ImageWrapper<T>> in_desc(ImageWrapper<T>(input), border_value);
     ImageWrapper<T> out_desc(output);
 
     switch (device) {
@@ -83,8 +83,7 @@ void dispatch_copy_make_border(hipStream_t stream, const Tensor& input, const Te
 }
 
 void CopyMakeBorder::operator()(hipStream_t stream, const Tensor& input, const Tensor& output, int32_t top,
-                                int32_t left, eBorderType border_mode, float4 border_value,
-                                eDeviceType device) const {
+                                int32_t left, eBorderType border_mode, float4 border_value, eDeviceType device) const {
     CHECK_TENSOR_DEVICE(input, device);
     CHECK_TENSOR_LAYOUT(input, eTensorLayout::TENSOR_LAYOUT_NHWC, eTensorLayout::TENSOR_LAYOUT_HWC);
     CHECK_TENSOR_DATATYPES(input, eDataType::DATA_TYPE_U8, eDataType::DATA_TYPE_S8, eDataType::DATA_TYPE_U16,

--- a/src/op_custom_crop.cpp
+++ b/src/op_custom_crop.cpp
@@ -26,7 +26,7 @@ THE SOFTWARE.
 #include <functional>
 
 #include "common/validation_helpers.hpp"
-#include "core/wrappers/image_wrapper.hpp"
+#include "core/wrappers/tensor_wrapper.hpp"
 #include "kernels/device/custom_crop_device.hpp"
 #include "kernels/host/custom_crop_host.hpp"
 
@@ -35,8 +35,8 @@ namespace roccv {
 template <typename T>
 void dispatch_custom_crop_dtype(hipStream_t stream, const Tensor& input, const Tensor& output, Box_t cropRect,
                                 eDeviceType device) {
-    ImageWrapper<T> inputWrapper(input);
-    ImageWrapper<T> outputWrapper(output);
+    TensorWrapper<T> inputWrapper(input);
+    TensorWrapper<T> outputWrapper(output);
 
     switch (device) {
         case eDeviceType::GPU: {

--- a/src/op_cvt_color.cpp
+++ b/src/op_cvt_color.cpp
@@ -27,7 +27,7 @@ THE SOFTWARE.
 
 #include "common/validation_helpers.hpp"
 #include "core/tensor.hpp"
-#include "core/wrappers/image_wrapper.hpp"
+#include "core/wrappers/tensor_wrapper.hpp"
 #include "kernels/device/cvt_color_device.hpp"
 #include "kernels/host/cvt_color_host.hpp"
 
@@ -87,38 +87,38 @@ void CvtColor::operator()(hipStream_t stream, const Tensor &input, Tensor &outpu
         switch (conversionCode) {
             case eColorConversionCode::COLOR_BGR2GRAY:
                 Kernels::Device::rgb_or_bgr_to_grayscale<uchar3, eSwizzle::ZYXW>
-                    <<<gridSize, blockSize, 0, stream>>>(ImageWrapper<uchar3>(input), ImageWrapper<uchar1>(output));
+                    <<<gridSize, blockSize, 0, stream>>>(TensorWrapper<uchar3>(input), TensorWrapper<uchar1>(output));
                 break;
 
             case eColorConversionCode::COLOR_RGB2GRAY:
                 Kernels::Device::rgb_or_bgr_to_grayscale<uchar3, eSwizzle::XYZW>
-                    <<<gridSize, blockSize, 0, stream>>>(ImageWrapper<uchar3>(input), ImageWrapper<uchar1>(output));
+                    <<<gridSize, blockSize, 0, stream>>>(TensorWrapper<uchar3>(input), TensorWrapper<uchar1>(output));
                 break;
 
             case eColorConversionCode::COLOR_BGR2RGB:
             case eColorConversionCode::COLOR_RGB2BGR:
                 Kernels::Device::reorder<uchar3, eSwizzle::ZYXW>
-                    <<<gridSize, blockSize, 0, stream>>>(ImageWrapper<uchar3>(input), ImageWrapper<uchar3>(output));
+                    <<<gridSize, blockSize, 0, stream>>>(TensorWrapper<uchar3>(input), TensorWrapper<uchar3>(output));
                 break;
 
             case eColorConversionCode::COLOR_BGR2YUV:
                 Kernels::Device::rgb_or_bgr_to_yuv<uchar3, eSwizzle::ZYXW><<<gridSize, blockSize, 0, stream>>>(
-                    ImageWrapper<uchar3>(input), ImageWrapper<uchar3>(output), 128.0f);
+                    TensorWrapper<uchar3>(input), TensorWrapper<uchar3>(output), 128.0f);
                 break;
 
             case eColorConversionCode::COLOR_RGB2YUV:
                 Kernels::Device::rgb_or_bgr_to_yuv<uchar3, eSwizzle::XYZW><<<gridSize, blockSize, 0, stream>>>(
-                    ImageWrapper<uchar3>(input), ImageWrapper<uchar3>(output), 128.0f);
+                    TensorWrapper<uchar3>(input), TensorWrapper<uchar3>(output), 128.0f);
                 break;
 
             case eColorConversionCode::COLOR_YUV2BGR:
                 Kernels::Device::yuv_to_rgb_or_bgr<uchar3, eSwizzle::ZYXW><<<gridSize, blockSize, 0, stream>>>(
-                    ImageWrapper<uchar3>(input), ImageWrapper<uchar3>(output), 128.0f);
+                    TensorWrapper<uchar3>(input), TensorWrapper<uchar3>(output), 128.0f);
                 break;
 
             case eColorConversionCode::COLOR_YUV2RGB:
                 Kernels::Device::yuv_to_rgb_or_bgr<uchar3, eSwizzle::XYZW><<<gridSize, blockSize, 0, stream>>>(
-                    ImageWrapper<uchar3>(input), ImageWrapper<uchar3>(output), 128.0f);
+                    TensorWrapper<uchar3>(input), TensorWrapper<uchar3>(output), 128.0f);
                 break;
 
             default:
@@ -129,39 +129,39 @@ void CvtColor::operator()(hipStream_t stream, const Tensor &input, Tensor &outpu
 
         switch (conversionCode) {
             case eColorConversionCode::COLOR_BGR2GRAY:
-                Kernels::Host::rgb_or_bgr_to_grayscale<uchar3, eSwizzle::ZYXW>(ImageWrapper<uchar3>(input),
-                                                                               ImageWrapper<uchar1>(output));
+                Kernels::Host::rgb_or_bgr_to_grayscale<uchar3, eSwizzle::ZYXW>(TensorWrapper<uchar3>(input),
+                                                                               TensorWrapper<uchar1>(output));
                 break;
 
             case eColorConversionCode::COLOR_RGB2GRAY:
-                Kernels::Host::rgb_or_bgr_to_grayscale<uchar3, eSwizzle::XYZW>(ImageWrapper<uchar3>(input),
-                                                                               ImageWrapper<uchar1>(output));
+                Kernels::Host::rgb_or_bgr_to_grayscale<uchar3, eSwizzle::XYZW>(TensorWrapper<uchar3>(input),
+                                                                               TensorWrapper<uchar1>(output));
                 break;
 
             case eColorConversionCode::COLOR_BGR2RGB:
             case eColorConversionCode::COLOR_RGB2BGR:
-                Kernels::Host::reorder<uchar3, eSwizzle::ZYXW>(ImageWrapper<uchar3>(input),
-                                                               ImageWrapper<uchar3>(output));
+                Kernels::Host::reorder<uchar3, eSwizzle::ZYXW>(TensorWrapper<uchar3>(input),
+                                                               TensorWrapper<uchar3>(output));
                 break;
 
             case eColorConversionCode::COLOR_BGR2YUV:
-                Kernels::Host::rgb_or_bgr_to_yuv<uchar3, eSwizzle::ZYXW>(ImageWrapper<uchar3>(input),
-                                                                         ImageWrapper<uchar3>(output), 128.0f);
+                Kernels::Host::rgb_or_bgr_to_yuv<uchar3, eSwizzle::ZYXW>(TensorWrapper<uchar3>(input),
+                                                                         TensorWrapper<uchar3>(output), 128.0f);
                 break;
 
             case eColorConversionCode::COLOR_RGB2YUV:
-                Kernels::Host::rgb_or_bgr_to_yuv<uchar3, eSwizzle::XYZW>(ImageWrapper<uchar3>(input),
-                                                                         ImageWrapper<uchar3>(output), 128.0f);
+                Kernels::Host::rgb_or_bgr_to_yuv<uchar3, eSwizzle::XYZW>(TensorWrapper<uchar3>(input),
+                                                                         TensorWrapper<uchar3>(output), 128.0f);
                 break;
 
             case eColorConversionCode::COLOR_YUV2BGR:
-                Kernels::Host::yuv_to_rgb_or_bgr<uchar3, eSwizzle::ZYXW>(ImageWrapper<uchar3>(input),
-                                                                         ImageWrapper<uchar3>(output), 128.0f);
+                Kernels::Host::yuv_to_rgb_or_bgr<uchar3, eSwizzle::ZYXW>(TensorWrapper<uchar3>(input),
+                                                                         TensorWrapper<uchar3>(output), 128.0f);
                 break;
 
             case eColorConversionCode::COLOR_YUV2RGB:
-                Kernels::Host::yuv_to_rgb_or_bgr<uchar3, eSwizzle::XYZW>(ImageWrapper<uchar3>(input),
-                                                                         ImageWrapper<uchar3>(output), 128.0f);
+                Kernels::Host::yuv_to_rgb_or_bgr<uchar3, eSwizzle::XYZW>(TensorWrapper<uchar3>(input),
+                                                                         TensorWrapper<uchar3>(output), 128.0f);
                 break;
 
             default:

--- a/src/op_flip.cpp
+++ b/src/op_flip.cpp
@@ -29,7 +29,7 @@ THE SOFTWARE.
 #include "common/validation_helpers.hpp"
 #include "core/exception.hpp"
 #include "core/status_type.h"
-#include "core/wrappers/image_wrapper.hpp"
+#include "core/wrappers/tensor_wrapper.hpp"
 #include "kernels/device/flip_device.hpp"
 #include "kernels/host/flip_host.hpp"
 
@@ -37,8 +37,8 @@ namespace roccv {
 
 template <typename T, eAxis FlipType>
 void dispatch_flip_axis(hipStream_t stream, const Tensor& input, const Tensor& output, eDeviceType device) {
-    ImageWrapper<T> inputWrapper(input);
-    ImageWrapper<T> outputWrapper(output);
+    TensorWrapper<T> inputWrapper(input);
+    TensorWrapper<T> outputWrapper(output);
 
     switch (device) {
         case eDeviceType::GPU: {

--- a/src/op_gamma_contrast.cpp
+++ b/src/op_gamma_contrast.cpp
@@ -34,7 +34,7 @@ THE SOFTWARE.
 #include "common/math_vector.hpp"
 #include "common/validation_helpers.hpp"
 #include "core/tensor.hpp"
-#include "core/wrappers/image_wrapper.hpp"
+#include "core/wrappers/tensor_wrapper.hpp"
 #include "kernels/device/gamma_contrast_device.hpp"
 #include "kernels/host/gamma_contrast_host.hpp"
 
@@ -43,8 +43,8 @@ namespace roccv {
 template <typename T>
 void dispatch_gamma_contrast_dtype(hipStream_t stream, const Tensor &input, const Tensor &output, float gamma,
                                    eDeviceType device) {
-    ImageWrapper<T> inputWrapper(input);
-    ImageWrapper<T> outputWrapper(output);
+    TensorWrapper<T> inputWrapper(input);
+    TensorWrapper<T> outputWrapper(output);
 
     if (device == eDeviceType::GPU) {
         dim3 block(64, 16);

--- a/src/op_histogram.cpp
+++ b/src/op_histogram.cpp
@@ -31,7 +31,7 @@ THE SOFTWARE.
 #include "common/array_wrapper.hpp"
 #include "common/validation_helpers.hpp"
 #include "core/wrappers/generic_tensor_wrapper.hpp"
-#include "core/wrappers/image_wrapper.hpp"
+#include "core/wrappers/tensor_wrapper.hpp"
 #include "kernels/device/histogram_device.hpp"
 #include "kernels/host/histogram_host.hpp"
 
@@ -44,7 +44,7 @@ template <typename T>
 void dispatch_histogram_dtype(hipStream_t stream, const Tensor& input,
                               std::optional<std::reference_wrapper<const Tensor>> mask, const Tensor& histogram,
                               eDeviceType device) {
-    ImageWrapper<uchar1> inputWrapper(input);
+    TensorWrapper<uchar1> inputWrapper(input);
 
     const auto o_height = histogram.shape()[histogram.shape().layout().height_index()];
     const auto o_width = histogram.shape()[histogram.shape().layout().width_index()];
@@ -91,7 +91,7 @@ void dispatch_histogram_dtype(hipStream_t stream, const Tensor& input,
                 std::reference_wrapper<const Tensor> mask_ref = mask.value();
                 const Tensor& actual_mask = mask_ref.get();
                 CHECK_TENSOR_COMPARISON(input.shape() == actual_mask.shape());
-                ImageWrapper<uchar1> maskWrapper(actual_mask);
+                TensorWrapper<uchar1> maskWrapper(actual_mask);
                 Kernels::Device::histogram_kernel<T><<<grid_size, threads_block, shared_mem_size, stream>>>(
                     inputWrapper, maskWrapper, GenericTensorWrapper<T>(histogram));
             } else {
@@ -115,7 +115,7 @@ void dispatch_histogram_dtype(hipStream_t stream, const Tensor& input,
                 std::reference_wrapper<const Tensor> mask_ref = mask.value();
                 const Tensor& actual_mask = mask_ref.get();
                 CHECK_TENSOR_COMPARISON(input.shape() == actual_mask.shape());
-                ImageWrapper<uchar1> maskWrapper(actual_mask);
+                TensorWrapper<uchar1> maskWrapper(actual_mask);
                 Kernels::Host::histogram_kernel(inputWrapper, maskWrapper, GenericTensorWrapper<T>(histogram));
             } else {
                 Kernels::Host::histogram_kernel(inputWrapper, GenericTensorWrapper<T>(histogram));

--- a/src/op_normalize.cpp
+++ b/src/op_normalize.cpp
@@ -28,7 +28,7 @@ THE SOFTWARE.
 #include "common/validation_helpers.hpp"
 #include "core/detail/type_traits.hpp"
 #include "core/tensor.hpp"
-#include "core/wrappers/image_wrapper.hpp"
+#include "core/wrappers/tensor_wrapper.hpp"
 #include "kernels/device/normalize_device.hpp"
 #include "kernels/host/normalize_host.hpp"
 
@@ -42,10 +42,10 @@ void dispatch_normalize_stddev(hipStream_t stream, const Tensor& input, const Te
     // tensors.
     using work_type = detail::MakeType<float, detail::NumComponents<T>>;
 
-    ImageWrapper<T> inputWrap(input);
-    ImageWrapper<T> outputWrap(output);
-    ImageWrapper<work_type> scaleWrap(scale);
-    ImageWrapper<work_type> baseWrap(base);
+    TensorWrapper<T> inputWrap(input);
+    TensorWrapper<T> outputWrap(output);
+    TensorWrapper<work_type> scaleWrap(scale);
+    TensorWrapper<work_type> baseWrap(base);
 
     switch (device) {
         case eDeviceType::GPU: {

--- a/src/op_reformat.cpp
+++ b/src/op_reformat.cpp
@@ -26,7 +26,7 @@ THE SOFTWARE.
 #include <unordered_map>
 
 #include "common/validation_helpers.hpp"
-#include "core/wrappers/image_wrapper.hpp"
+#include "core/wrappers/tensor_wrapper.hpp"
 #include "kernels/device/reformat_device.hpp"
 #include "kernels/host/reformat_host.hpp"
 
@@ -35,8 +35,8 @@ namespace roccv {
 namespace {
 template <int Channels, typename T>
 void DispatchReformatChannels(hipStream_t stream, const Tensor& input, const Tensor& output, eDeviceType device) {
-    ImageWrapper<T> inputWrap(input);
-    ImageWrapper<T> outputWrap(output);
+    TensorWrapper<T> inputWrap(input);
+    TensorWrapper<T> outputWrap(output);
 
     switch (device) {
         case eDeviceType::GPU: {

--- a/src/op_remap.cpp
+++ b/src/op_remap.cpp
@@ -77,10 +77,9 @@ void dispatch_remap_mapInterp(hipStream_t stream, const Tensor &input, const Ten
                               const eRemapType mapValueType, const bool alignCorners, const T borderValue,
                               const eDeviceType device) {
     ImageWrapper<T> outputWrapper(output);
-    InterpolationWrapper<B, M, ImageWrapper<float2>> wrappedMapTensor(
-        BorderWrapper<B, ImageWrapper<float2>>(ImageWrapper<float2>(map), make_float2(0, 0)));
-    InterpolationWrapper<B, I, ImageWrapper<T>> inputWrapper(
-        BorderWrapper<B, ImageWrapper<T>>(ImageWrapper<T>(input), borderValue));
+    auto wrappedMapTensor =
+        MakeInterpolationWrapper<M>(MakeBorderWrapper<B>(ImageWrapper<float2>(map), make_float2(0, 0)));
+    auto inputWrapper = MakeInterpolationWrapper<I>(MakeBorderWrapper<B>(ImageWrapper<T>(input), borderValue));
 
     int mapBatchSize = wrappedMapTensor.batches();
 

--- a/src/op_remap.cpp
+++ b/src/op_remap.cpp
@@ -77,8 +77,10 @@ void dispatch_remap_mapInterp(hipStream_t stream, const Tensor &input, const Ten
                               const eRemapType mapValueType, const bool alignCorners, const T borderValue,
                               const eDeviceType device) {
     ImageWrapper<T> outputWrapper(output);
-    InterpolationWrapper<float2, B, M> wrappedMapTensor(map, make_float2(0, 0));
-    InterpolationWrapper<T, B, I> inputWrapper(input, borderValue);
+    InterpolationWrapper<B, M, ImageWrapper<float2>> wrappedMapTensor(
+        BorderWrapper<B, ImageWrapper<float2>>(ImageWrapper<float2>(map), make_float2(0, 0)));
+    InterpolationWrapper<B, I, ImageWrapper<T>> inputWrapper(
+        BorderWrapper<B, ImageWrapper<T>>(ImageWrapper<T>(input), borderValue));
 
     int mapBatchSize = wrappedMapTensor.batches();
 

--- a/src/op_remap.cpp
+++ b/src/op_remap.cpp
@@ -29,7 +29,7 @@ THE SOFTWARE.
 #include "core/detail/internal_structs.hpp"
 #include "core/detail/math/math.hpp"
 #include "core/detail/type_traits.hpp"
-#include "core/wrappers/image_wrapper.hpp"
+#include "core/wrappers/tensor_wrapper.hpp"
 #include "core/wrappers/interpolation_wrapper.hpp"
 #include "kernels/device/remap_device.hpp"
 #include "kernels/host/remap_host.hpp"
@@ -76,10 +76,10 @@ template <typename T, eBorderType B, eInterpolationType I, eInterpolationType M>
 void dispatch_remap_mapInterp(hipStream_t stream, const Tensor &input, const Tensor &output, const Tensor &map,
                               const eRemapType mapValueType, const bool alignCorners, const T borderValue,
                               const eDeviceType device) {
-    ImageWrapper<T> outputWrapper(output);
+    TensorWrapper<T> outputWrapper(output);
     auto wrappedMapTensor =
-        MakeInterpolationWrapper<M>(MakeBorderWrapper<B>(ImageWrapper<float2>(map), make_float2(0, 0)));
-    auto inputWrapper = MakeInterpolationWrapper<I>(MakeBorderWrapper<B>(ImageWrapper<T>(input), borderValue));
+        MakeInterpolationWrapper<M>(MakeBorderWrapper<B>(TensorWrapper<float2>(map), make_float2(0, 0)));
+    auto inputWrapper = MakeInterpolationWrapper<I>(MakeBorderWrapper<B>(TensorWrapper<T>(input), borderValue));
 
     int mapBatchSize = wrappedMapTensor.batches();
 

--- a/src/op_resize.cpp
+++ b/src/op_resize.cpp
@@ -36,10 +36,10 @@ namespace roccv {
 
 template <typename T, eInterpolationType I>
 void dispatch_resize_interp(hipStream_t stream, const Tensor& input, const Tensor& output, eDeviceType device) {
-    ImageWrapper<T> outputWrapper(output);
+    TensorWrapper<T> outputWrapper(output);
     // Resize operation should clamp values at the border (REPLICATE border mode)
     auto inputWrapper =
-        MakeInterpolationWrapper<I>(MakeBorderWrapper<eBorderType::BORDER_TYPE_REPLICATE>(ImageWrapper<T>(input), T{}));
+        MakeInterpolationWrapper<I>(MakeBorderWrapper<eBorderType::BORDER_TYPE_REPLICATE>(TensorWrapper<T>(input), T{}));
 
     float scaleX = inputWrapper.width() / static_cast<float>(outputWrapper.width());
     float scaleY = inputWrapper.height() / static_cast<float>(outputWrapper.height());

--- a/src/op_resize.cpp
+++ b/src/op_resize.cpp
@@ -38,8 +38,8 @@ template <typename T, eInterpolationType I>
 void dispatch_resize_interp(hipStream_t stream, const Tensor& input, const Tensor& output, eDeviceType device) {
     ImageWrapper<T> outputWrapper(output);
     // Resize operation should clamp values at the border (REPLICATE border mode)
-    InterpolationWrapper<eBorderType::BORDER_TYPE_REPLICATE, I, ImageWrapper<T>> inputWrapper(
-        BorderWrapper<eBorderType::BORDER_TYPE_REPLICATE, ImageWrapper<T>>(ImageWrapper<T>(input), T{}));
+    auto inputWrapper =
+        MakeInterpolationWrapper<I>(MakeBorderWrapper<eBorderType::BORDER_TYPE_REPLICATE>(ImageWrapper<T>(input), T{}));
 
     float scaleX = inputWrapper.width() / static_cast<float>(outputWrapper.width());
     float scaleY = inputWrapper.height() / static_cast<float>(outputWrapper.height());

--- a/src/op_resize.cpp
+++ b/src/op_resize.cpp
@@ -38,7 +38,8 @@ template <typename T, eInterpolationType I>
 void dispatch_resize_interp(hipStream_t stream, const Tensor& input, const Tensor& output, eDeviceType device) {
     ImageWrapper<T> outputWrapper(output);
     // Resize operation should clamp values at the border (REPLICATE border mode)
-    InterpolationWrapper<T, eBorderType::BORDER_TYPE_REPLICATE, I> inputWrapper(input, T{});
+    InterpolationWrapper<eBorderType::BORDER_TYPE_REPLICATE, I, ImageWrapper<T>> inputWrapper(
+        BorderWrapper<eBorderType::BORDER_TYPE_REPLICATE, ImageWrapper<T>>(ImageWrapper<T>(input), T{}));
 
     float scaleX = inputWrapper.width() / static_cast<float>(outputWrapper.width());
     float scaleY = inputWrapper.height() / static_cast<float>(outputWrapper.height());
@@ -62,13 +63,13 @@ void dispatch_resize_interp(hipStream_t stream, const Tensor& input, const Tenso
 template <typename T>
 void dispatch_resize_dtype(hipStream_t stream, const Tensor& input, const Tensor& output,
                            eInterpolationType interpolation, eDeviceType device) {
-    static const std::unordered_map<
-        eInterpolationType,
-        std::function<void(hipStream_t stream, const Tensor& input, const Tensor& output, eDeviceType device)>>
-        funcs = {{eInterpolationType::INTERP_TYPE_NEAREST, dispatch_resize_interp<T, eInterpolationType::INTERP_TYPE_NEAREST>},
-                 {eInterpolationType::INTERP_TYPE_LINEAR, dispatch_resize_interp<T, eInterpolationType::INTERP_TYPE_LINEAR>},
-                 {eInterpolationType::INTERP_TYPE_CUBIC, dispatch_resize_interp<T, eInterpolationType::INTERP_TYPE_CUBIC>}
-                };
+    static const std::unordered_map<eInterpolationType, std::function<void(hipStream_t stream, const Tensor& input,
+                                                                           const Tensor& output, eDeviceType device)>>
+        funcs = {
+            {eInterpolationType::INTERP_TYPE_NEAREST,
+             dispatch_resize_interp<T, eInterpolationType::INTERP_TYPE_NEAREST>},
+            {eInterpolationType::INTERP_TYPE_LINEAR, dispatch_resize_interp<T, eInterpolationType::INTERP_TYPE_LINEAR>},
+            {eInterpolationType::INTERP_TYPE_CUBIC, dispatch_resize_interp<T, eInterpolationType::INTERP_TYPE_CUBIC>}};
 
     if (!funcs.contains(interpolation)) {
         throw Exception("Operation does not support the given interpolation mode.", eStatusType::NOT_IMPLEMENTED);
@@ -78,8 +79,8 @@ void dispatch_resize_dtype(hipStream_t stream, const Tensor& input, const Tensor
     func(stream, input, output, device);
 }
 
-void Resize::operator()(hipStream_t stream, const Tensor& input, const Tensor& output,
-                        eInterpolationType interpolation, eDeviceType device) const {
+void Resize::operator()(hipStream_t stream, const Tensor& input, const Tensor& output, eInterpolationType interpolation,
+                        eDeviceType device) const {
     CHECK_TENSOR_DEVICE(input, device);
     CHECK_TENSOR_DEVICE(output, device);
 

--- a/src/op_rotate.cpp
+++ b/src/op_rotate.cpp
@@ -55,7 +55,8 @@ void dispatch_rotate_interp(hipStream_t stream, const Tensor &input, const Tenso
     T borderVal = detail::SaturateCast<T>(make_float4(0.0f, 0.0f, 0.0f, 0.0f));
 
     ImageWrapper<T> outputWrap(output);
-    InterpolationWrapper<T, eBorderType::BORDER_TYPE_CONSTANT, InterpType> inputWrap(input, borderVal);
+    InterpolationWrapper<eBorderType::BORDER_TYPE_CONSTANT, InterpType, ImageWrapper<T>> inputWrap(
+        BorderWrapper<eBorderType::BORDER_TYPE_CONSTANT, ImageWrapper<T>>(ImageWrapper<T>(input), borderVal));
 
     switch (device) {
         case eDeviceType::GPU: {
@@ -74,8 +75,8 @@ void dispatch_rotate_interp(hipStream_t stream, const Tensor &input, const Tenso
 }
 
 template <typename T>
-void dispatch_rotate_type(hipStream_t stream, const Tensor &input, const Tensor &output, double angleDeg,
-                          double2 shift, eInterpolationType interpolation, eDeviceType device) {
+void dispatch_rotate_type(hipStream_t stream, const Tensor &input, const Tensor &output, double angleDeg, double2 shift,
+                          eInterpolationType interpolation, eDeviceType device) {
     // clang-format off
     static const std::unordered_map<eInterpolationType,
                                     std::function<void(hipStream_t, const Tensor &, const Tensor &, double,
@@ -94,8 +95,8 @@ void dispatch_rotate_type(hipStream_t stream, const Tensor &input, const Tensor 
     func(stream, input, output, angleDeg, shift, device);
 }
 
-void Rotate::operator()(hipStream_t stream, const Tensor &input, const Tensor &output, double angleDeg,
-                        double2 shift, eInterpolationType interpolation, eDeviceType device) const {
+void Rotate::operator()(hipStream_t stream, const Tensor &input, const Tensor &output, double angleDeg, double2 shift,
+                        eInterpolationType interpolation, eDeviceType device) const {
     CHECK_TENSOR_DEVICE(input, device);
     CHECK_TENSOR_CHANNELS(input, 1, 3, 4);
     CHECK_TENSOR_DATATYPES(input, eDataType::DATA_TYPE_U8, eDataType::DATA_TYPE_S8, eDataType::DATA_TYPE_U16,

--- a/src/op_rotate.cpp
+++ b/src/op_rotate.cpp
@@ -54,9 +54,9 @@ void dispatch_rotate_interp(hipStream_t stream, const Tensor &input, const Tenso
 
     T borderVal = detail::SaturateCast<T>(make_float4(0.0f, 0.0f, 0.0f, 0.0f));
 
-    ImageWrapper<T> outputWrap(output);
+    TensorWrapper<T> outputWrap(output);
     auto inputWrap = MakeInterpolationWrapper<InterpType>(
-        MakeBorderWrapper<eBorderType::BORDER_TYPE_CONSTANT>(ImageWrapper<T>(input), borderVal));
+        MakeBorderWrapper<eBorderType::BORDER_TYPE_CONSTANT>(TensorWrapper<T>(input), borderVal));
 
     switch (device) {
         case eDeviceType::GPU: {

--- a/src/op_rotate.cpp
+++ b/src/op_rotate.cpp
@@ -55,8 +55,8 @@ void dispatch_rotate_interp(hipStream_t stream, const Tensor &input, const Tenso
     T borderVal = detail::SaturateCast<T>(make_float4(0.0f, 0.0f, 0.0f, 0.0f));
 
     ImageWrapper<T> outputWrap(output);
-    InterpolationWrapper<eBorderType::BORDER_TYPE_CONSTANT, InterpType, ImageWrapper<T>> inputWrap(
-        BorderWrapper<eBorderType::BORDER_TYPE_CONSTANT, ImageWrapper<T>>(ImageWrapper<T>(input), borderVal));
+    auto inputWrap = MakeInterpolationWrapper<InterpType>(
+        MakeBorderWrapper<eBorderType::BORDER_TYPE_CONSTANT>(ImageWrapper<T>(input), borderVal));
 
     switch (device) {
         case eDeviceType::GPU: {

--- a/src/op_thresholding.cpp
+++ b/src/op_thresholding.cpp
@@ -27,7 +27,7 @@ THE SOFTWARE.
 
 #include "common/validation_helpers.hpp"
 #include "core/wrappers/generic_tensor_wrapper.hpp"
-#include "core/wrappers/image_wrapper.hpp"
+#include "core/wrappers/tensor_wrapper.hpp"
 #include "kernels/device/thresholding_device.hpp"
 #include "kernels/host/thresholding_host.hpp"
 
@@ -43,8 +43,8 @@ Threshold::~Threshold() {}
 template <typename T>
 void dispatch_threshold_dtype(hipStream_t stream, const Tensor &input, const Tensor &output, const Tensor &thresh,
                               const Tensor &maxVal, eThresholdType m_threshType, eDeviceType device) {
-    ImageWrapper<T> inputWrapper(input);
-    ImageWrapper<T> outputWrapper(output);
+    TensorWrapper<T> inputWrapper(input);
+    TensorWrapper<T> outputWrapper(output);
 
     const auto height = input.shape()[input.shape().layout().height_index()];
     const auto width = input.shape()[input.shape().layout().width_index()];

--- a/src/op_warp_affine.cpp
+++ b/src/op_warp_affine.cpp
@@ -35,8 +35,8 @@ template <typename T, eBorderType B, eInterpolationType I>
 void dispatch_warp_affine_interp(hipStream_t stream, const Tensor &input, const Tensor &output,
                                  const AffineTransform affineInv, T borderValue, eDeviceType device) {
     ArrayWrapper<float, 6> transform(affineInv);
-    ImageWrapper<T> outputWrapper(output);
-    InterpolationWrapper<T, B, I> inputWrapper(input, borderValue);
+    TensorWrapper<T> outputWrapper(output);
+    auto inputWrapper = MakeInterpolationWrapper<I>(MakeBorderWrapper<B>(TensorWrapper<T>(input), borderValue));
 
     switch (device) {
         case eDeviceType::GPU: {

--- a/src/op_warp_perspective.cpp
+++ b/src/op_warp_perspective.cpp
@@ -37,7 +37,8 @@ void dispatch_warp_perspective_interp(hipStream_t stream, const Tensor &input, c
                                       const PerspectiveTransform transMatrix, T borderValue, eDeviceType device) {
     ArrayWrapper<float, 9> transform(transMatrix);
     ImageWrapper<T> outputWrapper(output);
-    InterpolationWrapper<T, B, I> inputWrapper(input, borderValue);
+    InterpolationWrapper<B, I, ImageWrapper<T>> inputWrapper(
+        BorderWrapper<B, ImageWrapper<T>>(ImageWrapper<T>(input), borderValue));
 
     // Launch CPU/GPU kernel depending on requested device type.
     switch (device) {

--- a/src/op_warp_perspective.cpp
+++ b/src/op_warp_perspective.cpp
@@ -37,8 +37,7 @@ void dispatch_warp_perspective_interp(hipStream_t stream, const Tensor &input, c
                                       const PerspectiveTransform transMatrix, T borderValue, eDeviceType device) {
     ArrayWrapper<float, 9> transform(transMatrix);
     ImageWrapper<T> outputWrapper(output);
-    InterpolationWrapper<B, I, ImageWrapper<T>> inputWrapper(
-        BorderWrapper<B, ImageWrapper<T>>(ImageWrapper<T>(input), borderValue));
+    auto inputWrapper = MakeInterpolationWrapper<I>(MakeBorderWrapper<B>(ImageWrapper<T>(input), borderValue));
 
     // Launch CPU/GPU kernel depending on requested device type.
     switch (device) {

--- a/src/op_warp_perspective.cpp
+++ b/src/op_warp_perspective.cpp
@@ -36,8 +36,8 @@ template <typename T, eBorderType B, eInterpolationType I>
 void dispatch_warp_perspective_interp(hipStream_t stream, const Tensor &input, const Tensor &output,
                                       const PerspectiveTransform transMatrix, T borderValue, eDeviceType device) {
     ArrayWrapper<float, 9> transform(transMatrix);
-    ImageWrapper<T> outputWrapper(output);
-    auto inputWrapper = MakeInterpolationWrapper<I>(MakeBorderWrapper<B>(ImageWrapper<T>(input), borderValue));
+    TensorWrapper<T> outputWrapper(output);
+    auto inputWrapper = MakeInterpolationWrapper<I>(MakeBorderWrapper<B>(TensorWrapper<T>(input), borderValue));
 
     // Launch CPU/GPU kernel depending on requested device type.
     switch (device) {

--- a/tests/roccv/cpp/src/tests/core/wrappers/test_border_wrapper.cpp
+++ b/tests/roccv/cpp/src/tests/core/wrappers/test_border_wrapper.cpp
@@ -161,8 +161,8 @@ void TestCorrectness(float4 borderValue, int32_t batchSize, Size2D imageSize, in
     FillVector(inputData);
 
     // BorderWrapper to calculate the actual calculated values.
-    BorderWrapper<BorderType, ImageWrapper<T>> borderWrap(
-        ImageWrapper<T>(inputData, batchSize, imageSize.w, imageSize.h), borderVal);
+    auto borderWrap =
+        MakeBorderWrapper<BorderType>(ImageWrapper<T>(inputData, batchSize, imageSize.w, imageSize.h), borderVal);
     std::vector<BT> actualOutput(numElementsWithBorder);
     int actualIndex = 0;
     for (int batch = 0; batch < batchSize; ++batch) {

--- a/tests/roccv/cpp/src/tests/core/wrappers/test_border_wrapper.cpp
+++ b/tests/roccv/cpp/src/tests/core/wrappers/test_border_wrapper.cpp
@@ -115,8 +115,8 @@ int64_t GetCoordOfBorderPel(int64_t u, int64_t dimSize, eBorderType borderMode) 
  * coordinates fall out of bounds.
  */
 template <typename T, typename BT = detail::BaseType<T>>
-BT GoldenBorderAt(ImageWrapper<T>& input, eBorderType borderMode, T borderValue, int64_t sample, int64_t y,
-                  int64_t x, int64_t channel) {
+BT GoldenBorderAt(ImageWrapper<T>& input, eBorderType borderMode, T borderValue, int64_t sample, int64_t y, int64_t x,
+                  int64_t channel) {
     int64_t outX = x, outY = y;
 
     if (borderMode == eBorderType::BORDER_TYPE_CONSTANT) {
@@ -161,7 +161,8 @@ void TestCorrectness(float4 borderValue, int32_t batchSize, Size2D imageSize, in
     FillVector(inputData);
 
     // BorderWrapper to calculate the actual calculated values.
-    BorderWrapper<T, BorderType> borderWrap(ImageWrapper<T>(inputData, batchSize, imageSize.w, imageSize.h), borderVal);
+    BorderWrapper<BorderType, ImageWrapper<T>> borderWrap(
+        ImageWrapper<T>(inputData, batchSize, imageSize.w, imageSize.h), borderVal);
     std::vector<BT> actualOutput(numElementsWithBorder);
     int actualIndex = 0;
     for (int batch = 0; batch < batchSize; ++batch) {

--- a/tests/roccv/cpp/src/tests/core/wrappers/test_border_wrapper.cpp
+++ b/tests/roccv/cpp/src/tests/core/wrappers/test_border_wrapper.cpp
@@ -103,7 +103,7 @@ int64_t GetCoordOfBorderPel(int64_t u, int64_t dimSize, eBorderType borderMode) 
  *
  * @tparam T The underlying datatype of the image. (e.g. uchar3)
  * @tparam BT The base datatype of the image (e.g. unsigned char)
- * @param[in] input The input ImageWrapper referencing the underlying image data.
+ * @param[in] input The input TensorWrapper referencing the underlying image data.
  * @param[in] borderMode The border mode used to handle out of bounds coordinates.
  * @param[in] borderValue The value to fallback to when handling out of bounds coordinates with the CONSTANT border
  * mode.
@@ -115,7 +115,7 @@ int64_t GetCoordOfBorderPel(int64_t u, int64_t dimSize, eBorderType borderMode) 
  * coordinates fall out of bounds.
  */
 template <typename T, typename BT = detail::BaseType<T>>
-BT GoldenBorderAt(ImageWrapper<T>& input, eBorderType borderMode, T borderValue, int64_t sample, int64_t y, int64_t x,
+BT GoldenBorderAt(TensorWrapper<T>& input, eBorderType borderMode, T borderValue, int64_t sample, int64_t y, int64_t x,
                   int64_t channel) {
     int64_t outX = x, outY = y;
 
@@ -130,7 +130,7 @@ BT GoldenBorderAt(ImageWrapper<T>& input, eBorderType borderMode, T borderValue,
         outY = GetCoordOfBorderPel(y, input.height(), borderMode);
     }
 
-    // Return the value at the modified outX, outY coordinates using the passed in ImageWrapper.
+    // Return the value at the modified outX, outY coordinates using the passed in TensorWrapper.
     return detail::GetElement(input.at(sample, outY, outX, 0), channel);
 }
 
@@ -162,7 +162,7 @@ void TestCorrectness(float4 borderValue, int32_t batchSize, Size2D imageSize, in
 
     // BorderWrapper to calculate the actual calculated values.
     auto borderWrap =
-        MakeBorderWrapper<BorderType>(ImageWrapper<T>(inputData, batchSize, imageSize.w, imageSize.h), borderVal);
+        MakeBorderWrapper<BorderType>(TensorWrapper<T>(inputData, batchSize, imageSize.w, imageSize.h), borderVal);
     std::vector<BT> actualOutput(numElementsWithBorder);
     int actualIndex = 0;
     for (int batch = 0; batch < batchSize; ++batch) {
@@ -177,9 +177,9 @@ void TestCorrectness(float4 borderValue, int32_t batchSize, Size2D imageSize, in
         }
     }
 
-    // ImageWrapper for use in the golden output generator. ImageWrapper is unit tested separately, and is
+    // TensorWrapper for use in the golden output generator. TensorWrapper is unit tested separately, and is
     // considered working at this point in the dependency chain.
-    ImageWrapper<T> imageWrap(inputData, batchSize, imageSize.w, imageSize.h);
+    TensorWrapper<T> imageWrap(inputData, batchSize, imageSize.w, imageSize.h);
     std::vector<BT> goldenOutput(numElementsWithBorder);
     int goldenIndex = 0;
     for (int batch = 0; batch < batchSize; ++batch) {

--- a/tests/roccv/cpp/src/tests/core/wrappers/test_image_batch_var_shape_wrapper.cpp
+++ b/tests/roccv/cpp/src/tests/core/wrappers/test_image_batch_var_shape_wrapper.cpp
@@ -29,7 +29,7 @@
 #include <core/image_format.hpp>
 #include <core/wrappers/border_wrapper.hpp>
 #include <core/wrappers/interpolation_wrapper.hpp>
-#include <core/wrappers/var_shape_image_wrapper.hpp>
+#include <core/wrappers/image_batch_var_shape_wrapper.hpp>
 #include <vector>
 
 #include "test_helpers.hpp"
@@ -43,7 +43,7 @@ namespace {
 // Each launch covers exactly one image — the host loop steps through n and resizes the
 // grid to that image's dimensions, which avoids needing a max-bounds check inside the kernel.
 template <typename T>
-__global__ void VarShapeCopyKernel(VarShapeImageWrapper<T> src, VarShapeImageWrapper<T> dst, int32_t n) {
+__global__ void VarShapeCopyKernel(ImageBatchVarShapeWrapper<T> src, ImageBatchVarShapeWrapper<T> dst, int32_t n) {
     const int x = blockIdx.x * blockDim.x + threadIdx.x;
     const int y = blockIdx.y * blockDim.y + threadIdx.y;
     if (x >= dst.width(n) || y >= dst.height(n)) return;
@@ -91,8 +91,8 @@ void TestRoundtripCopy(const std::vector<Size2D>& sizes, ImageFormat fmt) {
 
     auto srcData = srcBatch.exportData(stream);
     auto dstData = dstBatch.exportData(stream);
-    VarShapeImageWrapper<T> srcWrap(srcData);
-    VarShapeImageWrapper<T> dstWrap(dstData);
+    ImageBatchVarShapeWrapper<T> srcWrap(srcData);
+    ImageBatchVarShapeWrapper<T> dstWrap(dstData);
 
     // Launch one kernel per image (sizes vary so a single 3D launch can't bound y to per-image height cleanly).
     for (int32_t i = 0; i < numImages; ++i) {
@@ -116,11 +116,11 @@ void TestRoundtripCopy(const std::vector<Size2D>& sizes, ImageFormat fmt) {
 }
 
 // Border-composition test: write the BORDER_TYPE_CONSTANT fallback for every output pixel by reading from a coordinate
-// that is guaranteed to be out of bounds for every image (-1, -1). Confirms BorderWrapper<B, VarShapeImageWrapper<T>>
+// that is guaranteed to be out of bounds for every image (-1, -1). Confirms BorderWrapper<B, ImageBatchVarShapeWrapper<T>>
 // correctly delegates to width(n) / height(n) for per-image bounds; otherwise it would dereference invalid memory.
 template <typename T>
 __global__ void VarShapeBorderConstantKernel(
-    BorderWrapper<eBorderType::BORDER_TYPE_CONSTANT, VarShapeImageWrapper<T>> src, VarShapeImageWrapper<T> dst,
+    BorderWrapper<eBorderType::BORDER_TYPE_CONSTANT, ImageBatchVarShapeWrapper<T>> src, ImageBatchVarShapeWrapper<T> dst,
     int32_t n) {
     const int x = blockIdx.x * blockDim.x + threadIdx.x;
     const int y = blockIdx.y * blockDim.y + threadIdx.y;
@@ -150,8 +150,8 @@ void TestBorderConstantComposition(const std::vector<Size2D>& sizes, ImageFormat
     auto srcData = srcBatch.exportData(stream);
     auto dstData = dstBatch.exportData(stream);
 
-    auto srcWrap = MakeBorderWrapper<eBorderType::BORDER_TYPE_CONSTANT>(VarShapeImageWrapper<T>(srcData), borderValue);
-    VarShapeImageWrapper<T> dstWrap(dstData);
+    auto srcWrap = MakeBorderWrapper<eBorderType::BORDER_TYPE_CONSTANT>(ImageBatchVarShapeWrapper<T>(srcData), borderValue);
+    ImageBatchVarShapeWrapper<T> dstWrap(dstData);
 
     for (int32_t i = 0; i < numImages; ++i) {
         dim3 block(16, 16);
@@ -186,9 +186,9 @@ void TestBorderConstantComposition(const std::vector<Size2D>& sizes, ImageFormat
 template <typename T>
 __global__ void VarShapeInterpNearestKernel(
     InterpolationWrapper<eInterpolationType::INTERP_TYPE_NEAREST,
-                         BorderWrapper<eBorderType::BORDER_TYPE_REPLICATE, VarShapeImageWrapper<T>>>
+                         BorderWrapper<eBorderType::BORDER_TYPE_REPLICATE, ImageBatchVarShapeWrapper<T>>>
         src,
-    VarShapeImageWrapper<T> dst, int32_t n) {
+    ImageBatchVarShapeWrapper<T> dst, int32_t n) {
     const int x = blockIdx.x * blockDim.x + threadIdx.x;
     const int y = blockIdx.y * blockDim.y + threadIdx.y;
     if (x >= dst.width(n) || y >= dst.height(n)) return;
@@ -229,8 +229,8 @@ void TestInterpolationNearestComposition(const std::vector<Size2D>& sizes, Image
     auto dstData = dstBatch.exportData(stream);
 
     auto srcWrap = MakeInterpolationWrapper<eInterpolationType::INTERP_TYPE_NEAREST>(
-        MakeBorderWrapper<eBorderType::BORDER_TYPE_REPLICATE>(VarShapeImageWrapper<T>(srcData), T{}));
-    VarShapeImageWrapper<T> dstWrap(dstData);
+        MakeBorderWrapper<eBorderType::BORDER_TYPE_REPLICATE>(ImageBatchVarShapeWrapper<T>(srcData), T{}));
+    ImageBatchVarShapeWrapper<T> dstWrap(dstData);
 
     for (int32_t i = 0; i < numImages; ++i) {
         dim3 block(16, 16);
@@ -262,7 +262,7 @@ void TestAccessors(const std::vector<Size2D>& sizes, ImageFormat fmt) {
         batch.pushBack(handles[i]);
     }
     auto data = batch.exportData(0);
-    VarShapeImageWrapper<T> wrap(data);
+    ImageBatchVarShapeWrapper<T> wrap(data);
 
     EXPECT_EQ(wrap.batches(), static_cast<int64_t>(numImages));
     EXPECT_EQ(wrap.channels(), static_cast<int64_t>(detail::NumElements<T>));
@@ -297,13 +297,13 @@ int main(int argc, char** argv) {
 
     TEST_CASE(TestAccessors<uchar3>({{16, 12}, {32, 24}, {7, 5}}, FMT_RGB8));
 
-    // BorderWrapper composed over VarShapeImageWrapper: constant-fill via guaranteed-OOB read.
+    // BorderWrapper composed over ImageBatchVarShapeWrapper: constant-fill via guaranteed-OOB read.
     TEST_CASE(
         TestBorderConstantComposition<uchar3>({{16, 12}, {32, 24}, {7, 5}}, FMT_RGB8, make_uchar3(0xAB, 0xCD, 0xEF)));
     TEST_CASE(TestBorderConstantComposition<uchar4>({{16, 12}, {32, 24}, {7, 5}}, FMT_RGBA8,
                                                     make_uchar4(0x12, 0x34, 0x56, 0x78)));
 
-    // InterpolationWrapper<NEAREST> composed over VarShapeImageWrapper: integer-coord roundtrip is identity.
+    // InterpolationWrapper<NEAREST> composed over ImageBatchVarShapeWrapper: integer-coord roundtrip is identity.
     TEST_CASE(TestInterpolationNearestComposition<uchar1>({{16, 12}, {32, 24}, {7, 5}}, FMT_U8));
     TEST_CASE(TestInterpolationNearestComposition<uchar3>({{16, 12}, {32, 24}, {7, 5}}, FMT_RGB8));
     TEST_CASE(TestInterpolationNearestComposition<uchar4>({{16, 12}, {32, 24}, {7, 5}}, FMT_RGBA8));

--- a/tests/roccv/cpp/src/tests/core/wrappers/test_image_batch_var_shape_wrapper.cpp
+++ b/tests/roccv/cpp/src/tests/core/wrappers/test_image_batch_var_shape_wrapper.cpp
@@ -28,8 +28,9 @@
 #include <core/image_data.hpp>
 #include <core/image_format.hpp>
 #include <core/wrappers/border_wrapper.hpp>
-#include <core/wrappers/interpolation_wrapper.hpp>
 #include <core/wrappers/image_batch_var_shape_wrapper.hpp>
+#include <core/wrappers/interpolation_wrapper.hpp>
+#include <cstring>
 #include <vector>
 
 #include "test_helpers.hpp"
@@ -116,12 +117,13 @@ void TestRoundtripCopy(const std::vector<Size2D>& sizes, ImageFormat fmt) {
 }
 
 // Border-composition test: write the BORDER_TYPE_CONSTANT fallback for every output pixel by reading from a coordinate
-// that is guaranteed to be out of bounds for every image (-1, -1). Confirms BorderWrapper<B, ImageBatchVarShapeWrapper<T>>
-// correctly delegates to width(n) / height(n) for per-image bounds; otherwise it would dereference invalid memory.
+// that is guaranteed to be out of bounds for every image (-1, -1). Confirms BorderWrapper<B,
+// ImageBatchVarShapeWrapper<T>> correctly delegates to width(n) / height(n) for per-image bounds; otherwise it would
+// dereference invalid memory.
 template <typename T>
 __global__ void VarShapeBorderConstantKernel(
-    BorderWrapper<eBorderType::BORDER_TYPE_CONSTANT, ImageBatchVarShapeWrapper<T>> src, ImageBatchVarShapeWrapper<T> dst,
-    int32_t n) {
+    BorderWrapper<eBorderType::BORDER_TYPE_CONSTANT, ImageBatchVarShapeWrapper<T>> src,
+    ImageBatchVarShapeWrapper<T> dst, int32_t n) {
     const int x = blockIdx.x * blockDim.x + threadIdx.x;
     const int y = blockIdx.y * blockDim.y + threadIdx.y;
     if (x >= dst.width(n) || y >= dst.height(n)) return;
@@ -150,7 +152,8 @@ void TestBorderConstantComposition(const std::vector<Size2D>& sizes, ImageFormat
     auto srcData = srcBatch.exportData(stream);
     auto dstData = dstBatch.exportData(stream);
 
-    auto srcWrap = MakeBorderWrapper<eBorderType::BORDER_TYPE_CONSTANT>(ImageBatchVarShapeWrapper<T>(srcData), borderValue);
+    auto srcWrap =
+        MakeBorderWrapper<eBorderType::BORDER_TYPE_CONSTANT>(ImageBatchVarShapeWrapper<T>(srcData), borderValue);
     ImageBatchVarShapeWrapper<T> dstWrap(dstData);
 
     for (int32_t i = 0; i < numImages; ++i) {
@@ -274,6 +277,71 @@ void TestAccessors(const std::vector<Size2D>& sizes, ImageFormat fmt) {
     HIP_VALIDATE_NO_ERRORS(hipStreamSynchronize(0));
 }
 
+// Host-path roundtrip: a CPU-resident batch exports a host snapshot, and the wrapper reads/writes
+// it directly from host code — no kernel launch, no stream. Mirrors TestRoundtripCopy for the GPU
+// path and confirms the residency-agnostic constructor handles the ...Host leaf.
+template <typename T, typename BT = detail::BaseType<T>>
+void TestHostRoundtripCopy(const std::vector<Size2D>& sizes, ImageFormat fmt) {
+    const int channels = detail::NumElements<T>;
+    const int32_t numImages = static_cast<int32_t>(sizes.size());
+
+    std::vector<std::vector<BT>> hostPixels(numImages);
+    for (int32_t i = 0; i < numImages; ++i) {
+        hostPixels[i].resize(static_cast<size_t>(sizes[i].w) * sizes[i].h * channels);
+        FillVector(hostPixels[i], /*seed=*/static_cast<uint32_t>(0x2000 + i));
+    }
+
+    // CPU-resident batches; fill each source image's host buffer directly.
+    ImageBatchVarShape srcBatch(numImages, eDeviceType::CPU);
+    ImageBatchVarShape dstBatch(numImages, eDeviceType::CPU);
+    std::vector<Image> srcImages, dstImages;
+    srcImages.reserve(numImages);
+    dstImages.reserve(numImages);
+    for (int32_t i = 0; i < numImages; ++i) {
+        srcImages.emplace_back(sizes[i], fmt, eDeviceType::CPU);
+        dstImages.emplace_back(sizes[i], fmt, eDeviceType::CPU);
+
+        auto sd = srcImages[i].exportData<ImageDataStridedHost>();
+        const ImagePlaneStrided& sp = sd.plane(0);
+        const size_t rowBytes = static_cast<size_t>(sizes[i].w) * channels * sizeof(BT);
+        for (int32_t y = 0; y < sizes[i].h; ++y) {
+            std::memcpy(static_cast<unsigned char*>(sp.basePtr) + y * sp.rowStride,
+                        hostPixels[i].data() + static_cast<size_t>(y) * sizes[i].w * channels, rowBytes);
+        }
+
+        srcBatch.pushBack(srcImages[i]);
+        dstBatch.pushBack(dstImages[i]);
+    }
+
+    auto srcData = srcBatch.exportData(0);
+    auto dstData = dstBatch.exportData(0);
+    ImageBatchVarShapeWrapper<T> srcWrap(srcData);
+    ImageBatchVarShapeWrapper<T> dstWrap(dstData);
+
+    // Copy whole pixels through the wrapper entirely on the host (same at(n,y,x,0) semantics as
+    // VarShapeCopyKernel, just without a device launch).
+    for (int32_t n = 0; n < numImages; ++n) {
+        for (int64_t y = 0; y < srcWrap.height(n); ++y) {
+            for (int64_t x = 0; x < srcWrap.width(n); ++x) {
+                dstWrap.at(n, y, x, 0) = srcWrap.at(n, y, x, 0);
+            }
+        }
+    }
+
+    // Read dst host buffers back and verify byte-for-byte against the original input.
+    for (int32_t i = 0; i < numImages; ++i) {
+        std::vector<BT> dstHost(static_cast<size_t>(sizes[i].w) * sizes[i].h * channels);
+        auto dd = dstImages[i].exportData<ImageDataStridedHost>();
+        const ImagePlaneStrided& dp = dd.plane(0);
+        const size_t rowBytes = static_cast<size_t>(sizes[i].w) * channels * sizeof(BT);
+        for (int32_t y = 0; y < sizes[i].h; ++y) {
+            std::memcpy(dstHost.data() + static_cast<size_t>(y) * sizes[i].w * channels,
+                        static_cast<const unsigned char*>(dp.basePtr) + y * dp.rowStride, rowBytes);
+        }
+        CompareVectors(dstHost, hostPixels[i]);
+    }
+}
+
 }  // namespace
 
 int main(int argc, char** argv) {
@@ -294,6 +362,12 @@ int main(int argc, char** argv) {
 
     // Single image, large.
     TEST_CASE(TestRoundtripCopy<uchar3>({{128, 96}}, FMT_RGB8));
+
+    // CPU path: the same roundtrip driven entirely from host code over a host-resident snapshot.
+    TEST_CASE(TestHostRoundtripCopy<uchar1>({{16, 12}, {32, 24}, {7, 5}, {48, 9}}, FMT_U8));
+    TEST_CASE(TestHostRoundtripCopy<float1>({{16, 12}, {32, 24}, {7, 5}, {48, 9}}, FMT_F32));
+    TEST_CASE(TestHostRoundtripCopy<uchar3>({{16, 12}, {32, 24}, {7, 5}, {48, 9}}, FMT_RGB8));
+    TEST_CASE(TestHostRoundtripCopy<uchar4>({{64, 64}, {64, 64}}, FMT_RGBA8));
 
     TEST_CASE(TestAccessors<uchar3>({{16, 12}, {32, 24}, {7, 5}}, FMT_RGB8));
 

--- a/tests/roccv/cpp/src/tests/core/wrappers/test_interpolation_wrapper.cpp
+++ b/tests/roccv/cpp/src/tests/core/wrappers/test_interpolation_wrapper.cpp
@@ -204,11 +204,10 @@ void TestCorrectness(int64_t batchSize, Size2D imageSize, float4 borderValue, fl
     std::vector<detail::BaseType<T>> goldenOutput;
 
     // Use roccv::InterpolationWrapper to get actual output
-    InterpolationWrapper<BorderType, InterpType, ImageWrapper<T>> actualWrap(
-        (BorderWrapper<BorderType, ImageWrapper<T>>(ImageWrapper<T>(input, batchSize, imageSize.w, imageSize.h),
-                                                    borderVal)));
-    BorderWrapper<BorderType, ImageWrapper<T>> goldenWrap(ImageWrapper<T>(input, batchSize, imageSize.w, imageSize.h),
-                                                          borderVal);
+    auto actualWrap = MakeInterpolationWrapper<InterpType>(
+        MakeBorderWrapper<BorderType>(ImageWrapper<T>(input, batchSize, imageSize.w, imageSize.h), borderVal));
+    auto goldenWrap =
+        MakeBorderWrapper<BorderType>(ImageWrapper<T>(input, batchSize, imageSize.w, imageSize.h), borderVal);
 
     for (int b = 0; b < batchSize; b++) {
         for (float y = 0; y < imageSize.h; y += idxDelta) {

--- a/tests/roccv/cpp/src/tests/core/wrappers/test_interpolation_wrapper.cpp
+++ b/tests/roccv/cpp/src/tests/core/wrappers/test_interpolation_wrapper.cpp
@@ -21,9 +21,9 @@
 
 #include <core/detail/casting.hpp>
 #include <core/detail/type_traits.hpp>
-#include "core/detail/vector_utils.hpp"
 #include <core/wrappers/interpolation_wrapper.hpp>
 
+#include "core/detail/vector_utils.hpp"
 #include "test_helpers.hpp"
 
 using namespace roccv;
@@ -45,7 +45,7 @@ namespace {
  * @return T The interpolated pixel.
  */
 template <typename T, eBorderType BorderType>
-T GoldenLinear(BorderWrapper<T, BorderType> input, int64_t sample, float y, float x) {
+T GoldenLinear(BorderWrapper<BorderType, ImageWrapper<T>> input, int64_t sample, float y, float x) {
     // Defines the vectorized float type for intermediate calculations.
     using WorkType = detail::MakeType<float, detail::NumComponents<T>>;
 
@@ -86,7 +86,7 @@ T GoldenLinear(BorderWrapper<T, BorderType> input, int64_t sample, float y, floa
  * @return T The interpolated pixel.
  */
 template <typename T, eBorderType BorderType>
-T GoldenNearest(BorderWrapper<T, BorderType> input, int64_t sample, float y, float x) {
+T GoldenNearest(BorderWrapper<BorderType, ImageWrapper<T>> input, int64_t sample, float y, float x) {
     // Nearest neighbor interpolation. Rounds given floating point values to the nearest integer.
     return input.at(sample, lroundf(y), lroundf(x), 0);
 }
@@ -98,7 +98,7 @@ T GoldenNearest(BorderWrapper<T, BorderType> input, int64_t sample, float y, flo
  * @return None.
  */
 void CalBicubicWeights(float dist, float* weight) {
-    const float A = -0.5f; // Note OpenCV sets alpha to -0.75f
+    const float A = -0.5f;  // Note OpenCV sets alpha to -0.75f
 
     weight[0] = ((A * (dist + 1) - 5 * A) * (dist + 1) + 8 * A) * (dist + 1) - 4 * A;
     weight[1] = ((A + 2) * dist - (A + 3)) * dist * dist + 1;
@@ -107,7 +107,8 @@ void CalBicubicWeights(float dist, float* weight) {
 }
 
 /**
- * @brief Golden model for Bicubic interpolation. This is the Catmull-Rom cubic interpolation commonly used in CV libraries.
+ * @brief Golden model for Bicubic interpolation. This is the Catmull-Rom cubic interpolation commonly used in CV
+ * libraries.
  *
  * @tparam T Image datatype.
  * @tparam BorderType Border type for boundary conditions.
@@ -118,7 +119,7 @@ void CalBicubicWeights(float dist, float* weight) {
  * @return T The interpolated pixel.
  */
 template <typename T, eBorderType BorderType>
-T GoldenBicubic(BorderWrapper<T, BorderType> input, int64_t sample, float y, float x) {
+T GoldenBicubic(BorderWrapper<BorderType, ImageWrapper<T>> input, int64_t sample, float y, float x) {
     // Defines the vectorized float type for intermediate calculations.
     using WorkType = detail::MakeType<float, detail::NumComponents<T>>;
 
@@ -135,7 +136,8 @@ T GoldenBicubic(BorderWrapper<T, BorderType> input, int64_t sample, float y, flo
     WorkType sum = SetAll<WorkType>(0.0f);
     for (int indexY = -1; indexY <= 2; indexY++) {
         for (int indexX = -1; indexX <= 2; indexX++) {
-            sum += detail::RangeCast<WorkType>(input.at(sample, intY + indexY, intX + indexX, 0)) * (weightX[indexX + 1] * weightY[indexY + 1]);
+            sum += detail::RangeCast<WorkType>(input.at(sample, intY + indexY, intX + indexX, 0)) *
+                   (weightX[indexX + 1] * weightY[indexY + 1]);
         }
     }
 
@@ -156,7 +158,7 @@ T GoldenBicubic(BorderWrapper<T, BorderType> input, int64_t sample, float y, flo
  * @return T The interpolated pixel.
  */
 template <typename T, eBorderType BorderType>
-T GoldenInterpolationAt(BorderWrapper<T, BorderType> input, int64_t sample, float y, float x,
+T GoldenInterpolationAt(BorderWrapper<BorderType, ImageWrapper<T>> input, int64_t sample, float y, float x,
                         eInterpolationType interp) {
     switch (interp) {
         case eInterpolationType::INTERP_TYPE_NEAREST:
@@ -202,9 +204,11 @@ void TestCorrectness(int64_t batchSize, Size2D imageSize, float4 borderValue, fl
     std::vector<detail::BaseType<T>> goldenOutput;
 
     // Use roccv::InterpolationWrapper to get actual output
-    InterpolationWrapper<T, BorderType, InterpType> actualWrap(
-        (BorderWrapper<T, BorderType>(ImageWrapper<T>(input, batchSize, imageSize.w, imageSize.h), borderVal)));
-    BorderWrapper<T, BorderType> goldenWrap(ImageWrapper<T>(input, batchSize, imageSize.w, imageSize.h), borderVal);
+    InterpolationWrapper<BorderType, InterpType, ImageWrapper<T>> actualWrap(
+        (BorderWrapper<BorderType, ImageWrapper<T>>(ImageWrapper<T>(input, batchSize, imageSize.w, imageSize.h),
+                                                    borderVal)));
+    BorderWrapper<BorderType, ImageWrapper<T>> goldenWrap(ImageWrapper<T>(input, batchSize, imageSize.w, imageSize.h),
+                                                          borderVal);
 
     for (int b = 0; b < batchSize; b++) {
         for (float y = 0; y < imageSize.h; y += idxDelta) {
@@ -220,7 +224,8 @@ void TestCorrectness(int64_t batchSize, Size2D imageSize, float4 borderValue, fl
             }
         }
     }
-    if constexpr (std::is_integral_v<detail::BaseType<T>> && std::is_signed_v<detail::BaseType<T>> && sizeof(detail::BaseType<T>) == 4) {
+    if constexpr (std::is_integral_v<detail::BaseType<T>> && std::is_signed_v<detail::BaseType<T>> &&
+                  sizeof(detail::BaseType<T>) == 4) {
         CompareVectorsNear(actualOutput, goldenOutput, NEAR_EQUAL_THRESHOLD * 2);
     } else {
         CompareVectorsNear(actualOutput, goldenOutput);
@@ -228,7 +233,7 @@ void TestCorrectness(int64_t batchSize, Size2D imageSize, float4 borderValue, fl
 }
 }  // namespace
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
     (void)argc;
     (void)argv;
     TEST_CASES_BEGIN();
@@ -322,7 +327,7 @@ int main(int argc, char **argv) {
     TEST_CASE((TestCorrectness<float1, eBorderType::BORDER_TYPE_REFLECT, eInterpolationType::INTERP_TYPE_CUBIC>(1, {20, 53}, make_float4(0, 0, 0, 1), 0.1f)));
     TEST_CASE((TestCorrectness<float3, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_CUBIC>(3, {38, 10}, make_float4(0, 0, 0, 1), 0.1f)));
     TEST_CASE((TestCorrectness<float4, eBorderType::BORDER_TYPE_WRAP, eInterpolationType::INTERP_TYPE_CUBIC>(5, {65, 21}, make_float4(1, 0.5, 0.5, 1), 0.1f)));
-     // clang-format on
+    // clang-format on
 
     TEST_CASES_END();
 }

--- a/tests/roccv/cpp/src/tests/core/wrappers/test_interpolation_wrapper.cpp
+++ b/tests/roccv/cpp/src/tests/core/wrappers/test_interpolation_wrapper.cpp
@@ -45,7 +45,7 @@ namespace {
  * @return T The interpolated pixel.
  */
 template <typename T, eBorderType BorderType>
-T GoldenLinear(BorderWrapper<BorderType, ImageWrapper<T>> input, int64_t sample, float y, float x) {
+T GoldenLinear(BorderWrapper<BorderType, TensorWrapper<T>> input, int64_t sample, float y, float x) {
     // Defines the vectorized float type for intermediate calculations.
     using WorkType = detail::MakeType<float, detail::NumComponents<T>>;
 
@@ -86,7 +86,7 @@ T GoldenLinear(BorderWrapper<BorderType, ImageWrapper<T>> input, int64_t sample,
  * @return T The interpolated pixel.
  */
 template <typename T, eBorderType BorderType>
-T GoldenNearest(BorderWrapper<BorderType, ImageWrapper<T>> input, int64_t sample, float y, float x) {
+T GoldenNearest(BorderWrapper<BorderType, TensorWrapper<T>> input, int64_t sample, float y, float x) {
     // Nearest neighbor interpolation. Rounds given floating point values to the nearest integer.
     return input.at(sample, lroundf(y), lroundf(x), 0);
 }
@@ -119,7 +119,7 @@ void CalBicubicWeights(float dist, float* weight) {
  * @return T The interpolated pixel.
  */
 template <typename T, eBorderType BorderType>
-T GoldenBicubic(BorderWrapper<BorderType, ImageWrapper<T>> input, int64_t sample, float y, float x) {
+T GoldenBicubic(BorderWrapper<BorderType, TensorWrapper<T>> input, int64_t sample, float y, float x) {
     // Defines the vectorized float type for intermediate calculations.
     using WorkType = detail::MakeType<float, detail::NumComponents<T>>;
 
@@ -158,7 +158,7 @@ T GoldenBicubic(BorderWrapper<BorderType, ImageWrapper<T>> input, int64_t sample
  * @return T The interpolated pixel.
  */
 template <typename T, eBorderType BorderType>
-T GoldenInterpolationAt(BorderWrapper<BorderType, ImageWrapper<T>> input, int64_t sample, float y, float x,
+T GoldenInterpolationAt(BorderWrapper<BorderType, TensorWrapper<T>> input, int64_t sample, float y, float x,
                         eInterpolationType interp) {
     switch (interp) {
         case eInterpolationType::INTERP_TYPE_NEAREST:
@@ -205,9 +205,9 @@ void TestCorrectness(int64_t batchSize, Size2D imageSize, float4 borderValue, fl
 
     // Use roccv::InterpolationWrapper to get actual output
     auto actualWrap = MakeInterpolationWrapper<InterpType>(
-        MakeBorderWrapper<BorderType>(ImageWrapper<T>(input, batchSize, imageSize.w, imageSize.h), borderVal));
+        MakeBorderWrapper<BorderType>(TensorWrapper<T>(input, batchSize, imageSize.w, imageSize.h), borderVal));
     auto goldenWrap =
-        MakeBorderWrapper<BorderType>(ImageWrapper<T>(input, batchSize, imageSize.w, imageSize.h), borderVal);
+        MakeBorderWrapper<BorderType>(TensorWrapper<T>(input, batchSize, imageSize.w, imageSize.h), borderVal);
 
     for (int b = 0; b < batchSize; b++) {
         for (float y = 0; y < imageSize.h; y += idxDelta) {

--- a/tests/roccv/cpp/src/tests/core/wrappers/test_tensor_wrapper.cpp
+++ b/tests/roccv/cpp/src/tests/core/wrappers/test_tensor_wrapper.cpp
@@ -20,7 +20,7 @@
  */
 
 #include <core/detail/type_traits.hpp>
-#include <core/wrappers/image_wrapper.hpp>
+#include <core/wrappers/tensor_wrapper.hpp>
 
 #include "test_helpers.hpp"
 
@@ -37,11 +37,11 @@ void TestCorrectness(int numImages, Size2D size) {
     std::vector<BT> ref(numElements);
     FillVector(ref);
 
-    ImageWrapper<T> input(ref, numImages, size.w, size.h);
+    TensorWrapper<T> input(ref, numImages, size.w, size.h);
     std::vector<BT> actual;
 
     // To determine if coordinates are pointing to the proper values in memory, iterate through the reference vector
-    // element-by-element and iterate through the ImageWrapper coordinate-wise. All values should be the same if
+    // element-by-element and iterate through the TensorWrapper coordinate-wise. All values should be the same if
     // everything lines up.
 
     for (int b = 0; b < numImages; ++b) {
@@ -58,9 +58,9 @@ void TestCorrectness(int numImages, Size2D size) {
 }
 
 template <typename T>
-void TestImageWrapperConstructor(int imageCount, Size2D imageSize, ImageFormat format) {
+void TestTensorWrapperConstructor(int imageCount, Size2D imageSize, ImageFormat format) {
     Tensor input(imageCount, imageSize, format);
-    ImageWrapper<T> wrapper(input);
+    TensorWrapper<T> wrapper(input);
 
     EXPECT_EQ(wrapper.batches(), imageCount);
     EXPECT_EQ(wrapper.channels(), format.channels());
@@ -74,7 +74,7 @@ int main(int argc, char** argv) {
     (void)argv;
     TEST_CASES_BEGIN();
 
-    TEST_CASE(TestImageWrapperConstructor<uchar3>(2, {54, 67}, FMT_RGB8));
+    TEST_CASE(TestTensorWrapperConstructor<uchar3>(2, {54, 67}, FMT_RGB8));
 
     TEST_CASE(TestCorrectness<uchar1>(1, {10, 10}));
     TEST_CASE(TestCorrectness<uchar3>(2, {43, 9}));

--- a/tests/roccv/cpp/src/tests/core/wrappers/test_var_shape_image_wrapper.cpp
+++ b/tests/roccv/cpp/src/tests/core/wrappers/test_var_shape_image_wrapper.cpp
@@ -1,0 +1,315 @@
+/*
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <core/hip_assert.h>
+#include <hip/hip_runtime.h>
+
+#include <core/detail/type_traits.hpp>
+#include <core/image.hpp>
+#include <core/image_batch_var_shape.hpp>
+#include <core/image_data.hpp>
+#include <core/image_format.hpp>
+#include <core/wrappers/border_wrapper.hpp>
+#include <core/wrappers/interpolation_wrapper.hpp>
+#include <core/wrappers/var_shape_image_wrapper.hpp>
+#include <vector>
+
+#include "test_helpers.hpp"
+
+using namespace roccv;
+using namespace roccv::tests;
+
+namespace {
+
+// Per-image copy kernel: writes dst[n,y,x,c] = src[n,y,x,c] for the image at batch index n.
+// Each launch covers exactly one image — the host loop steps through n and resizes the
+// grid to that image's dimensions, which avoids needing a max-bounds check inside the kernel.
+template <typename T>
+__global__ void VarShapeCopyKernel(VarShapeImageWrapper<T> src, VarShapeImageWrapper<T> dst, int32_t n) {
+    const int x = blockIdx.x * blockDim.x + threadIdx.x;
+    const int y = blockIdx.y * blockDim.y + threadIdx.y;
+    if (x >= dst.width(n) || y >= dst.height(n)) return;
+    dst.at(n, y, x, 0) = src.at(n, y, x, 0);
+}
+
+// Roundtrip test: build a varshape batch from heterogeneous host pixel data, run the copy kernel from src varshape
+// wrapper to dst varshape wrapper, read pixels back, and verify byte-equality with the original input.
+template <typename T, typename BT = detail::BaseType<T>>
+void TestRoundtripCopy(const std::vector<Size2D>& sizes, ImageFormat fmt) {
+    const int channels = detail::NumElements<T>;
+    const int32_t numImages = static_cast<int32_t>(sizes.size());
+
+    // Generate per-image host pixel data.
+    std::vector<std::vector<BT>> hostPixels(numImages);
+    for (int32_t i = 0; i < numImages; ++i) {
+        hostPixels[i].resize(static_cast<size_t>(sizes[i].w) * sizes[i].h * channels);
+        FillVector(hostPixels[i], /*seed=*/static_cast<uint32_t>(0x1000 + i));
+    }
+
+    hipStream_t stream = nullptr;
+
+    // Build source batch and copy host pixels in.
+    ImageBatchVarShape srcBatch(numImages);
+    std::vector<Image> srcImages;
+    srcImages.reserve(numImages);
+    for (int32_t i = 0; i < numImages; ++i) {
+        srcImages.emplace_back(sizes[i], fmt);
+        auto sd = srcImages[i].exportData<ImageDataStridedHip>();
+        const ImagePlaneStrided& sp = sd.plane(0);
+        const size_t rowBytes = static_cast<size_t>(sizes[i].w) * channels * sizeof(BT);
+        HIP_VALIDATE_NO_ERRORS(hipMemcpy2DAsync(sp.basePtr, sp.rowStride, hostPixels[i].data(), rowBytes, rowBytes,
+                                                sizes[i].h, hipMemcpyHostToDevice, stream));
+        srcBatch.pushBack(srcImages[i]);
+    }
+
+    // Build destination batch with matching shapes.
+    ImageBatchVarShape dstBatch(numImages);
+    std::vector<Image> dstImages;
+    dstImages.reserve(numImages);
+    for (int32_t i = 0; i < numImages; ++i) {
+        dstImages.emplace_back(sizes[i], fmt);
+        dstBatch.pushBack(dstImages[i]);
+    }
+
+    auto srcData = srcBatch.exportData(stream);
+    auto dstData = dstBatch.exportData(stream);
+    VarShapeImageWrapper<T> srcWrap(srcData);
+    VarShapeImageWrapper<T> dstWrap(dstData);
+
+    // Launch one kernel per image (sizes vary so a single 3D launch can't bound y to per-image height cleanly).
+    for (int32_t i = 0; i < numImages; ++i) {
+        dim3 block(16, 16);
+        dim3 grid((sizes[i].w + block.x - 1) / block.x, (sizes[i].h + block.y - 1) / block.y);
+        VarShapeCopyKernel<T><<<grid, block, 0, stream>>>(srcWrap, dstWrap, i);
+    }
+
+    HIP_VALIDATE_NO_ERRORS(hipStreamSynchronize(stream));
+
+    // Read back dst pixels and verify byte-for-byte against the original host input.
+    for (int32_t i = 0; i < numImages; ++i) {
+        std::vector<BT> dstHost(static_cast<size_t>(sizes[i].w) * sizes[i].h * channels);
+        auto dd = dstImages[i].exportData<ImageDataStridedHip>();
+        const ImagePlaneStrided& dp = dd.plane(0);
+        const size_t rowBytes = static_cast<size_t>(sizes[i].w) * channels * sizeof(BT);
+        HIP_VALIDATE_NO_ERRORS(hipMemcpy2D(dstHost.data(), rowBytes, dp.basePtr, dp.rowStride, rowBytes, sizes[i].h,
+                                           hipMemcpyDeviceToHost));
+        CompareVectors(dstHost, hostPixels[i]);
+    }
+}
+
+// Border-composition test: write the BORDER_TYPE_CONSTANT fallback for every output pixel by reading from a coordinate
+// that is guaranteed to be out of bounds for every image (-1, -1). Confirms BorderWrapper<B, VarShapeImageWrapper<T>>
+// correctly delegates to width(n) / height(n) for per-image bounds; otherwise it would dereference invalid memory.
+template <typename T>
+__global__ void VarShapeBorderConstantKernel(
+    BorderWrapper<eBorderType::BORDER_TYPE_CONSTANT, VarShapeImageWrapper<T>> src, VarShapeImageWrapper<T> dst,
+    int32_t n) {
+    const int x = blockIdx.x * blockDim.x + threadIdx.x;
+    const int y = blockIdx.y * blockDim.y + threadIdx.y;
+    if (x >= dst.width(n) || y >= dst.height(n)) return;
+    dst.at(n, y, x, 0) = src.at(n, -1, -1, 0);
+}
+
+template <typename T, typename BT = detail::BaseType<T>>
+void TestBorderConstantComposition(const std::vector<Size2D>& sizes, ImageFormat fmt, T borderValue) {
+    const int channels = detail::NumElements<T>;
+    const int32_t numImages = static_cast<int32_t>(sizes.size());
+
+    // Source pixels content doesn't matter — every read is forced OOB.
+    ImageBatchVarShape srcBatch(numImages);
+    ImageBatchVarShape dstBatch(numImages);
+    std::vector<Image> srcImages, dstImages;
+    srcImages.reserve(numImages);
+    dstImages.reserve(numImages);
+    for (int32_t i = 0; i < numImages; ++i) {
+        srcImages.emplace_back(sizes[i], fmt);
+        dstImages.emplace_back(sizes[i], fmt);
+        srcBatch.pushBack(srcImages[i]);
+        dstBatch.pushBack(dstImages[i]);
+    }
+
+    hipStream_t stream = nullptr;
+    auto srcData = srcBatch.exportData(stream);
+    auto dstData = dstBatch.exportData(stream);
+
+    BorderWrapper<eBorderType::BORDER_TYPE_CONSTANT, VarShapeImageWrapper<T>> srcWrap(VarShapeImageWrapper<T>(srcData),
+                                                                                      borderValue);
+    VarShapeImageWrapper<T> dstWrap(dstData);
+
+    for (int32_t i = 0; i < numImages; ++i) {
+        dim3 block(16, 16);
+        dim3 grid((sizes[i].w + block.x - 1) / block.x, (sizes[i].h + block.y - 1) / block.y);
+        VarShapeBorderConstantKernel<T><<<grid, block, 0, stream>>>(srcWrap, dstWrap, i);
+    }
+    HIP_VALIDATE_NO_ERRORS(hipStreamSynchronize(stream));
+
+    // Expect every output pixel of every image to equal borderValue.
+    std::vector<BT> borderBytes(channels);
+    for (int c = 0; c < channels; ++c) borderBytes[c] = detail::GetElement(borderValue, c);
+
+    for (int32_t i = 0; i < numImages; ++i) {
+        const size_t pixels = static_cast<size_t>(sizes[i].w) * sizes[i].h;
+        std::vector<BT> dstHost(pixels * channels);
+        auto dd = dstImages[i].exportData<ImageDataStridedHip>();
+        const ImagePlaneStrided& dp = dd.plane(0);
+        const size_t rowBytes = static_cast<size_t>(sizes[i].w) * channels * sizeof(BT);
+        HIP_VALIDATE_NO_ERRORS(hipMemcpy2D(dstHost.data(), rowBytes, dp.basePtr, dp.rowStride, rowBytes, sizes[i].h,
+                                           hipMemcpyDeviceToHost));
+        std::vector<BT> expected(pixels * channels);
+        for (size_t p = 0; p < pixels; ++p) {
+            for (int c = 0; c < channels; ++c) expected[p * channels + c] = borderBytes[c];
+        }
+        CompareVectors(dstHost, expected);
+    }
+}
+
+// Interpolation-composition test: NEAREST interpolation at integer coordinates is the identity, so a roundtrip copy
+// via InterpolationWrapper<NEAREST, REPLICATE, VarShape> must equal the source. Confirms the full wrapper chain
+// composes correctly over a VarShape backing.
+template <typename T>
+__global__ void VarShapeInterpNearestKernel(
+    InterpolationWrapper<eBorderType::BORDER_TYPE_REPLICATE, eInterpolationType::INTERP_TYPE_NEAREST,
+                         VarShapeImageWrapper<T>>
+        src,
+    VarShapeImageWrapper<T> dst, int32_t n) {
+    const int x = blockIdx.x * blockDim.x + threadIdx.x;
+    const int y = blockIdx.y * blockDim.y + threadIdx.y;
+    if (x >= dst.width(n) || y >= dst.height(n)) return;
+    dst.at(n, y, x, 0) = src.at(n, static_cast<float>(y), static_cast<float>(x), 0);
+}
+
+template <typename T, typename BT = detail::BaseType<T>>
+void TestInterpolationNearestComposition(const std::vector<Size2D>& sizes, ImageFormat fmt) {
+    const int channels = detail::NumElements<T>;
+    const int32_t numImages = static_cast<int32_t>(sizes.size());
+
+    std::vector<std::vector<BT>> hostPixels(numImages);
+    for (int32_t i = 0; i < numImages; ++i) {
+        hostPixels[i].resize(static_cast<size_t>(sizes[i].w) * sizes[i].h * channels);
+        FillVector(hostPixels[i], static_cast<uint32_t>(0x2000 + i));
+    }
+
+    hipStream_t stream = nullptr;
+    ImageBatchVarShape srcBatch(numImages);
+    ImageBatchVarShape dstBatch(numImages);
+    std::vector<Image> srcImages, dstImages;
+    srcImages.reserve(numImages);
+    dstImages.reserve(numImages);
+    for (int32_t i = 0; i < numImages; ++i) {
+        srcImages.emplace_back(sizes[i], fmt);
+        auto sd = srcImages[i].exportData<ImageDataStridedHip>();
+        const ImagePlaneStrided& sp = sd.plane(0);
+        const size_t rowBytes = static_cast<size_t>(sizes[i].w) * channels * sizeof(BT);
+        HIP_VALIDATE_NO_ERRORS(hipMemcpy2DAsync(sp.basePtr, sp.rowStride, hostPixels[i].data(), rowBytes, rowBytes,
+                                                sizes[i].h, hipMemcpyHostToDevice, stream));
+        srcBatch.pushBack(srcImages[i]);
+
+        dstImages.emplace_back(sizes[i], fmt);
+        dstBatch.pushBack(dstImages[i]);
+    }
+
+    auto srcData = srcBatch.exportData(stream);
+    auto dstData = dstBatch.exportData(stream);
+
+    using InterpType = InterpolationWrapper<eBorderType::BORDER_TYPE_REPLICATE, eInterpolationType::INTERP_TYPE_NEAREST,
+                                            VarShapeImageWrapper<T>>;
+    using BorderType = BorderWrapper<eBorderType::BORDER_TYPE_REPLICATE, VarShapeImageWrapper<T>>;
+    InterpType srcWrap(BorderType(VarShapeImageWrapper<T>(srcData), T{}));
+    VarShapeImageWrapper<T> dstWrap(dstData);
+
+    for (int32_t i = 0; i < numImages; ++i) {
+        dim3 block(16, 16);
+        dim3 grid((sizes[i].w + block.x - 1) / block.x, (sizes[i].h + block.y - 1) / block.y);
+        VarShapeInterpNearestKernel<T><<<grid, block, 0, stream>>>(srcWrap, dstWrap, i);
+    }
+    HIP_VALIDATE_NO_ERRORS(hipStreamSynchronize(stream));
+
+    for (int32_t i = 0; i < numImages; ++i) {
+        std::vector<BT> dstHost(static_cast<size_t>(sizes[i].w) * sizes[i].h * channels);
+        auto dd = dstImages[i].exportData<ImageDataStridedHip>();
+        const ImagePlaneStrided& dp = dd.plane(0);
+        const size_t rowBytes = static_cast<size_t>(sizes[i].w) * channels * sizeof(BT);
+        HIP_VALIDATE_NO_ERRORS(hipMemcpy2D(dstHost.data(), rowBytes, dp.basePtr, dp.rowStride, rowBytes, sizes[i].h,
+                                           hipMemcpyDeviceToHost));
+        CompareVectors(dstHost, hostPixels[i]);
+    }
+}
+
+// Verify accessor surface: width(n), height(n), batches(), channels().
+template <typename T>
+void TestAccessors(const std::vector<Size2D>& sizes, ImageFormat fmt) {
+    const int32_t numImages = static_cast<int32_t>(sizes.size());
+    ImageBatchVarShape batch(numImages);
+    std::vector<Image> handles;
+    handles.reserve(numImages);
+    for (int32_t i = 0; i < numImages; ++i) {
+        handles.emplace_back(sizes[i], fmt);
+        batch.pushBack(handles[i]);
+    }
+    auto data = batch.exportData(0);
+    VarShapeImageWrapper<T> wrap(data);
+
+    EXPECT_EQ(wrap.batches(), static_cast<int64_t>(numImages));
+    EXPECT_EQ(wrap.channels(), static_cast<int64_t>(detail::NumElements<T>));
+    // width/height are device pointers under the hood; reading them on host post-sync is safe because exportData
+    // recorded a hipEvent that hipStreamSynchronize on the null stream above (implicit) drains. The descriptor table
+    // lives in device memory though, so we round-trip the lookups through a tiny D->H pull via the wrapper's host
+    // mirror path — here we just check that the construction succeeded; per-image width/height behavior is exercised
+    // end-to-end by TestRoundtripCopy.
+    HIP_VALIDATE_NO_ERRORS(hipStreamSynchronize(0));
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    (void)argc;
+    (void)argv;
+    TEST_CASES_BEGIN();
+
+    // Single-channel, heterogeneous sizes.
+    TEST_CASE(TestRoundtripCopy<uchar1>({{16, 12}, {32, 24}, {7, 5}, {48, 9}}, FMT_U8));
+    TEST_CASE(TestRoundtripCopy<float1>({{16, 12}, {32, 24}, {7, 5}, {48, 9}}, FMT_F32));
+
+    // Multi-channel interleaved.
+    TEST_CASE(TestRoundtripCopy<uchar3>({{16, 12}, {32, 24}, {7, 5}, {48, 9}}, FMT_RGB8));
+    TEST_CASE(TestRoundtripCopy<uchar4>({{16, 12}, {32, 24}, {7, 5}, {48, 9}}, FMT_RGBA8));
+
+    // Homogeneous batch — the wrapper should still work when all images share the same shape.
+    TEST_CASE(TestRoundtripCopy<uchar4>({{64, 64}, {64, 64}, {64, 64}}, FMT_RGBA8));
+
+    // Single image, large.
+    TEST_CASE(TestRoundtripCopy<uchar3>({{128, 96}}, FMT_RGB8));
+
+    TEST_CASE(TestAccessors<uchar3>({{16, 12}, {32, 24}, {7, 5}}, FMT_RGB8));
+
+    // BorderWrapper composed over VarShapeImageWrapper: constant-fill via guaranteed-OOB read.
+    TEST_CASE(
+        TestBorderConstantComposition<uchar3>({{16, 12}, {32, 24}, {7, 5}}, FMT_RGB8, make_uchar3(0xAB, 0xCD, 0xEF)));
+    TEST_CASE(TestBorderConstantComposition<uchar4>({{16, 12}, {32, 24}, {7, 5}}, FMT_RGBA8,
+                                                    make_uchar4(0x12, 0x34, 0x56, 0x78)));
+
+    // InterpolationWrapper<NEAREST> composed over VarShapeImageWrapper: integer-coord roundtrip is identity.
+    TEST_CASE(TestInterpolationNearestComposition<uchar1>({{16, 12}, {32, 24}, {7, 5}}, FMT_U8));
+    TEST_CASE(TestInterpolationNearestComposition<uchar3>({{16, 12}, {32, 24}, {7, 5}}, FMT_RGB8));
+    TEST_CASE(TestInterpolationNearestComposition<uchar4>({{16, 12}, {32, 24}, {7, 5}}, FMT_RGBA8));
+
+    TEST_CASES_END();
+}

--- a/tests/roccv/cpp/src/tests/core/wrappers/test_var_shape_image_wrapper.cpp
+++ b/tests/roccv/cpp/src/tests/core/wrappers/test_var_shape_image_wrapper.cpp
@@ -150,8 +150,7 @@ void TestBorderConstantComposition(const std::vector<Size2D>& sizes, ImageFormat
     auto srcData = srcBatch.exportData(stream);
     auto dstData = dstBatch.exportData(stream);
 
-    BorderWrapper<eBorderType::BORDER_TYPE_CONSTANT, VarShapeImageWrapper<T>> srcWrap(VarShapeImageWrapper<T>(srcData),
-                                                                                      borderValue);
+    auto srcWrap = MakeBorderWrapper<eBorderType::BORDER_TYPE_CONSTANT>(VarShapeImageWrapper<T>(srcData), borderValue);
     VarShapeImageWrapper<T> dstWrap(dstData);
 
     for (int32_t i = 0; i < numImages; ++i) {
@@ -186,8 +185,8 @@ void TestBorderConstantComposition(const std::vector<Size2D>& sizes, ImageFormat
 // composes correctly over a VarShape backing.
 template <typename T>
 __global__ void VarShapeInterpNearestKernel(
-    InterpolationWrapper<eBorderType::BORDER_TYPE_REPLICATE, eInterpolationType::INTERP_TYPE_NEAREST,
-                         VarShapeImageWrapper<T>>
+    InterpolationWrapper<eInterpolationType::INTERP_TYPE_NEAREST,
+                         BorderWrapper<eBorderType::BORDER_TYPE_REPLICATE, VarShapeImageWrapper<T>>>
         src,
     VarShapeImageWrapper<T> dst, int32_t n) {
     const int x = blockIdx.x * blockDim.x + threadIdx.x;
@@ -229,10 +228,8 @@ void TestInterpolationNearestComposition(const std::vector<Size2D>& sizes, Image
     auto srcData = srcBatch.exportData(stream);
     auto dstData = dstBatch.exportData(stream);
 
-    using InterpType = InterpolationWrapper<eBorderType::BORDER_TYPE_REPLICATE, eInterpolationType::INTERP_TYPE_NEAREST,
-                                            VarShapeImageWrapper<T>>;
-    using BorderType = BorderWrapper<eBorderType::BORDER_TYPE_REPLICATE, VarShapeImageWrapper<T>>;
-    InterpType srcWrap(BorderType(VarShapeImageWrapper<T>(srcData), T{}));
+    auto srcWrap = MakeInterpolationWrapper<eInterpolationType::INTERP_TYPE_NEAREST>(
+        MakeBorderWrapper<eBorderType::BORDER_TYPE_REPLICATE>(VarShapeImageWrapper<T>(srcData), T{}));
     VarShapeImageWrapper<T> dstWrap(dstData);
 
     for (int32_t i = 0; i < numImages; ++i) {

--- a/tests/roccv/cpp/src/tests/operators/test_op_bilateral_filter.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_bilateral_filter.cpp
@@ -51,8 +51,7 @@ namespace {
 template <typename T, eBorderType borderMode, typename BT = detail::BaseType<T>>
 void GenerateGoldenBilateral(std::vector<BT>& input, std::vector<BT>& output, int32_t batchSize, Size2D imageSize,
                              int diameter, float sigmaColor, float sigmaSpace, T borderValue) {
-    BorderWrapper<borderMode, ImageWrapper<T>> src(ImageWrapper<T>(input, batchSize, imageSize.w, imageSize.h),
-                                                   borderValue);
+    auto src = MakeBorderWrapper<borderMode>(ImageWrapper<T>(input, batchSize, imageSize.w, imageSize.h), borderValue);
     ImageWrapper<T> dst(output, batchSize, imageSize.w, imageSize.h);
     using namespace roccv::detail;
     using Worktype = MakeType<float, NumElements<T>>;

--- a/tests/roccv/cpp/src/tests/operators/test_op_bilateral_filter.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_bilateral_filter.cpp
@@ -24,7 +24,7 @@ THE SOFTWARE.
 #include <core/detail/type_traits.hpp>
 #include <core/detail/vector_utils.hpp>
 #include <core/wrappers/border_wrapper.hpp>
-#include <core/wrappers/image_wrapper.hpp>
+#include <core/wrappers/tensor_wrapper.hpp>
 #include <op_bilateral_filter.hpp>
 
 #include "test_helpers.hpp"
@@ -51,8 +51,8 @@ namespace {
 template <typename T, eBorderType borderMode, typename BT = detail::BaseType<T>>
 void GenerateGoldenBilateral(std::vector<BT>& input, std::vector<BT>& output, int32_t batchSize, Size2D imageSize,
                              int diameter, float sigmaColor, float sigmaSpace, T borderValue) {
-    auto src = MakeBorderWrapper<borderMode>(ImageWrapper<T>(input, batchSize, imageSize.w, imageSize.h), borderValue);
-    ImageWrapper<T> dst(output, batchSize, imageSize.w, imageSize.h);
+    auto src = MakeBorderWrapper<borderMode>(TensorWrapper<T>(input, batchSize, imageSize.w, imageSize.h), borderValue);
+    TensorWrapper<T> dst(output, batchSize, imageSize.w, imageSize.h);
     using namespace roccv::detail;
     using Worktype = MakeType<float, NumElements<T>>;
 

--- a/tests/roccv/cpp/src/tests/operators/test_op_bilateral_filter.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_bilateral_filter.cpp
@@ -51,7 +51,8 @@ namespace {
 template <typename T, eBorderType borderMode, typename BT = detail::BaseType<T>>
 void GenerateGoldenBilateral(std::vector<BT>& input, std::vector<BT>& output, int32_t batchSize, Size2D imageSize,
                              int diameter, float sigmaColor, float sigmaSpace, T borderValue) {
-    BorderWrapper<T, borderMode> src(ImageWrapper<T>(input, batchSize, imageSize.w, imageSize.h), borderValue);
+    BorderWrapper<borderMode, ImageWrapper<T>> src(ImageWrapper<T>(input, batchSize, imageSize.w, imageSize.h),
+                                                   borderValue);
     ImageWrapper<T> dst(output, batchSize, imageSize.w, imageSize.h);
     using namespace roccv::detail;
     using Worktype = MakeType<float, NumElements<T>>;
@@ -179,9 +180,9 @@ int main(int argc, char** argv) {
     TEST_CASE((TestCorrectness<uchar, BORDER_TYPE_CONSTANT>(1, 20, 20, FMT_U8, 0, 50.0f, 1.2f, {0.0, 0.0, 0.0, 0.0},
                                                             eDeviceType::GPU)));
     TEST_CASE((TestCorrectness<uchar3, BORDER_TYPE_REPLICATE>(2, 20, 20, FMT_RGB8, -1, 50.0f, 1.2f,
-                                                             {0.0, 0.0, 0.0, 0.0}, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<float1, BORDER_TYPE_WRAP>(1, 24, 24, FMT_F32, 0, 500.0f, 1.2f,
-                                                         {500.0, 500.0, 0.0, 0.0}, eDeviceType::GPU)));
+                                                              {0.0, 0.0, 0.0, 0.0}, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<float1, BORDER_TYPE_WRAP>(1, 24, 24, FMT_F32, 0, 500.0f, 1.2f, {500.0, 500.0, 0.0, 0.0},
+                                                         eDeviceType::GPU)));
 
     TEST_CASE((TestCorrectness<uchar3, BORDER_TYPE_CONSTANT>(1, 20, 20, FMT_RGB8, 4, 50.0f, 3.0f, {0.0, 0.0, 0.0, 0.0},
                                                              eDeviceType::GPU)));
@@ -288,9 +289,9 @@ int main(int argc, char** argv) {
     TEST_CASE((TestCorrectness<uchar, BORDER_TYPE_CONSTANT>(1, 20, 20, FMT_U8, 0, 50.0f, 1.2f, {0.0, 0.0, 0.0, 0.0},
                                                             eDeviceType::CPU)));
     TEST_CASE((TestCorrectness<uchar3, BORDER_TYPE_REPLICATE>(2, 20, 20, FMT_RGB8, -1, 50.0f, 1.2f,
-                                                             {0.0, 0.0, 0.0, 0.0}, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<float1, BORDER_TYPE_WRAP>(1, 24, 24, FMT_F32, 0, 500.0f, 1.2f,
-                                                         {500.0, 500.0, 0.0, 0.0}, eDeviceType::CPU)));
+                                                              {0.0, 0.0, 0.0, 0.0}, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<float1, BORDER_TYPE_WRAP>(1, 24, 24, FMT_F32, 0, 500.0f, 1.2f, {500.0, 500.0, 0.0, 0.0},
+                                                         eDeviceType::CPU)));
 
     TEST_CASE((TestCorrectness<uchar3, BORDER_TYPE_CONSTANT>(1, 20, 20, FMT_RGB8, 4, 50.0f, 3.0f, {0.0, 0.0, 0.0, 0.0},
                                                              eDeviceType::CPU)));

--- a/tests/roccv/cpp/src/tests/operators/test_op_bnd_box.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_bnd_box.cpp
@@ -23,7 +23,7 @@ THE SOFTWARE.
 #include <algorithm>
 #include <core/detail/casting.hpp>
 #include <core/detail/type_traits.hpp>
-#include <core/wrappers/image_wrapper.hpp>
+#include <core/wrappers/tensor_wrapper.hpp>
 #include <iostream>
 #include <op_bnd_box.hpp>
 
@@ -85,8 +85,8 @@ template <typename T, typename BT = detail::BaseType<T>>
 void GenerateGoldenBndBox(std::vector<BT> &input, std::vector<BT> &output, int32_t batchSize, int32_t width,
                           int32_t height, const BndBoxes &bboxes) {
     // Wrap input/output vectors for simplified data access
-    ImageWrapper<T> src(input, batchSize, width, height);
-    ImageWrapper<T> dst(output, batchSize, width, height);
+    TensorWrapper<T> src(input, batchSize, width, height);
+    TensorWrapper<T> dst(output, batchSize, width, height);
 
     // Working type for internal pixel format, which has 4 channels.
     using WorkType = detail::MakeType<BT, 4>;

--- a/tests/roccv/cpp/src/tests/operators/test_op_brightness_contrast.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_brightness_contrast.cpp
@@ -22,7 +22,7 @@ THE SOFTWARE.
 
 #include <core/detail/casting.hpp>
 #include <core/detail/type_traits.hpp>
-#include <core/wrappers/image_wrapper.hpp>
+#include <core/wrappers/tensor_wrapper.hpp>
 #include <op_brightness_contrast.hpp>
 
 #include "test_helpers.hpp"
@@ -61,8 +61,8 @@ std::vector<BT_DEST> GoldenBrightnessContrast(std::vector<BT_SRC>& input, int32_
     std::vector<BT_DEST> output(input.size());
 
     // Wrap input/output vectors for simplified data access
-    ImageWrapper<SRC_DT> src(input, batchSize, width, height);
-    ImageWrapper<DEST_DT> dst(output, batchSize, width, height);
+    TensorWrapper<SRC_DT> src(input, batchSize, width, height);
+    TensorWrapper<DEST_DT> dst(output, batchSize, width, height);
 
     using work_type = detail::MakeType<BC_DT, detail::NumElements<DEST_DT>>;
 

--- a/tests/roccv/cpp/src/tests/operators/test_op_center_crop.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_center_crop.cpp
@@ -23,7 +23,7 @@ THE SOFTWARE.
 #include <cstdint>
 #include <core/detail/casting.hpp>
 #include <core/detail/type_traits.hpp>
-#include <core/wrappers/image_wrapper.hpp>
+#include <core/wrappers/tensor_wrapper.hpp>
 #include <op_center_crop.hpp>
 #include "test_helpers.hpp"
 
@@ -48,8 +48,8 @@ namespace {
 template <typename T, typename BT = detail::BaseType<T>>
 void GenerateGoldenCrop(std::vector<BT>& input, std::vector<BT>& output, int32_t batchSize, int32_t width, int32_t height, Size2D cropSize) {
     // Wrap input/output vectors for simplified data access
-    ImageWrapper<T> src(input, batchSize, width, height);
-    ImageWrapper<T> dst(output, batchSize, cropSize.w, cropSize.h);
+    TensorWrapper<T> src(input, batchSize, width, height);
+    TensorWrapper<T> dst(output, batchSize, cropSize.w, cropSize.h);
 
     int topLeftX = (width >> 1) - (cropSize.w >> 1);
     int topLeftY = (height >> 1) - (cropSize.h >> 1);

--- a/tests/roccv/cpp/src/tests/operators/test_op_composite.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_composite.cpp
@@ -21,7 +21,7 @@
 
 #include <core/detail/casting.hpp>
 #include <core/detail/type_traits.hpp>
-#include <core/wrappers/image_wrapper.hpp>
+#include <core/wrappers/tensor_wrapper.hpp>
 #include <op_composite.hpp>
 
 #include "test_helpers.hpp"
@@ -56,17 +56,17 @@ std::vector<detail::BaseType<OutputType>> GoldenComposite(std::vector<detail::Ba
     // number of elements as the InputType. For example, if input type is uchar3, working type is float3.
     using WorkType = detail::MakeType<float, detail::NumElements<InputType>>;
 
-    // Wrap input data into ImageWrappers for easy data access
-    ImageWrapper<InputType> fgWrap(foreground, batchSize, width, height);
-    ImageWrapper<InputType> bgWrap(background, batchSize, width, height);
-    ImageWrapper<MaskType> maskWrap(mask, batchSize, width, height);
+    // Wrap input data into TensorWrappers for easy data access
+    TensorWrapper<InputType> fgWrap(foreground, batchSize, width, height);
+    TensorWrapper<InputType> bgWrap(background, batchSize, width, height);
+    TensorWrapper<MaskType> maskWrap(mask, batchSize, width, height);
 
     // Size of the output depends on the requested number of output channels. If it is 3, then the output images will
     // have 3 channels. If it is 4, then an additional alpha channel is added to the output. This alpha channel is
     // always fully on.
     int numOutElements = batchSize * width * height * detail::NumElements<OutputType>;
     std::vector<detail::BaseType<OutputType>> output(numOutElements);
-    ImageWrapper<OutputType> outWrap(output, batchSize, width, height);
+    TensorWrapper<OutputType> outWrap(output, batchSize, width, height);
 
     for (int b = 0; b < batchSize; b++) {
         for (int y = 0; y < height; y++) {

--- a/tests/roccv/cpp/src/tests/operators/test_op_convert_to.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_convert_to.cpp
@@ -22,7 +22,7 @@ THE SOFTWARE.
 
 #include <core/detail/casting.hpp>
 #include <core/detail/type_traits.hpp>
-#include <core/wrappers/image_wrapper.hpp>
+#include <core/wrappers/tensor_wrapper.hpp>
 #include <op_convert_to.hpp>
 
 #include "test_helpers.hpp"
@@ -55,8 +55,8 @@ std::vector<BT_DEST> GoldenConvertTo(std::vector<BT_SRC>& input, int32_t batchSi
     std::vector<BT_DEST> output(input.size());
 
     // Wrap input/output vectors for simplified data access
-    ImageWrapper<SRC_DT> src(input, batchSize, width, height);
-    ImageWrapper<DEST_DT> dst(output, batchSize, width, height);
+    TensorWrapper<SRC_DT> src(input, batchSize, width, height);
+    TensorWrapper<DEST_DT> dst(output, batchSize, width, height);
 
     using AB_DT = decltype(float() * BT_SRC() * BT_DEST());
     using work_type = detail::MakeType<AB_DT, detail::NumElements<DEST_DT>>;

--- a/tests/roccv/cpp/src/tests/operators/test_op_copy_make_border.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_copy_make_border.cpp
@@ -57,7 +57,8 @@ std::vector<BT> GoldenCopyMakeBorder(std::vector<BT> input, int batchSize, Size2
 
     // Wrap the input images in a BorderWrapper to handle out of bounds image behavior. The BorderWrapper has already
     // been tested in another test so it can be used reliably.
-    BorderWrapper<T, BorderType> inputWrap(ImageWrapper<T>(input, batchSize, inputSize.w, inputSize.h), borderVal);
+    BorderWrapper<BorderType, ImageWrapper<T>> inputWrap(ImageWrapper<T>(input, batchSize, inputSize.w, inputSize.h),
+                                                         borderVal);
 
     std::vector<BT> output(batchSize * outputSize.h * outputSize.w * channels);
     ImageWrapper<T> outputWrap(output, batchSize, outputSize.w, outputSize.h);

--- a/tests/roccv/cpp/src/tests/operators/test_op_copy_make_border.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_copy_make_border.cpp
@@ -58,10 +58,10 @@ std::vector<BT> GoldenCopyMakeBorder(std::vector<BT> input, int batchSize, Size2
     // Wrap the input images in a BorderWrapper to handle out of bounds image behavior. The BorderWrapper has already
     // been tested in another test so it can be used reliably.
     auto inputWrap =
-        MakeBorderWrapper<BorderType>(ImageWrapper<T>(input, batchSize, inputSize.w, inputSize.h), borderVal);
+        MakeBorderWrapper<BorderType>(TensorWrapper<T>(input, batchSize, inputSize.w, inputSize.h), borderVal);
 
     std::vector<BT> output(batchSize * outputSize.h * outputSize.w * channels);
-    ImageWrapper<T> outputWrap(output, batchSize, outputSize.w, outputSize.h);
+    TensorWrapper<T> outputWrap(output, batchSize, outputSize.w, outputSize.h);
 
     for (int b = 0; b < batchSize; b++) {
         for (int y = 0; y < outputSize.h; y++) {

--- a/tests/roccv/cpp/src/tests/operators/test_op_copy_make_border.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_copy_make_border.cpp
@@ -57,8 +57,8 @@ std::vector<BT> GoldenCopyMakeBorder(std::vector<BT> input, int batchSize, Size2
 
     // Wrap the input images in a BorderWrapper to handle out of bounds image behavior. The BorderWrapper has already
     // been tested in another test so it can be used reliably.
-    BorderWrapper<BorderType, ImageWrapper<T>> inputWrap(ImageWrapper<T>(input, batchSize, inputSize.w, inputSize.h),
-                                                         borderVal);
+    auto inputWrap =
+        MakeBorderWrapper<BorderType>(ImageWrapper<T>(input, batchSize, inputSize.w, inputSize.h), borderVal);
 
     std::vector<BT> output(batchSize * outputSize.h * outputSize.w * channels);
     ImageWrapper<T> outputWrap(output, batchSize, outputSize.w, outputSize.h);

--- a/tests/roccv/cpp/src/tests/operators/test_op_custom_crop.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_custom_crop.cpp
@@ -22,7 +22,7 @@ THE SOFTWARE.
 #include <algorithm>
 #include <core/detail/casting.hpp>
 #include <core/detail/type_traits.hpp>
-#include <core/wrappers/image_wrapper.hpp>
+#include <core/wrappers/tensor_wrapper.hpp>
 #include <cstdint>
 #include <op_custom_crop.hpp>
 
@@ -50,8 +50,8 @@ template <typename T, typename BT = detail::BaseType<T>>
 void GenerateGoldenCrop(std::vector<BT>& input, std::vector<BT>& output, int32_t batchSize, int32_t width,
                         int32_t height, Box_t cropRect) {
     // Wrap input/output vectors for simplified data access
-    ImageWrapper<T> src(input, batchSize, width, height);
-    ImageWrapper<T> dst(output, batchSize, cropRect.width, cropRect.height);
+    TensorWrapper<T> src(input, batchSize, width, height);
+    TensorWrapper<T> dst(output, batchSize, cropRect.width, cropRect.height);
 
     for (int b = 0; b < batchSize; b++) {
         for (int y = 0; y < cropRect.height; y++) {

--- a/tests/roccv/cpp/src/tests/operators/test_op_cvt_color.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_cvt_color.cpp
@@ -22,7 +22,7 @@ THE SOFTWARE.
 
 #include <core/detail/swizzling.hpp>
 #include <core/detail/type_traits.hpp>
-#include <core/wrappers/image_wrapper.hpp>
+#include <core/wrappers/tensor_wrapper.hpp>
 #include <op_cvt_color.hpp>
 
 #include "test_helpers.hpp"
@@ -34,9 +34,9 @@ namespace {
 
 template <typename T, eSwizzle S, typename BT = detail::BaseType<T>>
 std::vector<BT> GoldenReorder(std::vector<BT>& input, int samples, int width, int height) {
-    ImageWrapper<T> inputWrap(input, samples, width, height);
+    TensorWrapper<T> inputWrap(input, samples, width, height);
     std::vector<BT> output(samples * width * height * detail::NumElements<T>);
-    ImageWrapper<T> outputWrap(output, samples, width, height);
+    TensorWrapper<T> outputWrap(output, samples, width, height);
 
     for (int b = 0; b < samples; b++) {
         for (int y = 0; y < height; y++) {
@@ -51,9 +51,9 @@ std::vector<BT> GoldenReorder(std::vector<BT>& input, int samples, int width, in
 
 template <typename T, eSwizzle S, typename BT = detail::BaseType<T>>
 std::vector<BT> GoldenYUVToRGB(std::vector<BT>& input, int samples, int width, int height, float delta) {
-    ImageWrapper<T> inputWrap(input, samples, width, height);
+    TensorWrapper<T> inputWrap(input, samples, width, height);
     std::vector<BT> output(samples * width * height * detail::NumElements<T>);
-    ImageWrapper<T> outputWrap(output, samples, width, height);
+    TensorWrapper<T> outputWrap(output, samples, width, height);
 
     for (int b = 0; b < samples; b++) {
         for (int y = 0; y < height; y++) {
@@ -77,9 +77,9 @@ std::vector<BT> GoldenYUVToRGB(std::vector<BT>& input, int samples, int width, i
 
 template <typename T, eSwizzle S, typename BT = detail::BaseType<T>>
 std::vector<BT> GoldenRGBToYUV(std::vector<BT>& input, int samples, int width, int height, float delta) {
-    ImageWrapper<T> inputWrap(input, samples, width, height);
+    TensorWrapper<T> inputWrap(input, samples, width, height);
     std::vector<BT> output(samples * width * height * detail::NumElements<T>);
-    ImageWrapper<T> outputWrap(output, samples, width, height);
+    TensorWrapper<T> outputWrap(output, samples, width, height);
 
     for (int b = 0; b < samples; b++) {
         for (int y = 0; y < height; y++) {
@@ -104,11 +104,11 @@ std::vector<BT> GoldenRGBToYUV(std::vector<BT>& input, int samples, int width, i
 
 template <typename T, eSwizzle S, typename BT = detail::BaseType<T>>
 std::vector<BT> GoldenRGBToGrayscale(std::vector<BT>& input, int samples, int width, int height) {
-    ImageWrapper<T> inputWrap(input, samples, width, height);
+    TensorWrapper<T> inputWrap(input, samples, width, height);
     std::vector<BT> output(samples * width * height);
 
     // Output must always be uchar1 for grayscale
-    ImageWrapper<uchar1> outputWrap(output, samples, width, height);
+    TensorWrapper<uchar1> outputWrap(output, samples, width, height);
 
     for (int b = 0; b < samples; b++) {
         for (int y = 0; y < height; y++) {

--- a/tests/roccv/cpp/src/tests/operators/test_op_flip.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_flip.cpp
@@ -23,7 +23,7 @@ THE SOFTWARE.
 #include <algorithm>
 #include <core/detail/casting.hpp>
 #include <core/detail/type_traits.hpp>
-#include <core/wrappers/image_wrapper.hpp>
+#include <core/wrappers/tensor_wrapper.hpp>
 #include <op_flip.hpp>
 #include "test_helpers.hpp"
 
@@ -52,8 +52,8 @@ std::vector<BT> GoldenFlip(std::vector<BT>& input, int32_t batchSize, int32_t wi
     std::vector<BT> output(input.size());
 
     // Wrap input/output vectors for simplified data access
-    ImageWrapper<T> src(input, batchSize, width, height);
-    ImageWrapper<T> dst(output, batchSize, width, height);
+    TensorWrapper<T> src(input, batchSize, width, height);
+    TensorWrapper<T> dst(output, batchSize, width, height);
 
     for (int b = 0; b < batchSize; ++b) {
         for (int y = 0; y < height; ++y) {

--- a/tests/roccv/cpp/src/tests/operators/test_op_gamma_contrast.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_gamma_contrast.cpp
@@ -24,7 +24,7 @@ THE SOFTWARE.
 #include "core/detail/casting.hpp"
 #include "core/detail/type_traits.hpp"
 #include "core/detail/math/vectorized_type_math.hpp"
-#include <core/wrappers/image_wrapper.hpp>
+#include <core/wrappers/tensor_wrapper.hpp>
 #include <iostream>
 #include <op_gamma_contrast.hpp>
 #include "operator_types.h"
@@ -56,8 +56,8 @@ std::vector<BT> GoldenGammaContrast(std::vector<BT>& input, int32_t batchSize, i
     std::vector<BT> output(input.size());
 
     // Wrap input/output vectors for simplified data access
-    ImageWrapper<T> src(input, batchSize, width, height);
-    ImageWrapper<T> dst(output, batchSize, width, height);
+    TensorWrapper<T> src(input, batchSize, width, height);
+    TensorWrapper<T> dst(output, batchSize, width, height);
     using work_type = detail::MakeType<float, detail::NumElements<T>>;
 
     for (int b = 0; b < batchSize; ++b) {

--- a/tests/roccv/cpp/src/tests/operators/test_op_histogram.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_histogram.cpp
@@ -21,7 +21,7 @@ THE SOFTWARE.
 */
 
 #include <algorithm>
-#include <core/wrappers/image_wrapper.hpp>
+#include <core/wrappers/tensor_wrapper.hpp>
 #include <iostream>
 #include <op_histogram.hpp>
 #include <optional>
@@ -57,7 +57,7 @@ std::vector<BT> GoldenHistogram(std::vector<uchar>& input, int32_t batchSize, in
     std::vector<BT> local_histogram(256);
 
     // Wrap the input vector for simplified data access
-    ImageWrapper<uchar> src(input, batchSize, width, height);
+    TensorWrapper<uchar> src(input, batchSize, width, height);
 
     for (int b = 0; b < batchSize; ++b) {
         std::fill(local_histogram.begin(), local_histogram.end(), 0);
@@ -94,8 +94,8 @@ std::vector<BT> GoldenHistogramMask(std::vector<uchar>& input, std::vector<uchar
     std::vector<BT> local_histogram(256);
 
     // Wrap input/mask vectors for simplified data access
-    ImageWrapper<uchar> src(input, batchSize, width, height);
-    ImageWrapper<uchar> maskWrap(mask, batchSize, width, height);
+    TensorWrapper<uchar> src(input, batchSize, width, height);
+    TensorWrapper<uchar> maskWrap(mask, batchSize, width, height);
 
     for (int b = 0; b < batchSize; ++b) {
         std::fill(local_histogram.begin(), local_histogram.end(), 0);

--- a/tests/roccv/cpp/src/tests/operators/test_op_normalize.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_normalize.cpp
@@ -22,7 +22,7 @@ THE SOFTWARE.
 
 #include <core/detail/casting.hpp>
 #include <core/detail/type_traits.hpp>
-#include <core/wrappers/image_wrapper.hpp>
+#include <core/wrappers/tensor_wrapper.hpp>
 #include <op_normalize.hpp>
 
 #include "test_helpers.hpp"

--- a/tests/roccv/cpp/src/tests/operators/test_op_remap.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_remap.cpp
@@ -21,7 +21,7 @@ THE SOFTWARE.
 */
 
 #include <algorithm>
-#include <core/wrappers/image_wrapper.hpp>
+#include <core/wrappers/tensor_wrapper.hpp>
 #include <core/wrappers/interpolation_wrapper.hpp>
 #include <iostream>
 #include <op_remap.hpp>
@@ -97,14 +97,14 @@ std::vector<BT> GoldenRemap(std::vector<BT>& input, int32_t batchSize, int32_t m
 
     // Create interpolation wrapper for input vector
     auto src = MakeInterpolationWrapper<InterpType>(MakeBorderWrapper<BorderType>(
-        ImageWrapper<T>(input, batchSize, inWidth, inHeight), detail::SaturateCast<T>(borderValue)));
+        TensorWrapper<T>(input, batchSize, inWidth, inHeight), detail::SaturateCast<T>(borderValue)));
 
     // Wrap the output vector for simplified data access
-    ImageWrapper<T> dst(output, batchSize, outWidth, outHeight);
+    TensorWrapper<T> dst(output, batchSize, outWidth, outHeight);
 
     // Create an interpolation wrapper for the map tensor
     auto map = MakeInterpolationWrapper<MapInterpType>(
-        MakeBorderWrapper<BorderType>(ImageWrapper<float2>(mapData.data(), mapBatchSize, mapWidth, mapHeight),
+        MakeBorderWrapper<BorderType>(TensorWrapper<float2>(mapData.data(), mapBatchSize, mapWidth, mapHeight),
                                       detail::SaturateCast<float2>(borderValue)));
 
     int2 srcSize = make_int2(src.width(), src.height());

--- a/tests/roccv/cpp/src/tests/operators/test_op_remap.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_remap.cpp
@@ -96,17 +96,16 @@ std::vector<BT> GoldenRemap(std::vector<BT>& input, int32_t batchSize, int32_t m
     std::vector<BT> output(outputSize);
 
     // Create interpolation wrapper for input vector
-    InterpolationWrapper<BorderType, InterpType, ImageWrapper<T>> src((BorderWrapper<BorderType, ImageWrapper<T>>(
-        ImageWrapper<T>(input, batchSize, inWidth, inHeight), detail::SaturateCast<T>(borderValue))));
+    auto src = MakeInterpolationWrapper<InterpType>(MakeBorderWrapper<BorderType>(
+        ImageWrapper<T>(input, batchSize, inWidth, inHeight), detail::SaturateCast<T>(borderValue)));
 
     // Wrap the output vector for simplified data access
     ImageWrapper<T> dst(output, batchSize, outWidth, outHeight);
 
     // Create an interpolation wrapper for the map tensor
-    InterpolationWrapper<BorderType, MapInterpType, ImageWrapper<float2>> map(
-        (BorderWrapper<BorderType, ImageWrapper<float2>>(
-            ImageWrapper<float2>(mapData.data(), mapBatchSize, mapWidth, mapHeight),
-            detail::SaturateCast<float2>(borderValue))));
+    auto map = MakeInterpolationWrapper<MapInterpType>(
+        MakeBorderWrapper<BorderType>(ImageWrapper<float2>(mapData.data(), mapBatchSize, mapWidth, mapHeight),
+                                      detail::SaturateCast<float2>(borderValue)));
 
     int2 srcSize = make_int2(src.width(), src.height());
     int2 dstSize = make_int2(dst.width(), dst.height());

--- a/tests/roccv/cpp/src/tests/operators/test_op_remap.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_remap.cpp
@@ -25,8 +25,9 @@ THE SOFTWARE.
 #include <core/wrappers/interpolation_wrapper.hpp>
 #include <iostream>
 #include <op_remap.hpp>
-#include "core/detail/internal_structs.hpp"
+
 #include "core/detail/casting.hpp"
+#include "core/detail/internal_structs.hpp"
 #include "core/detail/math/vectorized_type_math.hpp"
 #include "core/detail/type_traits.hpp"
 #include "operator_types.h"
@@ -39,11 +40,11 @@ using namespace roccv::detail;
 // Keep all non-entrypoint functions in an anonymous namespace to prevent redefinition errors across translation units.
 namespace {
 
-RemapParams GetRemapParams(const int2 &srcSize, const int2 &dstSize, const int2 &mapSize, bool alignCorners, eRemapType mapValueType)
-{
+RemapParams GetRemapParams(const int2& srcSize, const int2& dstSize, const int2& mapSize, bool alignCorners,
+                           eRemapType mapValueType) {
     RemapParams params;
 
-    switch(mapValueType) {
+    switch (mapValueType) {
         case REMAP_ABSOLUTE:
             params.srcScale = make_float2(0.f, 0.f);
             params.mapScale = StaticCast<float2>(mapSize) / StaticCast<float2>(dstSize);
@@ -54,7 +55,7 @@ RemapParams GetRemapParams(const int2 &srcSize, const int2 &dstSize, const int2 
         case REMAP_ABSOLUTE_NORMALIZED:
             params.srcScale = make_float2(0.f, 0.f);
             params.mapScale = StaticCast<float2>(mapSize) / StaticCast<float2>(dstSize);
-            params.valScale  = (StaticCast<float2>(srcSize) - (alignCorners ? 1.f : 0.f)) / 2.f;
+            params.valScale = (StaticCast<float2>(srcSize) - (alignCorners ? 1.f : 0.f)) / 2.f;
             params.srcOffset = params.valScale - (alignCorners ? 0.f : .5f);
             params.dstOffset = 0.f;
             break;
@@ -87,24 +88,25 @@ RemapParams GetRemapParams(const int2 &srcSize, const int2 &dstSize, const int2 
  */
 template <typename T, eBorderType BorderType, eInterpolationType InterpType, eInterpolationType MapInterpType,
           typename BT = detail::BaseType<T>>
-std::vector<BT> GoldenRemap(std::vector<BT>& input, int32_t batchSize, int32_t mapBatchSize, int32_t inWidth, int32_t inHeight, int32_t outWidth, 
-                            int32_t outHeight, int32_t mapWidth, int32_t mapHeight, std::vector<float2>& mapData, eRemapType mapType, bool alignCorners, float4 borderValue) {
-    
+std::vector<BT> GoldenRemap(std::vector<BT>& input, int32_t batchSize, int32_t mapBatchSize, int32_t inWidth,
+                            int32_t inHeight, int32_t outWidth, int32_t outHeight, int32_t mapWidth, int32_t mapHeight,
+                            std::vector<float2>& mapData, eRemapType mapType, bool alignCorners, float4 borderValue) {
     int channels = detail::NumElements<T>;
     int outputSize = batchSize * outWidth * outHeight * channels;
     std::vector<BT> output(outputSize);
 
     // Create interpolation wrapper for input vector
-    InterpolationWrapper<T, BorderType, InterpType> src((BorderWrapper<T, BorderType>(
+    InterpolationWrapper<BorderType, InterpType, ImageWrapper<T>> src((BorderWrapper<BorderType, ImageWrapper<T>>(
         ImageWrapper<T>(input, batchSize, inWidth, inHeight), detail::SaturateCast<T>(borderValue))));
 
     // Wrap the output vector for simplified data access
     ImageWrapper<T> dst(output, batchSize, outWidth, outHeight);
 
     // Create an interpolation wrapper for the map tensor
-    // InterpolationWrapper<float2, BorderType, MapInterpType> wrappedMapTensor(map, make_float2(0, 0));
-    InterpolationWrapper<float2, BorderType, MapInterpType> map((BorderWrapper<float2, BorderType>(
-        ImageWrapper<float2>(mapData.data(), mapBatchSize, mapWidth, mapHeight), detail::SaturateCast<float2>(borderValue))));
+    InterpolationWrapper<BorderType, MapInterpType, ImageWrapper<float2>> map(
+        (BorderWrapper<BorderType, ImageWrapper<float2>>(
+            ImageWrapper<float2>(mapData.data(), mapBatchSize, mapWidth, mapHeight),
+            detail::SaturateCast<float2>(borderValue))));
 
     int2 srcSize = make_int2(src.width(), src.height());
     int2 dstSize = make_int2(dst.width(), dst.height());
@@ -119,13 +121,12 @@ std::vector<BT> GoldenRemap(std::vector<BT>& input, int32_t batchSize, int32_t m
     for (int b = 0; b < dst.batches(); b++) {
         for (int y = 0; y < dst.height(); y++) {
             for (int x = 0; x < dst.width(); x++) {
-                
                 dstCoord.x = static_cast<float>(x);
                 dstCoord.y = static_cast<float>(y);
-                
+
                 mapCoord.x = (dstCoord.x + params.dstOffset) * params.mapScale.x;
                 mapCoord.y = (dstCoord.y + params.dstOffset) * params.mapScale.y;
-                
+
                 float2 mapValue = map.at((mapBatchSize == 1 ? 0 : b), mapCoord.y, mapCoord.x, 0);
 
                 srcCoord.x = dstCoord.x * params.srcScale.x + mapValue.x * params.valScale.x + params.srcOffset.x;
@@ -162,7 +163,8 @@ std::vector<BT> GoldenRemap(std::vector<BT>& input, int32_t batchSize, int32_t m
  */
 template <typename T, eBorderType BorderType, eInterpolationType InterpType, eInterpolationType MapInterpType,
           typename BT = detail::BaseType<T>>
-void TestCorrectness(int batchSize, int mapBatchSize, int inWidth, int inHeight, int outWidth, int outHeight, int mapWidth, int mapHeight, ImageFormat format, float4 borderValue, eRemapType mapType,
+void TestCorrectness(int batchSize, int mapBatchSize, int inWidth, int inHeight, int outWidth, int outHeight,
+                     int mapWidth, int mapHeight, ImageFormat format, float4 borderValue, eRemapType mapType,
                      bool alignCorners, eDeviceType device) {
     // Create input and output tensor based on test parameters
     Tensor input(batchSize, {inWidth, inHeight}, format, device);
@@ -174,7 +176,7 @@ void TestCorrectness(int batchSize, int mapBatchSize, int inWidth, int inHeight,
 
     // Copy generated input data into input tensor
     CopyVectorIntoTensor(input, inputData);
-    
+
     int mapSize = mapBatchSize * mapWidth * mapHeight;
 
     std::vector<float2> mapData(mapSize);
@@ -188,11 +190,10 @@ void TestCorrectness(int batchSize, int mapBatchSize, int inWidth, int inHeight,
                 }
             }
         }
-    }
-    else if (mapType == REMAP_ABSOLUTE_NORMALIZED) {
+    } else if (mapType == REMAP_ABSOLUTE_NORMALIZED) {
         for (int b = 0; b < mapBatchSize; b++) {
-            for (int y = 0; y < mapHeight; y++){
-                for (int x = 0; x < mapWidth; x++){
+            for (int y = 0; y < mapHeight; y++) {
+                for (int x = 0; x < mapWidth; x++) {
                     float normX = ((2.0f * static_cast<float>(x)) / static_cast<float>(mapWidth - 1)) - 1.0f;
                     float normY = ((2.0f * static_cast<float>(y)) / static_cast<float>(mapHeight - 1)) - 1.0f;
 
@@ -204,11 +205,10 @@ void TestCorrectness(int batchSize, int mapBatchSize, int inWidth, int inHeight,
                 }
             }
         }
-    }
-    else if (mapType == REMAP_RELATIVE_NORMALIZED) {
+    } else if (mapType == REMAP_RELATIVE_NORMALIZED) {
         for (int b = 0; b < mapBatchSize; b++) {
-            for (int y = 0; y < mapHeight; y++){
-                for (int x = 0; x < mapWidth; x++){
+            for (int y = 0; y < mapHeight; y++) {
+                for (int x = 0; x < mapWidth; x++) {
                     // Generate normalized coordinates in [-1, 1] range
                     float normX = ((2.0f * static_cast<float>(x)) / static_cast<float>(mapWidth - 1)) - 1.0f;
                     float normY = ((2.0f * static_cast<float>(y)) / static_cast<float>(mapHeight - 1)) - 1.0f;
@@ -235,7 +235,8 @@ void TestCorrectness(int batchSize, int mapBatchSize, int inWidth, int inHeight,
     hipStream_t stream;
     HIP_VALIDATE_NO_ERRORS(hipStreamCreate(&stream));
     Remap op;
-    op(stream, input, output, mapTensor, InterpType, MapInterpType, mapType, alignCorners, BorderType, borderValue, device);
+    op(stream, input, output, mapTensor, InterpType, MapInterpType, mapType, alignCorners, BorderType, borderValue,
+       device);
     HIP_VALIDATE_NO_ERRORS(hipStreamSynchronize(stream));
     HIP_VALIDATE_NO_ERRORS(hipStreamDestroy(stream));
 
@@ -243,9 +244,9 @@ void TestCorrectness(int batchSize, int mapBatchSize, int inWidth, int inHeight,
     std::vector<BT> result(output.shape().size());
     CopyTensorIntoVector(result, output);
 
-    std::vector<BT> ref = GoldenRemap<T, BorderType, InterpType, MapInterpType>(inputData, batchSize, mapBatchSize, inWidth,
-                                                                                        inHeight, outWidth, outHeight, 
-                                                                                        mapWidth, mapHeight, mapData, mapType, alignCorners, borderValue);
+    std::vector<BT> ref = GoldenRemap<T, BorderType, InterpType, MapInterpType>(
+        inputData, batchSize, mapBatchSize, inWidth, inHeight, outWidth, outHeight, mapWidth, mapHeight, mapData,
+        mapType, alignCorners, borderValue);
 
     // Compare data in actual output versus the generated golden reference image
     CompareVectors(result, ref);
@@ -258,144 +259,186 @@ int main(int argc, char** argv) {
     TEST_CASES_BEGIN();
 
     TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
-                               eInterpolationType::INTERP_TYPE_NEAREST>(
-        1, 1, 480, 360, 480, 360, 480, 360, FMT_U8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, false, eDeviceType::GPU)));
+                               eInterpolationType::INTERP_TYPE_NEAREST>(1, 1, 480, 360, 480, 360, 480, 360, FMT_U8,
+                                                                        make_float4(0.0f, 0.0f, 0.0f, 1.0f),
+                                                                        REMAP_ABSOLUTE, false, eDeviceType::GPU)));
     TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
                                eInterpolationType::INTERP_TYPE_NEAREST>(
-        1, 1, 480, 360, 480, 360, 480, 360, FMT_U8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE_NORMALIZED, false, eDeviceType::GPU)));
+        1, 1, 480, 360, 480, 360, 480, 360, FMT_U8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE_NORMALIZED,
+        false, eDeviceType::GPU)));
     TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
                                eInterpolationType::INTERP_TYPE_NEAREST>(
-        1, 1, 480, 360, 480, 360, 480, 360, FMT_U8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_RELATIVE_NORMALIZED, false, eDeviceType::GPU)));
+        1, 1, 480, 360, 480, 360, 480, 360, FMT_U8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_RELATIVE_NORMALIZED,
+        false, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<uchar3, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
+                               eInterpolationType::INTERP_TYPE_NEAREST>(1, 1, 480, 360, 480, 360, 480, 360, FMT_RGB8,
+                                                                        make_float4(0.0f, 0.0f, 0.0f, 1.0f),
+                                                                        REMAP_ABSOLUTE, false, eDeviceType::GPU)));
     TEST_CASE((TestCorrectness<uchar3, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
                                eInterpolationType::INTERP_TYPE_NEAREST>(
-        1, 1, 480, 360, 480, 360, 480, 360, FMT_RGB8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, false, eDeviceType::GPU)));
+        1, 1, 480, 360, 480, 360, 480, 360, FMT_RGB8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE_NORMALIZED,
+        false, eDeviceType::GPU)));
     TEST_CASE((TestCorrectness<uchar3, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
                                eInterpolationType::INTERP_TYPE_NEAREST>(
-        1, 1, 480, 360, 480, 360, 480, 360, FMT_RGB8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE_NORMALIZED, false, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<uchar3, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
-                               eInterpolationType::INTERP_TYPE_NEAREST>(
-        1, 1, 480, 360, 480, 360, 480, 360, FMT_RGB8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_RELATIVE_NORMALIZED, false, eDeviceType::GPU)));
+        1, 1, 480, 360, 480, 360, 480, 360, FMT_RGB8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_RELATIVE_NORMALIZED,
+        false, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<uchar4, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
+                               eInterpolationType::INTERP_TYPE_NEAREST>(1, 1, 480, 360, 480, 360, 480, 360, FMT_RGBA8,
+                                                                        make_float4(0.0f, 0.0f, 0.0f, 1.0f),
+                                                                        REMAP_ABSOLUTE, false, eDeviceType::GPU)));
     TEST_CASE((TestCorrectness<uchar4, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
                                eInterpolationType::INTERP_TYPE_NEAREST>(
-        1, 1, 480, 360, 480, 360, 480, 360, FMT_RGBA8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, false, eDeviceType::GPU)));
+        1, 1, 480, 360, 480, 360, 480, 360, FMT_RGBA8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE_NORMALIZED,
+        false, eDeviceType::GPU)));
     TEST_CASE((TestCorrectness<uchar4, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
                                eInterpolationType::INTERP_TYPE_NEAREST>(
-        1, 1, 480, 360, 480, 360, 480, 360, FMT_RGBA8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE_NORMALIZED, false, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<uchar4, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
-                               eInterpolationType::INTERP_TYPE_NEAREST>(
-        1, 1, 480, 360, 480, 360, 480, 360, FMT_RGBA8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_RELATIVE_NORMALIZED, false, eDeviceType::GPU)));
-    
-    TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
-                               eInterpolationType::INTERP_TYPE_NEAREST>(
-        1, 1, 480, 360, 480, 360, 480, 360, FMT_U8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, true, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
-                               eInterpolationType::INTERP_TYPE_NEAREST>(
-        1, 1, 480, 360, 480, 360, 480, 360, FMT_U8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE_NORMALIZED, true, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
-                               eInterpolationType::INTERP_TYPE_NEAREST>(
-        1, 1, 480, 360, 480, 360, 480, 360, FMT_U8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_RELATIVE_NORMALIZED, true, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<uchar3, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
-                               eInterpolationType::INTERP_TYPE_NEAREST>(
-        1, 1, 480, 360, 480, 360, 480, 360, FMT_RGB8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, true, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<uchar3, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
-                               eInterpolationType::INTERP_TYPE_NEAREST>(
-        1, 1, 480, 360, 480, 360, 480, 360, FMT_RGB8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE_NORMALIZED, true, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<uchar3, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
-                               eInterpolationType::INTERP_TYPE_NEAREST>(
-        1, 1, 480, 360, 480, 360, 480, 360, FMT_RGB8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_RELATIVE_NORMALIZED, true, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<uchar4, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
-                               eInterpolationType::INTERP_TYPE_NEAREST>(
-        1, 1, 480, 360, 480, 360, 480, 360, FMT_RGBA8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, true, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<uchar4, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
-                               eInterpolationType::INTERP_TYPE_NEAREST>(
-        1, 1, 480, 360, 480, 360, 480, 360, FMT_RGBA8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE_NORMALIZED, true, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<uchar4, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
-                               eInterpolationType::INTERP_TYPE_NEAREST>(
-        1, 1, 480, 360, 480, 360, 480, 360, FMT_RGBA8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_RELATIVE_NORMALIZED, true, eDeviceType::GPU)));
+        1, 1, 480, 360, 480, 360, 480, 360, FMT_RGBA8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_RELATIVE_NORMALIZED,
+        false, eDeviceType::GPU)));
 
     TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
-                               eInterpolationType::INTERP_TYPE_NEAREST>(
-        2, 1, 480, 360, 480, 360, 480, 360, FMT_U8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, false, eDeviceType::GPU)));
+                               eInterpolationType::INTERP_TYPE_NEAREST>(1, 1, 480, 360, 480, 360, 480, 360, FMT_U8,
+                                                                        make_float4(0.0f, 0.0f, 0.0f, 1.0f),
+                                                                        REMAP_ABSOLUTE, true, eDeviceType::GPU)));
     TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
                                eInterpolationType::INTERP_TYPE_NEAREST>(
-        2, 2, 480, 360, 480, 360, 480, 360, FMT_U8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, false, eDeviceType::GPU)));
+        1, 1, 480, 360, 480, 360, 480, 360, FMT_U8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE_NORMALIZED,
+        true, eDeviceType::GPU)));
     TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
                                eInterpolationType::INTERP_TYPE_NEAREST>(
-        2, 1, 480, 360, 480, 360, 480, 360, FMT_U8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, true, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
+        1, 1, 480, 360, 480, 360, 480, 360, FMT_U8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_RELATIVE_NORMALIZED,
+        true, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<uchar3, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
+                               eInterpolationType::INTERP_TYPE_NEAREST>(1, 1, 480, 360, 480, 360, 480, 360, FMT_RGB8,
+                                                                        make_float4(0.0f, 0.0f, 0.0f, 1.0f),
+                                                                        REMAP_ABSOLUTE, true, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<uchar3, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
                                eInterpolationType::INTERP_TYPE_NEAREST>(
-        2, 2, 480, 360, 480, 360, 480, 360, FMT_U8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, true, eDeviceType::GPU)));
+        1, 1, 480, 360, 480, 360, 480, 360, FMT_RGB8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE_NORMALIZED,
+        true, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<uchar3, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
+                               eInterpolationType::INTERP_TYPE_NEAREST>(
+        1, 1, 480, 360, 480, 360, 480, 360, FMT_RGB8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_RELATIVE_NORMALIZED,
+        true, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<uchar4, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
+                               eInterpolationType::INTERP_TYPE_NEAREST>(1, 1, 480, 360, 480, 360, 480, 360, FMT_RGBA8,
+                                                                        make_float4(0.0f, 0.0f, 0.0f, 1.0f),
+                                                                        REMAP_ABSOLUTE, true, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<uchar4, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
+                               eInterpolationType::INTERP_TYPE_NEAREST>(
+        1, 1, 480, 360, 480, 360, 480, 360, FMT_RGBA8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE_NORMALIZED,
+        true, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<uchar4, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
+                               eInterpolationType::INTERP_TYPE_NEAREST>(
+        1, 1, 480, 360, 480, 360, 480, 360, FMT_RGBA8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_RELATIVE_NORMALIZED,
+        true, eDeviceType::GPU)));
 
     TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
-                               eInterpolationType::INTERP_TYPE_NEAREST>(
-        1, 1, 480, 360, 480, 360, 480, 360, FMT_U8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, false, eDeviceType::CPU)));
+                               eInterpolationType::INTERP_TYPE_NEAREST>(2, 1, 480, 360, 480, 360, 480, 360, FMT_U8,
+                                                                        make_float4(0.0f, 0.0f, 0.0f, 1.0f),
+                                                                        REMAP_ABSOLUTE, false, eDeviceType::GPU)));
     TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
-                               eInterpolationType::INTERP_TYPE_NEAREST>(
-        1, 1, 480, 360, 480, 360, 480, 360, FMT_U8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE_NORMALIZED, false, eDeviceType::CPU)));
+                               eInterpolationType::INTERP_TYPE_NEAREST>(2, 2, 480, 360, 480, 360, 480, 360, FMT_U8,
+                                                                        make_float4(0.0f, 0.0f, 0.0f, 1.0f),
+                                                                        REMAP_ABSOLUTE, false, eDeviceType::GPU)));
     TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
-                               eInterpolationType::INTERP_TYPE_NEAREST>(
-        1, 1, 480, 360, 480, 360, 480, 360, FMT_U8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_RELATIVE_NORMALIZED, false, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<uchar3, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
-                               eInterpolationType::INTERP_TYPE_NEAREST>(
-        1, 1, 480, 360, 480, 360, 480, 360, FMT_RGB8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, false, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<uchar3, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
-                               eInterpolationType::INTERP_TYPE_NEAREST>(
-        1, 1, 480, 360, 480, 360, 480, 360, FMT_RGB8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE_NORMALIZED, false, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<uchar3, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
-                               eInterpolationType::INTERP_TYPE_NEAREST>(
-        1, 1, 480, 360, 480, 360, 480, 360, FMT_RGB8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_RELATIVE_NORMALIZED, false, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<uchar4, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
-                               eInterpolationType::INTERP_TYPE_NEAREST>(
-        1, 1, 480, 360, 480, 360, 480, 360, FMT_RGBA8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, false, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<uchar4, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
-                               eInterpolationType::INTERP_TYPE_NEAREST>(
-        1, 1, 480, 360, 480, 360, 480, 360, FMT_RGBA8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE_NORMALIZED, false, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<uchar4, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
-                               eInterpolationType::INTERP_TYPE_NEAREST>(
-        1, 1, 480, 360, 480, 360, 480, 360, FMT_RGBA8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_RELATIVE_NORMALIZED, false, eDeviceType::CPU)));
+                               eInterpolationType::INTERP_TYPE_NEAREST>(2, 1, 480, 360, 480, 360, 480, 360, FMT_U8,
+                                                                        make_float4(0.0f, 0.0f, 0.0f, 1.0f),
+                                                                        REMAP_ABSOLUTE, true, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
+                               eInterpolationType::INTERP_TYPE_NEAREST>(2, 2, 480, 360, 480, 360, 480, 360, FMT_U8,
+                                                                        make_float4(0.0f, 0.0f, 0.0f, 1.0f),
+                                                                        REMAP_ABSOLUTE, true, eDeviceType::GPU)));
 
     TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
-                               eInterpolationType::INTERP_TYPE_NEAREST>(
-        1, 1, 480, 360, 480, 360, 480, 360, FMT_U8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, true, eDeviceType::CPU)));
+                               eInterpolationType::INTERP_TYPE_NEAREST>(1, 1, 480, 360, 480, 360, 480, 360, FMT_U8,
+                                                                        make_float4(0.0f, 0.0f, 0.0f, 1.0f),
+                                                                        REMAP_ABSOLUTE, false, eDeviceType::CPU)));
     TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
                                eInterpolationType::INTERP_TYPE_NEAREST>(
-        1, 1, 480, 360, 480, 360, 480, 360, FMT_U8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE_NORMALIZED, true, eDeviceType::CPU)));
+        1, 1, 480, 360, 480, 360, 480, 360, FMT_U8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE_NORMALIZED,
+        false, eDeviceType::CPU)));
     TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
                                eInterpolationType::INTERP_TYPE_NEAREST>(
-        1, 1, 480, 360, 480, 360, 480, 360, FMT_U8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_RELATIVE_NORMALIZED, true, eDeviceType::CPU)));
+        1, 1, 480, 360, 480, 360, 480, 360, FMT_U8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_RELATIVE_NORMALIZED,
+        false, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uchar3, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
+                               eInterpolationType::INTERP_TYPE_NEAREST>(1, 1, 480, 360, 480, 360, 480, 360, FMT_RGB8,
+                                                                        make_float4(0.0f, 0.0f, 0.0f, 1.0f),
+                                                                        REMAP_ABSOLUTE, false, eDeviceType::CPU)));
     TEST_CASE((TestCorrectness<uchar3, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
                                eInterpolationType::INTERP_TYPE_NEAREST>(
-        1, 1, 480, 360, 480, 360, 480, 360, FMT_RGB8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, true, eDeviceType::CPU)));
+        1, 1, 480, 360, 480, 360, 480, 360, FMT_RGB8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE_NORMALIZED,
+        false, eDeviceType::CPU)));
     TEST_CASE((TestCorrectness<uchar3, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
                                eInterpolationType::INTERP_TYPE_NEAREST>(
-        1, 1, 480, 360, 480, 360, 480, 360, FMT_RGB8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE_NORMALIZED, true, eDeviceType::CPU)));
+        1, 1, 480, 360, 480, 360, 480, 360, FMT_RGB8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_RELATIVE_NORMALIZED,
+        false, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uchar4, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
+                               eInterpolationType::INTERP_TYPE_NEAREST>(1, 1, 480, 360, 480, 360, 480, 360, FMT_RGBA8,
+                                                                        make_float4(0.0f, 0.0f, 0.0f, 1.0f),
+                                                                        REMAP_ABSOLUTE, false, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uchar4, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
+                               eInterpolationType::INTERP_TYPE_NEAREST>(
+        1, 1, 480, 360, 480, 360, 480, 360, FMT_RGBA8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE_NORMALIZED,
+        false, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uchar4, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
+                               eInterpolationType::INTERP_TYPE_NEAREST>(
+        1, 1, 480, 360, 480, 360, 480, 360, FMT_RGBA8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_RELATIVE_NORMALIZED,
+        false, eDeviceType::CPU)));
+
+    TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
+                               eInterpolationType::INTERP_TYPE_NEAREST>(1, 1, 480, 360, 480, 360, 480, 360, FMT_U8,
+                                                                        make_float4(0.0f, 0.0f, 0.0f, 1.0f),
+                                                                        REMAP_ABSOLUTE, true, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
+                               eInterpolationType::INTERP_TYPE_NEAREST>(
+        1, 1, 480, 360, 480, 360, 480, 360, FMT_U8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE_NORMALIZED,
+        true, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
+                               eInterpolationType::INTERP_TYPE_NEAREST>(
+        1, 1, 480, 360, 480, 360, 480, 360, FMT_U8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_RELATIVE_NORMALIZED,
+        true, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uchar3, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
+                               eInterpolationType::INTERP_TYPE_NEAREST>(1, 1, 480, 360, 480, 360, 480, 360, FMT_RGB8,
+                                                                        make_float4(0.0f, 0.0f, 0.0f, 1.0f),
+                                                                        REMAP_ABSOLUTE, true, eDeviceType::CPU)));
     TEST_CASE((TestCorrectness<uchar3, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
                                eInterpolationType::INTERP_TYPE_NEAREST>(
-        1, 1, 480, 360, 480, 360, 480, 360, FMT_RGB8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_RELATIVE_NORMALIZED, true, eDeviceType::CPU)));
+        1, 1, 480, 360, 480, 360, 480, 360, FMT_RGB8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE_NORMALIZED,
+        true, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uchar3, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
+                               eInterpolationType::INTERP_TYPE_NEAREST>(
+        1, 1, 480, 360, 480, 360, 480, 360, FMT_RGB8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_RELATIVE_NORMALIZED,
+        true, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uchar4, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
+                               eInterpolationType::INTERP_TYPE_NEAREST>(1, 1, 480, 360, 480, 360, 480, 360, FMT_RGBA8,
+                                                                        make_float4(0.0f, 0.0f, 0.0f, 1.0f),
+                                                                        REMAP_ABSOLUTE, true, eDeviceType::CPU)));
     TEST_CASE((TestCorrectness<uchar4, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
                                eInterpolationType::INTERP_TYPE_NEAREST>(
-        1, 1, 480, 360, 480, 360, 480, 360, FMT_RGBA8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, true, eDeviceType::CPU)));
+        1, 1, 480, 360, 480, 360, 480, 360, FMT_RGBA8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE_NORMALIZED,
+        true, eDeviceType::CPU)));
     TEST_CASE((TestCorrectness<uchar4, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
                                eInterpolationType::INTERP_TYPE_NEAREST>(
-        1, 1, 480, 360, 480, 360, 480, 360, FMT_RGBA8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE_NORMALIZED, true, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<uchar4, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
-                               eInterpolationType::INTERP_TYPE_NEAREST>(
-        1, 1, 480, 360, 480, 360, 480, 360, FMT_RGBA8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_RELATIVE_NORMALIZED, true, eDeviceType::CPU)));
+        1, 1, 480, 360, 480, 360, 480, 360, FMT_RGBA8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_RELATIVE_NORMALIZED,
+        true, eDeviceType::CPU)));
 
     TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
-                               eInterpolationType::INTERP_TYPE_NEAREST>(
-        2, 1, 480, 360, 480, 360, 480, 360, FMT_U8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, false, eDeviceType::CPU)));
+                               eInterpolationType::INTERP_TYPE_NEAREST>(2, 1, 480, 360, 480, 360, 480, 360, FMT_U8,
+                                                                        make_float4(0.0f, 0.0f, 0.0f, 1.0f),
+                                                                        REMAP_ABSOLUTE, false, eDeviceType::CPU)));
     TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
-                               eInterpolationType::INTERP_TYPE_NEAREST>(
-        2, 2, 480, 360, 480, 360, 480, 360, FMT_U8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, false, eDeviceType::CPU)));
+                               eInterpolationType::INTERP_TYPE_NEAREST>(2, 2, 480, 360, 480, 360, 480, 360, FMT_U8,
+                                                                        make_float4(0.0f, 0.0f, 0.0f, 1.0f),
+                                                                        REMAP_ABSOLUTE, false, eDeviceType::CPU)));
     TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
-                               eInterpolationType::INTERP_TYPE_NEAREST>(
-        2, 1, 480, 360, 480, 360, 480, 360, FMT_U8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, true, eDeviceType::CPU)));
+                               eInterpolationType::INTERP_TYPE_NEAREST>(2, 1, 480, 360, 480, 360, 480, 360, FMT_U8,
+                                                                        make_float4(0.0f, 0.0f, 0.0f, 1.0f),
+                                                                        REMAP_ABSOLUTE, true, eDeviceType::CPU)));
     TEST_CASE((TestCorrectness<uchar1, eBorderType::BORDER_TYPE_CONSTANT, eInterpolationType::INTERP_TYPE_NEAREST,
-                               eInterpolationType::INTERP_TYPE_NEAREST>(
-        2, 2, 480, 360, 480, 360, 480, 360, FMT_U8, make_float4(0.0f, 0.0f, 0.0f, 1.0f), REMAP_ABSOLUTE, true, eDeviceType::CPU)));
-
-
+                               eInterpolationType::INTERP_TYPE_NEAREST>(2, 2, 480, 360, 480, 360, 480, 360, FMT_U8,
+                                                                        make_float4(0.0f, 0.0f, 0.0f, 1.0f),
+                                                                        REMAP_ABSOLUTE, true, eDeviceType::CPU)));
 
     TEST_CASES_END();
 }

--- a/tests/roccv/cpp/src/tests/operators/test_op_resize.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_resize.cpp
@@ -54,9 +54,8 @@ std::vector<BT> GoldenResize(std::vector<detail::BaseType<T>> &input, int batchS
 
     // Use the replicate (or clamping) border mode by default to handle out of bounds conditions with certain
     // interpolation modes.
-    InterpolationWrapper<eBorderType::BORDER_TYPE_REPLICATE, InterpType, ImageWrapper<T>> inputWrap(
-        BorderWrapper<eBorderType::BORDER_TYPE_REPLICATE, ImageWrapper<T>>(
-            ImageWrapper<T>(input, batchSize, inputSize.w, inputSize.h), T{}));
+    auto inputWrap = MakeInterpolationWrapper<InterpType>(MakeBorderWrapper<eBorderType::BORDER_TYPE_REPLICATE>(
+        ImageWrapper<T>(input, batchSize, inputSize.w, inputSize.h), T{}));
 
     // Determine the scaling factor required to map from the output coordinates to the corresponding input coordinates
     // on both the x and y axes.

--- a/tests/roccv/cpp/src/tests/operators/test_op_resize.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_resize.cpp
@@ -54,8 +54,8 @@ std::vector<BT> GoldenResize(std::vector<detail::BaseType<T>> &input, int batchS
 
     // Use the replicate (or clamping) border mode by default to handle out of bounds conditions with certain
     // interpolation modes.
-    InterpolationWrapper<T, eBorderType::BORDER_TYPE_REPLICATE, InterpType> inputWrap(
-        BorderWrapper<T, eBorderType::BORDER_TYPE_REPLICATE>(
+    InterpolationWrapper<eBorderType::BORDER_TYPE_REPLICATE, InterpType, ImageWrapper<T>> inputWrap(
+        BorderWrapper<eBorderType::BORDER_TYPE_REPLICATE, ImageWrapper<T>>(
             ImageWrapper<T>(input, batchSize, inputSize.w, inputSize.h), T{}));
 
     // Determine the scaling factor required to map from the output coordinates to the corresponding input coordinates

--- a/tests/roccv/cpp/src/tests/operators/test_op_resize.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_resize.cpp
@@ -50,12 +50,12 @@ std::vector<BT> GoldenResize(std::vector<detail::BaseType<T>> &input, int batchS
     size_t numOutputElements = batchSize * outputSize.w * outputSize.h * detail::NumElements<T>;
 
     std::vector<detail::BaseType<T>> output(numOutputElements);
-    ImageWrapper<T> outputWrap(output, batchSize, outputSize.w, outputSize.h);
+    TensorWrapper<T> outputWrap(output, batchSize, outputSize.w, outputSize.h);
 
     // Use the replicate (or clamping) border mode by default to handle out of bounds conditions with certain
     // interpolation modes.
     auto inputWrap = MakeInterpolationWrapper<InterpType>(MakeBorderWrapper<eBorderType::BORDER_TYPE_REPLICATE>(
-        ImageWrapper<T>(input, batchSize, inputSize.w, inputSize.h), T{}));
+        TensorWrapper<T>(input, batchSize, inputSize.w, inputSize.h), T{}));
 
     // Determine the scaling factor required to map from the output coordinates to the corresponding input coordinates
     // on both the x and y axes.

--- a/tests/roccv/cpp/src/tests/operators/test_op_rotate.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_rotate.cpp
@@ -67,9 +67,9 @@ std::vector<detail::BaseType<T>> GoldenRotate(std::vector<detail::BaseType<T>>& 
 
     T borderVal = detail::SaturateCast<T>(make_float4(0.0f, 0.0f, 0.0f, 0.0f));
 
-    ImageWrapper<T> outputWrapper(output, batchSize, imageSize.w, imageSize.h);
+    TensorWrapper<T> outputWrapper(output, batchSize, imageSize.w, imageSize.h);
     auto inputWrapper = MakeInterpolationWrapper<InterpType>(MakeBorderWrapper<eBorderType::BORDER_TYPE_CONSTANT>(
-        ImageWrapper<T>(input, batchSize, imageSize.w, imageSize.h), borderVal));
+        TensorWrapper<T>(input, batchSize, imageSize.w, imageSize.h), borderVal));
 
     /**
      * Affine warp for a combined rotation and translate looks like the following when in its inverse representation:

--- a/tests/roccv/cpp/src/tests/operators/test_op_rotate.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_rotate.cpp
@@ -68,9 +68,8 @@ std::vector<detail::BaseType<T>> GoldenRotate(std::vector<detail::BaseType<T>>& 
     T borderVal = detail::SaturateCast<T>(make_float4(0.0f, 0.0f, 0.0f, 0.0f));
 
     ImageWrapper<T> outputWrapper(output, batchSize, imageSize.w, imageSize.h);
-    InterpolationWrapper<eBorderType::BORDER_TYPE_CONSTANT, InterpType, ImageWrapper<T>> inputWrapper(
-        BorderWrapper<eBorderType::BORDER_TYPE_CONSTANT, ImageWrapper<T>>(
-            ImageWrapper<T>(input, batchSize, imageSize.w, imageSize.h), borderVal));
+    auto inputWrapper = MakeInterpolationWrapper<InterpType>(MakeBorderWrapper<eBorderType::BORDER_TYPE_CONSTANT>(
+        ImageWrapper<T>(input, batchSize, imageSize.w, imageSize.h), borderVal));
 
     /**
      * Affine warp for a combined rotation and translate looks like the following when in its inverse representation:

--- a/tests/roccv/cpp/src/tests/operators/test_op_rotate.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_rotate.cpp
@@ -68,9 +68,9 @@ std::vector<detail::BaseType<T>> GoldenRotate(std::vector<detail::BaseType<T>>& 
     T borderVal = detail::SaturateCast<T>(make_float4(0.0f, 0.0f, 0.0f, 0.0f));
 
     ImageWrapper<T> outputWrapper(output, batchSize, imageSize.w, imageSize.h);
-    InterpolationWrapper<T, eBorderType::BORDER_TYPE_CONSTANT, InterpType> inputWrapper(
-        BorderWrapper<T, eBorderType::BORDER_TYPE_CONSTANT>(ImageWrapper<T>(input, batchSize, imageSize.w, imageSize.h),
-                                                            borderVal));
+    InterpolationWrapper<eBorderType::BORDER_TYPE_CONSTANT, InterpType, ImageWrapper<T>> inputWrapper(
+        BorderWrapper<eBorderType::BORDER_TYPE_CONSTANT, ImageWrapper<T>>(
+            ImageWrapper<T>(input, batchSize, imageSize.w, imageSize.h), borderVal));
 
     /**
      * Affine warp for a combined rotation and translate looks like the following when in its inverse representation:

--- a/tests/roccv/cpp/src/tests/operators/test_op_thresholding.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_thresholding.cpp
@@ -24,7 +24,7 @@ THE SOFTWARE.
 #include "core/detail/casting.hpp"
 #include "core/detail/type_traits.hpp"
 #include "core/detail/math/vectorized_type_math.hpp"
-#include <core/wrappers/image_wrapper.hpp>
+#include <core/wrappers/tensor_wrapper.hpp>
 #include <iostream>
 #include <op_thresholding.hpp>
 #include "operator_types.h"
@@ -59,8 +59,8 @@ std::vector<BT> GoldenBinaryThreshold(std::vector<BT>& input, int32_t batchSize,
     std::vector<BT> output(input.size());
 
     // Wrap input/output vectors for simplified data access
-    ImageWrapper<T> src(input, batchSize, width, height);
-    ImageWrapper<T> dst(output, batchSize, width, height);
+    TensorWrapper<T> src(input, batchSize, width, height);
+    TensorWrapper<T> dst(output, batchSize, width, height);
     
     for (int b = 0; b < batchSize; ++b) {
         double th = thresh[b];
@@ -88,8 +88,8 @@ std::vector<BT> GoldenBinaryInvThreshold(std::vector<BT>& input, int32_t batchSi
     std::vector<BT> output(input.size());
 
     // Wrap input/output vectors for simplified data access
-    ImageWrapper<T> src(input, batchSize, width, height);
-    ImageWrapper<T> dst(output, batchSize, width, height);
+    TensorWrapper<T> src(input, batchSize, width, height);
+    TensorWrapper<T> dst(output, batchSize, width, height);
     
     for (int b = 0; b < batchSize; ++b) {
         double th = thresh[b];
@@ -117,8 +117,8 @@ std::vector<BT> GoldenTruncThreshold(std::vector<BT>& input, int32_t batchSize, 
     std::vector<BT> output(input.size());
 
     // Wrap input/output vectors for simplified data access
-    ImageWrapper<T> src(input, batchSize, width, height);
-    ImageWrapper<T> dst(output, batchSize, width, height);
+    TensorWrapper<T> src(input, batchSize, width, height);
+    TensorWrapper<T> dst(output, batchSize, width, height);
     
     for (int b = 0; b < batchSize; ++b) {
         double th = thresh[b];
@@ -145,8 +145,8 @@ std::vector<BT> GoldenToZeroThreshold(std::vector<BT>& input, int32_t batchSize,
     std::vector<BT> output(input.size());
 
     // Wrap input/output vectors for simplified data access
-    ImageWrapper<T> src(input, batchSize, width, height);
-    ImageWrapper<T> dst(output, batchSize, width, height);
+    TensorWrapper<T> src(input, batchSize, width, height);
+    TensorWrapper<T> dst(output, batchSize, width, height);
     
     for (int b = 0; b < batchSize; ++b) {
         double th = thresh[b];
@@ -173,8 +173,8 @@ std::vector<BT> GoldenToZeroInvThreshold(std::vector<BT>& input, int32_t batchSi
     std::vector<BT> output(input.size());
 
     // Wrap input/output vectors for simplified data access
-    ImageWrapper<T> src(input, batchSize, width, height);
-    ImageWrapper<T> dst(output, batchSize, width, height);
+    TensorWrapper<T> src(input, batchSize, width, height);
+    TensorWrapper<T> dst(output, batchSize, width, height);
     
     for (int b = 0; b < batchSize; ++b) {
         double th = thresh[b];

--- a/tests/roccv/cpp/src/tests/operators/test_op_warp_affine.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_warp_affine.cpp
@@ -55,7 +55,7 @@ std::vector<detail::BaseType<T>> GoldenWarpAffine(std::vector<detail::BaseType<T
                                                   const std::array<float, 6>& mat, bool isInverted, int batchSize,
                                                   Size2D inputSize, Size2D outputSize, float4 borderValue) {
     // Create interpolation wrapper for input vector
-    InterpolationWrapper<T, BorderType, InterpType> inputWrap((BorderWrapper<T, BorderType>(
+    InterpolationWrapper<BorderType, InterpType, ImageWrapper<T>> inputWrap((BorderWrapper<BorderType, ImageWrapper<T>>(
         ImageWrapper<T>(input, batchSize, inputSize.w, inputSize.h), detail::SaturateCast<T>(borderValue))));
 
     // Create ImageWrapper for output vector. We also need to create said output vector.

--- a/tests/roccv/cpp/src/tests/operators/test_op_warp_affine.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_warp_affine.cpp
@@ -55,8 +55,8 @@ std::vector<detail::BaseType<T>> GoldenWarpAffine(std::vector<detail::BaseType<T
                                                   const std::array<float, 6>& mat, bool isInverted, int batchSize,
                                                   Size2D inputSize, Size2D outputSize, float4 borderValue) {
     // Create interpolation wrapper for input vector
-    InterpolationWrapper<BorderType, InterpType, ImageWrapper<T>> inputWrap((BorderWrapper<BorderType, ImageWrapper<T>>(
-        ImageWrapper<T>(input, batchSize, inputSize.w, inputSize.h), detail::SaturateCast<T>(borderValue))));
+    auto inputWrap = MakeInterpolationWrapper<InterpType>(MakeBorderWrapper<BorderType>(
+        ImageWrapper<T>(input, batchSize, inputSize.w, inputSize.h), detail::SaturateCast<T>(borderValue)));
 
     // Create ImageWrapper for output vector. We also need to create said output vector.
     std::vector<detail::BaseType<T>> output(batchSize * outputSize.w * outputSize.h * detail::NumElements<T>);

--- a/tests/roccv/cpp/src/tests/operators/test_op_warp_affine.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_warp_affine.cpp
@@ -56,11 +56,11 @@ std::vector<detail::BaseType<T>> GoldenWarpAffine(std::vector<detail::BaseType<T
                                                   Size2D inputSize, Size2D outputSize, float4 borderValue) {
     // Create interpolation wrapper for input vector
     auto inputWrap = MakeInterpolationWrapper<InterpType>(MakeBorderWrapper<BorderType>(
-        ImageWrapper<T>(input, batchSize, inputSize.w, inputSize.h), detail::SaturateCast<T>(borderValue)));
+        TensorWrapper<T>(input, batchSize, inputSize.w, inputSize.h), detail::SaturateCast<T>(borderValue)));
 
-    // Create ImageWrapper for output vector. We also need to create said output vector.
+    // Create TensorWrapper for output vector. We also need to create said output vector.
     std::vector<detail::BaseType<T>> output(batchSize * outputSize.w * outputSize.h * detail::NumElements<T>);
-    ImageWrapper<T> outputWrap(output, batchSize, outputSize.w, outputSize.h);
+    TensorWrapper<T> outputWrap(output, batchSize, outputSize.w, outputSize.h);
 
     // Prepare the transformation matrix. An affine transform is effectively a 3x3 perspective transform with its last
     // row set to [0, 0, 1].

--- a/tests/roccv/cpp/src/tests/operators/test_op_warp_perspective.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_warp_perspective.cpp
@@ -53,11 +53,11 @@ std::vector<detail::BaseType<T>> GoldenWarpPerspective(std::vector<detail::BaseT
                                                        Size2D inputSize, Size2D outputSize, float4 borderValue) {
     // Create interpolation wrapper for input vector
     auto inputWrap = MakeInterpolationWrapper<InterpType>(MakeBorderWrapper<BorderType>(
-        ImageWrapper<T>(input, batchSize, inputSize.w, inputSize.h), detail::SaturateCast<T>(borderValue)));
+        TensorWrapper<T>(input, batchSize, inputSize.w, inputSize.h), detail::SaturateCast<T>(borderValue)));
 
-    // Create ImageWrapper for output vector. We also need to create said output vector.
+    // Create TensorWrapper for output vector. We also need to create said output vector.
     std::vector<detail::BaseType<T>> output(batchSize * outputSize.w * outputSize.h * detail::NumElements<T>);
-    ImageWrapper<T> outputWrap(output, batchSize, outputSize.w, outputSize.h);
+    TensorWrapper<T> outputWrap(output, batchSize, outputSize.w, outputSize.h);
 
     // If given matrix is not the inverted representation of the transformation, we have to invert it first (since we
     // transform from output -> input).

--- a/tests/roccv/cpp/src/tests/operators/test_op_warp_perspective.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_warp_perspective.cpp
@@ -52,7 +52,7 @@ std::vector<detail::BaseType<T>> GoldenWarpPerspective(std::vector<detail::BaseT
                                                        const std::array<float, 9>& mat, bool isInverted, int batchSize,
                                                        Size2D inputSize, Size2D outputSize, float4 borderValue) {
     // Create interpolation wrapper for input vector
-    InterpolationWrapper<T, BorderType, InterpType> inputWrap((BorderWrapper<T, BorderType>(
+    InterpolationWrapper<BorderType, InterpType, ImageWrapper<T>> inputWrap((BorderWrapper<BorderType, ImageWrapper<T>>(
         ImageWrapper<T>(input, batchSize, inputSize.w, inputSize.h), detail::SaturateCast<T>(borderValue))));
 
     // Create ImageWrapper for output vector. We also need to create said output vector.

--- a/tests/roccv/cpp/src/tests/operators/test_op_warp_perspective.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_warp_perspective.cpp
@@ -52,8 +52,8 @@ std::vector<detail::BaseType<T>> GoldenWarpPerspective(std::vector<detail::BaseT
                                                        const std::array<float, 9>& mat, bool isInverted, int batchSize,
                                                        Size2D inputSize, Size2D outputSize, float4 borderValue) {
     // Create interpolation wrapper for input vector
-    InterpolationWrapper<BorderType, InterpType, ImageWrapper<T>> inputWrap((BorderWrapper<BorderType, ImageWrapper<T>>(
-        ImageWrapper<T>(input, batchSize, inputSize.w, inputSize.h), detail::SaturateCast<T>(borderValue))));
+    auto inputWrap = MakeInterpolationWrapper<InterpType>(MakeBorderWrapper<BorderType>(
+        ImageWrapper<T>(input, batchSize, inputSize.w, inputSize.h), detail::SaturateCast<T>(borderValue)));
 
     // Create ImageWrapper for output vector. We also need to create said output vector.
     std::vector<detail::BaseType<T>> output(batchSize * outputSize.w * outputSize.h * detail::NumElements<T>);


### PR DESCRIPTION
## PR Description
- **Code Changes**
  - Adds the required kernel-accessible wrappers for the `ImageBatchVarShape` container.
  - Renames `ImageWrapper` to `TensorWrapper` for clarity purposes. `TensorWrapper` should be used to wrap `Tensor`, while `ImageBatchVarShapeWrapper` wraps its respective `ImageBatchVarShape`.
  - Reworks BorderWrapper and InterpolationWrapper so that they can be composed with either `TensorWrapper` or `ImageBatchVarShapeWrapper`. Reduces potential code duplication.
- **Tests**
  - Adds unit tests for all newly added types. Ensures ImageBatchVarShape can perform a round-trip copy from the GPU to the host while indexing properly. Also tests composability with the BorderWrapper implementation.

## Notes
- Keeping as a draft PR until #151 is merged in. Since this PR is based off of that branch.