### PR TITLE
[New Operator] Initial implementation of Brightness Contrast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The full documentation for rocCV is available at [https://rocm.docs.amd.com/proj
 
 ### Added
 - Added `Reformat` operator.
+- Added `BrightnessContrast` operator
 - Dockerfile support for running rocCV in a container environment.
 
 ### Changed

--- a/docs/reference/rocCV-supported-operators.rst
+++ b/docs/reference/rocCV-supported-operators.rst
@@ -15,6 +15,7 @@ The rocCV is a collection of the following computer vision operators that are su
     "AdvCvtColor","Converts color spaces with explicit BT601/BT709/BT2020 coefficients, including NV12/NV21 paths.","U8","NHWC, HWC"
     "BilateralFilter", "Applies a bilateral filter.", "U8", "NHWC, HWC"
     "BndBox","Draws bounding boxes on the images in a tensor.","U8","NHWC, HWC"
+    "BrightnessContrast", "Adjusts the brightness and contrast on images in a tensor.", "U8, U16, S16, S32, F32", "NHWC, HWC"
     "Composite","Composites two input tensors using a provided alpha mask.","U8, S8, U32, S32, F32","NHWC, HWC"
     "CvtColor","Converts the color space of the images in a tensor.","U8","NHWC, HWC"
     "CopyMakeBorder","Generates a border using a specified border mode around the input tensor.","U8, S8, U32, S32, F32","NHWC"

--- a/docs/supported-operators.md
+++ b/docs/supported-operators.md
@@ -7,6 +7,7 @@ See below for a list of Computer Vision operators rocCV supports.
 |AdvCvtColor|Converts color spaces using explicit BT601/BT709/BT2020 coefficients and supports NV12/NV21 paths.|U8|NHWC, HWC|Both|
 |BilateralFilter|Applies a bilateral filter to reduce image noise while preserving strong edges.|U8, S8, U16, S16, U32, S32, F32, F64|NHWC, HWC|Both|
 |BndBox|Draws rectangular borders using the specified locations, dimensions and colors, in order to show the locations and sizes of objects in an image.|U8, S8|NHWC, HWC|Both|
+|BrightnessContrast|Adjusts the brightness and contrast of an image.|U8, U16, S16, S32, F32|NHWC, HWC|Both|
 |CenterCrop|Crops an image at its center with a given rectangular region.|U8, S8, U16, S16, U32, S32, F32, F64|NHWC, HWC|Both|
 |Composite|Composites two input tensors using a provided alpha mask.|U8, S8, U32, S32, F32|NHWC, HWC|Both|
 |CopyMakeBorder|Generates a border using a specified border mode around the input image.|U8, S8, U16, S16, U32, S32, F32, F64|NHWC, HWC|Both|

--- a/include/kernels/device/brightness_contrast_device.hpp
+++ b/include/kernels/device/brightness_contrast_device.hpp
@@ -42,7 +42,7 @@ __global__ void brightness_contrast(SrcWrapper input, DstWrapper output, BCWrapp
     const int y = threadIdx.y + blockIdx.y * blockDim.y;
     const int batch = blockIdx.z;
 
-    if (x >= output.width() || y >= output.height() || batch >= output.batches()) return;
+    if (x >= output.width() || y >= output.height()) return;
 
     // get the brightness/contrast scalars to apply
     const bc_type brightness = bc_wrappers.brightnessWrapper.at(batch);

--- a/include/kernels/device/brightness_contrast_device.hpp
+++ b/include/kernels/device/brightness_contrast_device.hpp
@@ -1,0 +1,58 @@
+/**
+Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#pragma once
+
+#include <hip/hip_runtime.h>
+
+#include "core/detail/casting.hpp"
+#include "core/detail/type_traits.hpp"
+#include "core/wrappers/image_wrapper.hpp"
+
+namespace Kernels {
+namespace Device {
+template <typename SrcWrapper, typename DstWrapper, typename BCWrappers>
+__global__ void brightness_contrast(SrcWrapper input, DstWrapper output, BCWrappers bc_wrappers) {
+    using namespace roccv::detail;  // For RangeCast, NumElements, etc.
+    using dst_type = typename DstWrapper::ValueType;
+    using bc_type = typename BCWrappers::ValueType;
+
+    // get the pixel coords
+    const int x = threadIdx.x + blockIdx.x * blockDim.x;
+    const int y = threadIdx.y + blockIdx.y * blockDim.y;
+    const int batch = blockIdx.z;
+
+    // get the brightness/contrast scalars to apply
+    const bc_type brightness = bc_wrappers.brightnessWrapper.at(batch)
+    const bc_type contrast = bc_wrappers.contrastWrapper.at(batch)
+    const bc_type brightnessShift = bc_wrappers.brightnessShiftWrapper.at(batch)
+    const bc_type contrastCenter = bc_wrappers.contrastCenterWrapper.at(batch)
+
+    if (x >= output.width() || y >= output.height() || batch >= output.batches()) return;
+
+    // TODO: LEFT OFF HERE
+    work_type src_val = StaticCast<work_type>(input.at(batch, y, x, 0));
+    work_type result = alpha * src_val + beta;
+    output.at(batch, y, x, 0) = SaturateCast<dst_type>(result);
+}
+}  // namespace Device
+}  // namespace Kernels

--- a/include/kernels/host/brightness_contrast_host.hpp
+++ b/include/kernels/host/brightness_contrast_host.hpp
@@ -23,6 +23,7 @@ THE SOFTWARE.
 #pragma once
 
 #include <hip/hip_runtime.h>
+
 #include "core/detail/casting.hpp"
 #include "core/detail/type_traits.hpp"
 #include "core/wrappers/image_wrapper.hpp"
@@ -46,7 +47,8 @@ void brightness_contrast(SrcWrapper input, DstWrapper output, BCWrappers bc_wrap
         for (int y = 0; y < output.height(); y++) {
             for (int x = 0; x < output.width(); x++) {
                 work_type src_val = StaticCast<work_type>(input.at(batch, y, x, 0));
-                work_type result = brightnessShift + brightness * (contrastCenter + contrast * (src_val - contrastCenter));
+                work_type result =
+                    brightnessShift + brightness * (contrastCenter + contrast * (src_val - contrastCenter));
                 output.at(batch, y, x, 0) = SaturateCast<dst_type>(result);
             }
         }

--- a/include/kernels/host/brightness_contrast_host.hpp
+++ b/include/kernels/host/brightness_contrast_host.hpp
@@ -23,36 +23,34 @@ THE SOFTWARE.
 #pragma once
 
 #include <hip/hip_runtime.h>
-
 #include "core/detail/casting.hpp"
 #include "core/detail/type_traits.hpp"
 #include "core/wrappers/image_wrapper.hpp"
 
 namespace Kernels {
-namespace Device {
+namespace Host {
 template <typename SrcWrapper, typename DstWrapper, typename BCWrappers>
-__global__ void brightness_contrast(SrcWrapper input, DstWrapper output, BCWrappers bc_wrappers) {
+void brightness_contrast(SrcWrapper input, DstWrapper output, BCWrappers bc_wrappers) {
     using namespace roccv::detail;
     using dst_type = typename DstWrapper::ValueType;
     using bc_type = typename BCWrappers::ValueType;
     using work_type = MakeType<bc_type, NumElements<dst_type>>;
 
-    // get the pixel coords (=thread)
-    const int x = threadIdx.x + blockIdx.x * blockDim.x;
-    const int y = threadIdx.y + blockIdx.y * blockDim.y;
-    const int batch = blockIdx.z;
+#pragma omp parallel for
+    for (int batch = 0; batch < output.batches(); batch++) {
+        const bc_type brightness = bc_wrappers.brightnessWrapper.at(batch);
+        const bc_type contrast = bc_wrappers.contrastWrapper.at(batch);
+        const bc_type brightnessShift = bc_wrappers.brightnessShiftWrapper.at(batch);
+        const bc_type contrastCenter = bc_wrappers.contrastCenterWrapper.at(batch);
 
-    if (x >= output.width() || y >= output.height() || batch >= output.batches()) return;
-
-    // get the brightness/contrast scalars to apply
-    const bc_type brightness = bc_wrappers.brightnessWrapper.at(batch);
-    const bc_type contrast = bc_wrappers.contrastWrapper.at(batch);
-    const bc_type brightnessShift = bc_wrappers.brightnessShiftWrapper.at(batch);
-    const bc_type contrastCenter = bc_wrappers.contrastCenterWrapper.at(batch);
-
-    work_type src_val = StaticCast<work_type>(input.at(batch, y, x, 0));
-    work_type result = brightnessShift + brightness * (contrastCenter + contrast * (src_val - contrastCenter));
-    output.at(batch, y, x, 0) = SaturateCast<dst_type>(result);
+        for (int y = 0; y < output.height(); y++) {
+            for (int x = 0; x < output.width(); x++) {
+                work_type src_val = StaticCast<work_type>(input.at(batch, y, x, 0));
+                work_type result = brightnessShift + brightness * (contrastCenter + contrast * (src_val - contrastCenter));
+                output.at(batch, y, x, 0) = SaturateCast<dst_type>(result);
+            }
+        }
+    }
 }
-}  // namespace Device
+}  // namespace Host
 }  // namespace Kernels

--- a/include/op_brightness_contrast.hpp
+++ b/include/op_brightness_contrast.hpp
@@ -1,0 +1,80 @@
+/**
+Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+#pragma once
+#include <hip/hip_runtime.h>
+#include <operator_types.h>
+
+#include <i_operator.hpp>
+
+#include "core/tensor.hpp"
+
+namespace roccv {
+/**
+ * @brief Class for managing the Brightness Contrast operator.
+ *
+ */
+class BrightnessContrast final : public IOperator {
+   public:
+    /**
+     * @brief Construct a new Op Brightness Contrast object. The object can be used
+     * to adjust the brightness and contrast of an image.
+     * outputs(x,y) = brightnessShift + brightness * (contrastCenter + contrast * (inputs(x,y) - contrastCenter))
+     * 
+     * Limitations:
+     *
+     * Input:
+     *       Supported TensorLayout(s): [HWC, NHWC]
+     *                        Channels: [1, 2, 3, 4]
+     *       Supported DataType(s):     [U8, U16, S16, S32, F32]
+     *
+     * Output:
+     *       Supported TensorLayout(s): [HWC, NHWC]
+     *                        Channels: [1, 2, 3, 4]
+     *       Supported DataType(s):     [U8, U16, S16, S32, F32]
+     *
+     * Input/Output dependency:
+     *
+     *       Property      |  Input == Output
+     *      -------------- | -------------
+     *       TensorLayout  | Yes
+     *       DataType      | No
+     *       Channels      | Yes
+     *       Width         | Yes
+     *       Height        | Yes
+     *
+     * @param[in] stream The HIP stream to run this operator on.
+     * @param[in] input Input tensor with image data.
+     * @param[out] output  Output tensor for storing modified image data.
+     * @param[in] brightness (Optional) Tensor with brightness multipliers. Can contain 1 or N elements where N is the number of input images.
+     * @param[in] contrast (Optional) Tensor with contrast multipliers. Can contain 1 or N elements where N is the number of input images.
+     * @param[in] brightnessShift (Optional) Tensor with brightness shifts. Can contain 1 or N elements where N is the number of input images.
+     * @param[in] contrastCenter (Optional) Tensor with contrast centers. Can contain 1 or N elements where N is the number of input images.
+     * @param[in] device The device to run this operator on. (Default: GPU)
+     */
+    void operator()(hipStream_t stream, const roccv::Tensor &input, const roccv::Tensor &output,
+                    std::optional<std::reference_wrapper<const Tensor>> brightness, 
+                    std::optional<std::reference_wrapper<const Tensor>> contrast,
+                    std::optional<std::reference_wrapper<const Tensor>> brightnessShift,
+                    std::optional<std::reference_wrapper<const Tensor>> contrastCenter,
+                    eDeviceType device = eDeviceType::GPU) const;
+};
+}  // namespace roccv

--- a/include/op_brightness_contrast.hpp
+++ b/include/op_brightness_contrast.hpp
@@ -38,7 +38,7 @@ class BrightnessContrast final : public IOperator {
      * @brief Construct a new Op Brightness Contrast object. The object can be used
      * to adjust the brightness and contrast of an image.
      * outputs(x,y) = brightnessShift + brightness * (contrastCenter + contrast * (inputs(x,y) - contrastCenter))
-     * 
+     *
      * Limitations:
      *
      * Input:
@@ -64,14 +64,18 @@ class BrightnessContrast final : public IOperator {
      * @param[in] stream The HIP stream to run this operator on.
      * @param[in] input Input tensor with image data.
      * @param[out] output  Output tensor for storing modified image data.
-     * @param[in] brightness (Optional) Tensor with brightness multipliers. Can contain 1 or N elements where N is the number of input images.
-     * @param[in] contrast (Optional) Tensor with contrast multipliers. Can contain 1 or N elements where N is the number of input images.
-     * @param[in] brightnessShift (Optional) Tensor with brightness shifts. Can contain 1 or N elements where N is the number of input images.
-     * @param[in] contrastCenter (Optional) Tensor with contrast centers. Can contain 1 or N elements where N is the number of input images.
+     * @param[in] brightness (Optional) Tensor with brightness multipliers. Can contain 1 or N elements where N is the
+     * number of input images. Default: 1.0.
+     * @param[in] contrast (Optional) Tensor with contrast multipliers. Can contain 1 or N elements where N is the
+     * number of input images. Default: 1.0.
+     * @param[in] brightnessShift (Optional) Tensor with brightness shifts. Can contain 1 or N elements where N is the
+     * number of input images. Default: 0.0.
+     * @param[in] contrastCenter (Optional) Tensor with contrast centers. Can contain 1 or N elements where N is the
+     * number of input images. Default: midpoint of input data type range.
      * @param[in] device The device to run this operator on. (Default: GPU)
      */
     void operator()(hipStream_t stream, const roccv::Tensor &input, const roccv::Tensor &output,
-                    std::optional<std::reference_wrapper<const Tensor>> brightness, 
+                    std::optional<std::reference_wrapper<const Tensor>> brightness,
                     std::optional<std::reference_wrapper<const Tensor>> contrast,
                     std::optional<std::reference_wrapper<const Tensor>> brightnessShift,
                     std::optional<std::reference_wrapper<const Tensor>> contrastCenter,

--- a/include/op_brightness_contrast.hpp
+++ b/include/op_brightness_contrast.hpp
@@ -60,6 +60,7 @@ class BrightnessContrast final : public IOperator {
      *       Channels      | Yes
      *       Width         | Yes
      *       Height        | Yes
+     *       Batch         | Yes
      *
      * @param[in] stream The HIP stream to run this operator on.
      * @param[in] input Input tensor with image data.

--- a/include/operator_types.h
+++ b/include/operator_types.h
@@ -27,6 +27,11 @@ THE SOFTWARE.
 
 #include <vector>
 
+#include "core/tensor.hpp"
+#include "core/exception.hpp"
+#include <optional>
+
+
 typedef enum eInterpolationType {
     INTERP_TYPE_NEAREST = 0,
     INTERP_TYPE_LINEAR = 1,
@@ -86,6 +91,13 @@ typedef enum eThresholdType {
     THRESH_TOZERO = 0x08,
     THRESH_TOZERO_INV = 0x10,
 } eThresholdType;
+
+// for op_brightness_contrast param handling
+typedef enum eBCType {
+    BC_TYPE_DEFAULT = 0,
+    BC_TYPE_BROADCAST = 1,
+    BC_TYPE_PER = 2
+} eBCType;
 
 // Column Major
 typedef float PerspectiveTransform[9];
@@ -186,5 +198,53 @@ class BndBoxes {
    private:
     std::vector<std::vector<BndBox_t>> m_bndboxesVec;
 };
+
+//TODO add comments
+template <typename DT>
+class BCWrapper {
+    public:
+    BCWrapper(std::optional<std::reference_wrapper<const Tensor>> tensor_opt,
+                DT default_val) : default_value(default_val) {
+        if (!tensor_opt.has_value()) {
+            arg_type = eBCType::BC_TYPE_DEFAULT;
+            data = nullptr;
+            batch_stride = -1;
+        } else {
+            const Tensor& tensor = tensor_opt->get();
+            if (tensor.layout() != eTensorLayout::TENSOR_LAYOUT_N) {
+                throw Exception("The given tensor layout is not supported for BCWrapper", eStatusType::NOT_IMPLEMENTED);
+            }
+            arg_type = (tensor.shape(tensor.layout().batch_index()) == 1) ? eBCType::BC_TYPE_BROADCAST : eBCType::BC_TYPE_PER;
+            TensorDataStrided tdata = tensor.exportData<TensorDataStrided>();
+            batch_stride = tdata.stride(tensor.layout().batch_index());
+            data = static_cast<unsigned char*>(tdata.basePtr());
+        }
+    }
+    __device__ __host__ const DT at(int64_t n) const {
+        switch (arg_type) {
+            case eBCType::BC_TYPE_BROADCAST:
+                return *(reinterpret_cast<DT*>(data));
+            case eBCType::BC_TYPE_PER:
+                return *(reinterpret_cast<DT*>(data + (batch_stride * n)));
+            default:
+                return default_value;
+        }
+    }
+
+    private:
+        DT default_value;
+        eBCType arg_type;
+        int64_t batch_stride;
+        unsigned char* data;
+};
+
+template <typename DT>
+struct GroupBCWrappers {
+    BCWrapper<DT> brightness;
+    BCWrapper<DT> contrast;
+    BCWrapper<DT> brightnessShift;
+    BCWrapper<DT> contrastCenter;
+};
+
 
 }  // namespace roccv

--- a/include/operator_types.h
+++ b/include/operator_types.h
@@ -240,10 +240,12 @@ class BCWrapper {
 
 template <typename DT>
 struct GroupBCWrappers {
-    BCWrapper<DT> brightness;
-    BCWrapper<DT> contrast;
-    BCWrapper<DT> brightnessShift;
-    BCWrapper<DT> contrastCenter;
+    using ValueType = DT;
+
+    BCWrapper<DT> brightnessWrapper;
+    BCWrapper<DT> contrastWrapper;
+    BCWrapper<DT> brightnessShiftWrapper;
+    BCWrapper<DT> contrastCenterWrapper;
 };
 
 

--- a/include/operator_types.h
+++ b/include/operator_types.h
@@ -91,13 +91,6 @@ typedef enum eThresholdType {
     THRESH_TOZERO_INV = 0x10,
 } eThresholdType;
 
-// Used to describe params to the Brightness Contrast operator
-typedef enum eBCType {
-    BC_TYPE_DEFAULT = 0,    ///< Use default value.
-    BC_TYPE_BROADCAST = 1,  ///< Broadcast single value to all samples.
-    BC_TYPE_PER = 2         ///< Per-sample values.
-} eBCType;
-
 // Column Major
 typedef float PerspectiveTransform[9];
 
@@ -197,77 +190,4 @@ class BndBoxes {
    private:
     std::vector<std::vector<BndBox_t>> m_bndboxesVec;
 };
-
-/**
- * @brief Wraps parameters to the Brightness Contrast operator for efficient access.
- *
- * @tparam DT Data type of the parameter.
- */
-template <typename DT>
-class BCWrapper {
-   public:
-    /**
-     * @brief Construct a new BCWrapper object.
-     *
-     * @param[in] tensor_opt Optional reference to a 1D tensor containing the parameter values.
-     * @param[in] default_val Default value to use (one for all samples) when tensor is not provided.
-     */
-    BCWrapper(std::optional<std::reference_wrapper<const Tensor>> tensor_opt, DT default_val)
-        : default_value(default_val) {
-        if (!tensor_opt.has_value()) {
-            arg_type = eBCType::BC_TYPE_DEFAULT;
-            data = nullptr;
-            batch_stride = -1;
-        } else {
-            const Tensor &tensor = tensor_opt->get();
-            if (tensor.layout() != eTensorLayout::TENSOR_LAYOUT_N) {
-                throw Exception("The given tensor layout is not supported for BCWrapper", eStatusType::NOT_IMPLEMENTED);
-            }
-            arg_type =
-                (tensor.shape(tensor.layout().batch_index()) == 1) ? eBCType::BC_TYPE_BROADCAST : eBCType::BC_TYPE_PER;
-            TensorDataStrided tdata = tensor.exportData<TensorDataStrided>();
-            batch_stride = tdata.stride(tensor.layout().batch_index());
-            data = static_cast<unsigned char *>(tdata.basePtr());
-        }
-    }
-
-    /**
-     * @brief Retrieves the parameter value for a specific batch index.
-     *
-     * @param n The batch index.
-     * @return The parameter value at the specified batch index.
-     */
-    __device__ __host__ const DT at(int64_t n) const {
-        switch (arg_type) {
-            case eBCType::BC_TYPE_BROADCAST:
-                return *(reinterpret_cast<DT *>(data));
-            case eBCType::BC_TYPE_PER:
-                return *(reinterpret_cast<DT *>(data + (batch_stride * n)));
-            default:
-                return default_value;
-        }
-    }
-
-   private:
-    DT default_value;
-    eBCType arg_type;
-    int64_t batch_stride;
-    unsigned char *data;
-};
-
-/**
- * @brief Groups the four brightness/contrast parameter wrappers.
- *
- * @tparam DT Data type of the parameters.
- */
-template <typename DT>
-struct GroupBCWrappers {
-    using ValueType = DT;
-
-    BCWrapper<DT> brightnessWrapper;
-    BCWrapper<DT> contrastWrapper;
-    BCWrapper<DT> brightnessShiftWrapper;
-    BCWrapper<DT> contrastCenterWrapper;
-};
-
 }  // namespace roccv

--- a/include/operator_types.h
+++ b/include/operator_types.h
@@ -25,12 +25,11 @@ THE SOFTWARE.
 #include <hip/hip_vector_types.h>
 #include <stdint.h>
 
+#include <optional>
 #include <vector>
 
-#include "core/tensor.hpp"
 #include "core/exception.hpp"
-#include <optional>
-
+#include "core/tensor.hpp"
 
 typedef enum eInterpolationType {
     INTERP_TYPE_NEAREST = 0,
@@ -94,9 +93,9 @@ typedef enum eThresholdType {
 
 // Used to describe params to the Brightness Contrast operator
 typedef enum eBCType {
-    BC_TYPE_DEFAULT = 0,      ///< Use default value.
-    BC_TYPE_BROADCAST = 1,    ///< Broadcast single value to all samples.
-    BC_TYPE_PER = 2           ///< Per-sample values.
+    BC_TYPE_DEFAULT = 0,    ///< Use default value.
+    BC_TYPE_BROADCAST = 1,  ///< Broadcast single value to all samples.
+    BC_TYPE_PER = 2         ///< Per-sample values.
 } eBCType;
 
 // Column Major
@@ -213,21 +212,22 @@ class BCWrapper {
      * @param[in] tensor_opt Optional reference to a 1D tensor containing the parameter values.
      * @param[in] default_val Default value to use (one for all samples) when tensor is not provided.
      */
-    BCWrapper(std::optional<std::reference_wrapper<const Tensor>> tensor_opt,
-              DT default_val) : default_value(default_val) {
+    BCWrapper(std::optional<std::reference_wrapper<const Tensor>> tensor_opt, DT default_val)
+        : default_value(default_val) {
         if (!tensor_opt.has_value()) {
             arg_type = eBCType::BC_TYPE_DEFAULT;
             data = nullptr;
             batch_stride = -1;
         } else {
-            const Tensor& tensor = tensor_opt->get();
+            const Tensor &tensor = tensor_opt->get();
             if (tensor.layout() != eTensorLayout::TENSOR_LAYOUT_N) {
                 throw Exception("The given tensor layout is not supported for BCWrapper", eStatusType::NOT_IMPLEMENTED);
             }
-            arg_type = (tensor.shape(tensor.layout().batch_index()) == 1) ? eBCType::BC_TYPE_BROADCAST : eBCType::BC_TYPE_PER;
+            arg_type =
+                (tensor.shape(tensor.layout().batch_index()) == 1) ? eBCType::BC_TYPE_BROADCAST : eBCType::BC_TYPE_PER;
             TensorDataStrided tdata = tensor.exportData<TensorDataStrided>();
             batch_stride = tdata.stride(tensor.layout().batch_index());
-            data = static_cast<unsigned char*>(tdata.basePtr());
+            data = static_cast<unsigned char *>(tdata.basePtr());
         }
     }
 
@@ -240,9 +240,9 @@ class BCWrapper {
     __device__ __host__ const DT at(int64_t n) const {
         switch (arg_type) {
             case eBCType::BC_TYPE_BROADCAST:
-                return *(reinterpret_cast<DT*>(data));
+                return *(reinterpret_cast<DT *>(data));
             case eBCType::BC_TYPE_PER:
-                return *(reinterpret_cast<DT*>(data + (batch_stride * n)));
+                return *(reinterpret_cast<DT *>(data + (batch_stride * n)));
             default:
                 return default_value;
         }
@@ -252,7 +252,7 @@ class BCWrapper {
     DT default_value;
     eBCType arg_type;
     int64_t batch_stride;
-    unsigned char* data;
+    unsigned char *data;
 };
 
 /**
@@ -269,6 +269,5 @@ struct GroupBCWrappers {
     BCWrapper<DT> brightnessShiftWrapper;
     BCWrapper<DT> contrastCenterWrapper;
 };
-
 
 }  // namespace roccv

--- a/include/operator_types.h
+++ b/include/operator_types.h
@@ -92,11 +92,11 @@ typedef enum eThresholdType {
     THRESH_TOZERO_INV = 0x10,
 } eThresholdType;
 
-// for op_brightness_contrast param handling
+// Used to describe params to the Brightness Contrast operator
 typedef enum eBCType {
-    BC_TYPE_DEFAULT = 0,
-    BC_TYPE_BROADCAST = 1,
-    BC_TYPE_PER = 2
+    BC_TYPE_DEFAULT = 0,      ///< Use default value.
+    BC_TYPE_BROADCAST = 1,    ///< Broadcast single value to all samples.
+    BC_TYPE_PER = 2           ///< Per-sample values.
 } eBCType;
 
 // Column Major
@@ -199,12 +199,22 @@ class BndBoxes {
     std::vector<std::vector<BndBox_t>> m_bndboxesVec;
 };
 
-//TODO add comments
+/**
+ * @brief Wraps parameters to the Brightness Contrast operator for efficient access.
+ *
+ * @tparam DT Data type of the parameter.
+ */
 template <typename DT>
 class BCWrapper {
-    public:
+   public:
+    /**
+     * @brief Construct a new BCWrapper object.
+     *
+     * @param[in] tensor_opt Optional reference to a 1D tensor containing the parameter values.
+     * @param[in] default_val Default value to use (one for all samples) when tensor is not provided.
+     */
     BCWrapper(std::optional<std::reference_wrapper<const Tensor>> tensor_opt,
-                DT default_val) : default_value(default_val) {
+              DT default_val) : default_value(default_val) {
         if (!tensor_opt.has_value()) {
             arg_type = eBCType::BC_TYPE_DEFAULT;
             data = nullptr;
@@ -220,6 +230,13 @@ class BCWrapper {
             data = static_cast<unsigned char*>(tdata.basePtr());
         }
     }
+
+    /**
+     * @brief Retrieves the parameter value for a specific batch index.
+     *
+     * @param n The batch index.
+     * @return The parameter value at the specified batch index.
+     */
     __device__ __host__ const DT at(int64_t n) const {
         switch (arg_type) {
             case eBCType::BC_TYPE_BROADCAST:
@@ -231,13 +248,18 @@ class BCWrapper {
         }
     }
 
-    private:
-        DT default_value;
-        eBCType arg_type;
-        int64_t batch_stride;
-        unsigned char* data;
+   private:
+    DT default_value;
+    eBCType arg_type;
+    int64_t batch_stride;
+    unsigned char* data;
 };
 
+/**
+ * @brief Groups the four brightness/contrast parameter wrappers.
+ *
+ * @tparam DT Data type of the parameters.
+ */
 template <typename DT>
 struct GroupBCWrappers {
     using ValueType = DT;

--- a/include/roccv_operators.hpp
+++ b/include/roccv_operators.hpp
@@ -22,6 +22,7 @@ THE SOFTWARE.
 
 #include "op_bilateral_filter.hpp"
 #include "op_bnd_box.hpp"
+#include "op_brightness_contrast.hpp"
 #include "op_composite.hpp"
 #include "op_copy_make_border.hpp"
 #include "op_custom_crop.hpp"

--- a/include/roccv_operators.hpp
+++ b/include/roccv_operators.hpp
@@ -20,15 +20,16 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
+#include "op_adv_cvt_color.hpp"
 #include "op_bilateral_filter.hpp"
 #include "op_bnd_box.hpp"
 #include "op_brightness_contrast.hpp"
+#include "op_center_crop.hpp"
 #include "op_composite.hpp"
+#include "op_convert_to.hpp"
 #include "op_copy_make_border.hpp"
 #include "op_custom_crop.hpp"
-#include "op_center_crop.hpp"
 #include "op_cvt_color.hpp"
-#include "op_adv_cvt_color.hpp"
 #include "op_flip.hpp"
 #include "op_gamma_contrast.hpp"
 #include "op_histogram.hpp"
@@ -40,4 +41,3 @@ THE SOFTWARE.
 #include "op_thresholding.hpp"
 #include "op_warp_affine.hpp"
 #include "op_warp_perspective.hpp"
-#include "op_convert_to.hpp"

--- a/python/include/operators/py_op_brightness_contrast.hpp
+++ b/python/include/operators/py_op_brightness_contrast.hpp
@@ -33,12 +33,16 @@ namespace py = pybind11;
 class PyOpBrightnessContrast {
    public:
     static void Export(py::module& m);
-    static PyTensor Execute(PyTensor& input, eDataType dtype, std::optional<std::reference_wrapper<PyTensor>> brightness,
-                            std::optional<std::reference_wrapper<PyTensor>> contrast, std::optional<std::reference_wrapper<PyTensor>> brightnessShift,
+    static PyTensor Execute(PyTensor& input, eDataType dtype,
+                            std::optional<std::reference_wrapper<PyTensor>> brightness,
+                            std::optional<std::reference_wrapper<PyTensor>> contrast,
+                            std::optional<std::reference_wrapper<PyTensor>> brightnessShift,
                             std::optional<std::reference_wrapper<PyTensor>> contrastCenter,
                             std::optional<std::reference_wrapper<PyStream>> stream, eDeviceType device);
-    static void ExecuteInto(PyTensor& output, PyTensor& input, std::optional<std::reference_wrapper<PyTensor>> brightness,
-                            std::optional<std::reference_wrapper<PyTensor>> contrast, std::optional<std::reference_wrapper<PyTensor>> brightnessShift,
+    static void ExecuteInto(PyTensor& output, PyTensor& input,
+                            std::optional<std::reference_wrapper<PyTensor>> brightness,
+                            std::optional<std::reference_wrapper<PyTensor>> contrast,
+                            std::optional<std::reference_wrapper<PyTensor>> brightnessShift,
                             std::optional<std::reference_wrapper<PyTensor>> contrastCenter,
                             std::optional<std::reference_wrapper<PyStream>> stream, eDeviceType device);
 };

--- a/python/include/operators/py_op_brightness_contrast.hpp
+++ b/python/include/operators/py_op_brightness_contrast.hpp
@@ -1,0 +1,44 @@
+/**
+Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#pragma once
+
+#include <operator_types.h>
+#include <pybind11/pybind11.h>
+
+#include "py_stream.hpp"
+#include "py_tensor.hpp"
+
+namespace py = pybind11;
+
+class PyOpBrightnessContrast {
+   public:
+    static void Export(py::module& m);
+    static PyTensor Execute(PyTensor& input, eDataType dtype, std::optional<std::reference_wrapper<PyTensor>> brightness,
+                            std::optional<std::reference_wrapper<PyTensor>> contrast, std::optional<std::reference_wrapper<PyTensor>> brightnessShift,
+                            std::optional<std::reference_wrapper<PyTensor>> contrastCenter,
+                            std::optional<std::reference_wrapper<PyStream>> stream, eDeviceType device);
+    static void ExecuteInto(PyTensor& output, PyTensor& input, std::optional<std::reference_wrapper<PyTensor>> brightness,
+                            std::optional<std::reference_wrapper<PyTensor>> contrast, std::optional<std::reference_wrapper<PyTensor>> brightnessShift,
+                            std::optional<std::reference_wrapper<PyTensor>> contrastCenter,
+                            std::optional<std::reference_wrapper<PyStream>> stream, eDeviceType device);
+};

--- a/python/src/main.cpp
+++ b/python/src/main.cpp
@@ -23,6 +23,7 @@ THE SOFTWARE.
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
+#include "operators/py_op_adv_cvt_color.hpp"
 #include "operators/py_op_bilateral_filter.hpp"
 #include "operators/py_op_bnd_box.hpp"
 #include "operators/py_op_brightness_contrast.hpp"
@@ -32,7 +33,6 @@ THE SOFTWARE.
 #include "operators/py_op_copy_make_border.hpp"
 #include "operators/py_op_custom_crop.hpp"
 #include "operators/py_op_cvt_color.hpp"
-#include "operators/py_op_adv_cvt_color.hpp"
 #include "operators/py_op_flip.hpp"
 #include "operators/py_op_gamma_contrast.hpp"
 #include "operators/py_op_histogram.hpp"

--- a/python/src/main.cpp
+++ b/python/src/main.cpp
@@ -25,6 +25,7 @@ THE SOFTWARE.
 
 #include "operators/py_op_bilateral_filter.hpp"
 #include "operators/py_op_bnd_box.hpp"
+#include "operators/py_op_brightness_contrast.hpp"
 #include "operators/py_op_center_crop.hpp"
 #include "operators/py_op_composite.hpp"
 #include "operators/py_op_convert_to.hpp"
@@ -75,6 +76,7 @@ PYBIND11_MODULE(rocpycv, m) {
     PyOpCvtColor::Export(m);
     PyOpAdvCvtColor::Export(m);
     PyOpBndBox::Export(m);
+    PyOpBrightnessContrast::Export(m);
     PyOpGammaContrast::Export(m);
     PyOpComposite::Export(m);
     PyOpCopyMakeBorder::Export(m);

--- a/python/src/operators/py_op_brightness_contrast.cpp
+++ b/python/src/operators/py_op_brightness_contrast.cpp
@@ -24,60 +24,71 @@ THE SOFTWARE.
 
 #include <op_brightness_contrast.hpp>
 
-PyTensor PyOpBrightnessContrast::Execute(PyTensor& input, eDataType dtype, std::optional<std::reference_wrapper<PyTensor>> brightness,
-                            std::optional<std::reference_wrapper<PyTensor>> contrast, std::optional<std::reference_wrapper<PyTensor>> brightnessShift,
-                            std::optional<std::reference_wrapper<PyTensor>> contrastCenter,
-                            std::optional<std::reference_wrapper<PyStream>> stream, eDeviceType device) {
+PyTensor PyOpBrightnessContrast::Execute(PyTensor& input, eDataType dtype,
+                                         std::optional<std::reference_wrapper<PyTensor>> brightness,
+                                         std::optional<std::reference_wrapper<PyTensor>> contrast,
+                                         std::optional<std::reference_wrapper<PyTensor>> brightnessShift,
+                                         std::optional<std::reference_wrapper<PyTensor>> contrastCenter,
+                                         std::optional<std::reference_wrapper<PyStream>> stream, eDeviceType device) {
     hipStream_t hipStream = stream.has_value() ? stream.value().get().getStream() : nullptr;
     auto inputTensor = input.getTensor();
-    auto brightnessTensor = brightness.has_value()
-                          ? std::optional<std::reference_wrapper<roccv::Tensor>>(*brightness.value().get().getTensor())
-                          : std::nullopt;
-    auto contrastTensor = contrast.has_value()
-                          ? std::optional<std::reference_wrapper<roccv::Tensor>>(*contrast.value().get().getTensor())
-                          : std::nullopt;
-    auto brightnessShiftTensor = brightnessShift.has_value()
-                          ? std::optional<std::reference_wrapper<roccv::Tensor>>(*brightnessShift.value().get().getTensor())
-                          : std::nullopt;
-    auto contrastCenterTensor = contrastCenter.has_value()
-                          ? std::optional<std::reference_wrapper<roccv::Tensor>>(*contrastCenter.value().get().getTensor())
-                          : std::nullopt;
+    auto brightnessTensor =
+        brightness.has_value()
+            ? std::optional<std::reference_wrapper<roccv::Tensor>>(*brightness.value().get().getTensor())
+            : std::nullopt;
+    auto contrastTensor =
+        contrast.has_value() ? std::optional<std::reference_wrapper<roccv::Tensor>>(*contrast.value().get().getTensor())
+                             : std::nullopt;
+    auto brightnessShiftTensor =
+        brightnessShift.has_value()
+            ? std::optional<std::reference_wrapper<roccv::Tensor>>(*brightnessShift.value().get().getTensor())
+            : std::nullopt;
+    auto contrastCenterTensor =
+        contrastCenter.has_value()
+            ? std::optional<std::reference_wrapper<roccv::Tensor>>(*contrastCenter.value().get().getTensor())
+            : std::nullopt;
 
     auto outputTensor = std::make_shared<roccv::Tensor>(inputTensor->shape(), roccv::DataType(dtype), device);
 
     roccv::BrightnessContrast op;
-    op(hipStream, *inputTensor, *outputTensor, brightnessTensor, contrastTensor, brightnessShiftTensor, contrastCenterTensor, device);
-    return PyTensor(outputTensor);                                        
+    op(hipStream, *inputTensor, *outputTensor, brightnessTensor, contrastTensor, brightnessShiftTensor,
+       contrastCenterTensor, device);
+    return PyTensor(outputTensor);
 }
 
-void PyOpBrightnessContrast::ExecuteInto(PyTensor& output, PyTensor& input, std::optional<std::reference_wrapper<PyTensor>> brightness,
-                            std::optional<std::reference_wrapper<PyTensor>> contrast, std::optional<std::reference_wrapper<PyTensor>> brightnessShift,
-                            std::optional<std::reference_wrapper<PyTensor>> contrastCenter,
-                                            std::optional<std::reference_wrapper<PyStream>> stream, eDeviceType device) {
+void PyOpBrightnessContrast::ExecuteInto(PyTensor& output, PyTensor& input,
+                                         std::optional<std::reference_wrapper<PyTensor>> brightness,
+                                         std::optional<std::reference_wrapper<PyTensor>> contrast,
+                                         std::optional<std::reference_wrapper<PyTensor>> brightnessShift,
+                                         std::optional<std::reference_wrapper<PyTensor>> contrastCenter,
+                                         std::optional<std::reference_wrapper<PyStream>> stream, eDeviceType device) {
     hipStream_t hipStream = stream.has_value() ? stream.value().get().getStream() : nullptr;
-    auto brightnessTensor = brightness.has_value()
-                          ? std::optional<std::reference_wrapper<roccv::Tensor>>(*brightness.value().get().getTensor())
-                          : std::nullopt;
-    auto contrastTensor = contrast.has_value()
-                          ? std::optional<std::reference_wrapper<roccv::Tensor>>(*contrast.value().get().getTensor())
-                          : std::nullopt;
-    auto brightnessShiftTensor = brightnessShift.has_value()
-                          ? std::optional<std::reference_wrapper<roccv::Tensor>>(*brightnessShift.value().get().getTensor())
-                          : std::nullopt;
-    auto contrastCenterTensor = contrastCenter.has_value()
-                          ? std::optional<std::reference_wrapper<roccv::Tensor>>(*contrastCenter.value().get().getTensor())
-                          : std::nullopt;
+    auto brightnessTensor =
+        brightness.has_value()
+            ? std::optional<std::reference_wrapper<roccv::Tensor>>(*brightness.value().get().getTensor())
+            : std::nullopt;
+    auto contrastTensor =
+        contrast.has_value() ? std::optional<std::reference_wrapper<roccv::Tensor>>(*contrast.value().get().getTensor())
+                             : std::nullopt;
+    auto brightnessShiftTensor =
+        brightnessShift.has_value()
+            ? std::optional<std::reference_wrapper<roccv::Tensor>>(*brightnessShift.value().get().getTensor())
+            : std::nullopt;
+    auto contrastCenterTensor =
+        contrastCenter.has_value()
+            ? std::optional<std::reference_wrapper<roccv::Tensor>>(*contrastCenter.value().get().getTensor())
+            : std::nullopt;
 
     roccv::BrightnessContrast op;
-    op(hipStream, *input.getTensor(), *output.getTensor(), brightnessTensor, contrastTensor, brightnessShiftTensor, contrastCenterTensor, device);
+    op(hipStream, *input.getTensor(), *output.getTensor(), brightnessTensor, contrastTensor, brightnessShiftTensor,
+       contrastCenterTensor, device);
 }
-
 
 void PyOpBrightnessContrast::Export(py::module& m) {
     using namespace py::literals;
-    m.def("brightness_contrast", &PyOpBrightnessContrast::Execute, "src"_a, "dtype"_a,
-            "brightness"_a = py::none(), "contrast"_a = py::none(), "brightness_shift"_a = py::none(), "contrast_center"_a = py::none(),
-            py::kw_only(), "stream"_a = nullptr, "device"_a = eDeviceType::GPU, R"pbdoc(
+    m.def("brightness_contrast", &PyOpBrightnessContrast::Execute, "src"_a, "dtype"_a, "brightness"_a = py::none(),
+          "contrast"_a = py::none(), "brightness_shift"_a = py::none(), "contrast_center"_a = py::none(), py::kw_only(),
+          "stream"_a = nullptr, "device"_a = eDeviceType::GPU, R"pbdoc(
             
             Executes the Brightness Contrast operation on the given HIP stream.
 
@@ -87,10 +98,10 @@ void PyOpBrightnessContrast::Export(py::module& m) {
             Args:
                 src (rocpycv.Tensor): Input tensor containing one or more images.
                 dtype (eDataType): Datatype of the output tensor.
-                brightness (rocpycv.Tensor, optional): Brightness multipliers. Can contain 1 or N values where N is the number of input images. Default to 1.0.
-                contrast (rocpycv.Tensor, optional): Contrast multipliers. Can contain 1 or N values where N is the number of input images. Default to 1.0.
-                brightness_shift (rocpycv.Tensor, optional): Brightness shifts. Can contain 1 or N values where N is the number of input images. Default to 0.0.
-                contrast_center (rocpycv.Tensor, optional): Contrast centers. Can contain 1 or N values where N is the number of input images. Default to middle of input type range.
+                brightness (rocpycv.Tensor, optional): Brightness multipliers. Can contain 1 or N values where N is the number of input images. Default: 1.0.
+                contrast (rocpycv.Tensor, optional): Contrast multipliers. Can contain 1 or N values where N is the number of input images. Default: 1.0.
+                brightness_shift (rocpycv.Tensor, optional): Brightness shifts. Can contain 1 or N values where N is the number of input images. Default: 0.0.
+                contrast_center (rocpycv.Tensor, optional): Contrast centers. Can contain 1 or N values where N is the number of input images. Default: midpoint of input data type range.
                 stream (rocpycv.Stream, optional): HIP stream to run this operation on.
                 device (rocpycv.Device, optional): The device to run this operation on. Defaults to GPU.
 
@@ -98,8 +109,8 @@ void PyOpBrightnessContrast::Export(py::module& m) {
                 rocpycv.Tensor: The output tensor.
         )pbdoc");
     m.def("brightness_contrast_into", &PyOpBrightnessContrast::ExecuteInto, "dst"_a, "src"_a,
-            "brightness"_a = py::none(), "contrast"_a = py::none(), "brightness_shift"_a = py::none(), "contrast_center"_a = py::none(),
-            py::kw_only(), "stream"_a = nullptr, "device"_a = eDeviceType::GPU, R"pbdoc(
+          "brightness"_a = py::none(), "contrast"_a = py::none(), "brightness_shift"_a = py::none(),
+          "contrast_center"_a = py::none(), py::kw_only(), "stream"_a = nullptr, "device"_a = eDeviceType::GPU, R"pbdoc(
             
             Executes the  Brightness Contrast operation on the given HIP stream.
 
@@ -109,10 +120,10 @@ void PyOpBrightnessContrast::Export(py::module& m) {
             Args:
                 dst (rocpycv.Tensor): The output tensor which results are written to.
                 src (rocpycv.Tensor): Input tensor containing one or more images.
-                brightness (rocpycv.Tensor, optional): Brightness multipliers. Can contain 1 or N values where N is the number of input images. Default to 1.0.
-                contrast (rocpycv.Tensor, optional): Contrast multipliers. Can contain 1 or N values where N is the number of input images. Default to 1.0.
-                brightness_shift (rocpycv.Tensor, optional): Brightness shifts. Can contain 1 or N values where N is the number of input images. Default to 0.0.
-                contrast_center (rocpycv.Tensor, optional): Contrast centers. Can contain 1 or N values where N is the number of input images. Default to middle of input type range.
+                brightness (rocpycv.Tensor, optional): Brightness multipliers. Can contain 1 or N values where N is the number of input images. Default: 1.0.
+                contrast (rocpycv.Tensor, optional): Contrast multipliers. Can contain 1 or N values where N is the number of input images. Default: 1.0.
+                brightness_shift (rocpycv.Tensor, optional): Brightness shifts. Can contain 1 or N values where N is the number of input images. Default: 0.0.
+                contrast_center (rocpycv.Tensor, optional): Contrast centers. Can contain 1 or N values where N is the number of input images. Default: midpoint of input data type range.
                 stream (rocpycv.Stream, optional): HIP stream to run this operation on.
                 device (rocpycv.Device, optional): The device to run this operation on. Defaults to GPU.
 

--- a/python/src/operators/py_op_brightness_contrast.cpp
+++ b/python/src/operators/py_op_brightness_contrast.cpp
@@ -1,0 +1,122 @@
+/**
+Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#include "operators/py_op_brightness_contrast.hpp"
+
+#include <op_brightness_contrast.hpp>
+
+PyTensor PyOpBrightnessContrast::Execute(PyTensor& input, eDataType dtype, std::optional<std::reference_wrapper<PyTensor>> brightness,
+                            std::optional<std::reference_wrapper<PyTensor>> contrast, std::optional<std::reference_wrapper<PyTensor>> brightnessShift,
+                            std::optional<std::reference_wrapper<PyTensor>> contrastCenter,
+                            std::optional<std::reference_wrapper<PyStream>> stream, eDeviceType device) {
+    hipStream_t hipStream = stream.has_value() ? stream.value().get().getStream() : nullptr;
+    auto inputTensor = input.getTensor();
+    auto brightnessTensor = brightness.has_value()
+                          ? std::optional<std::reference_wrapper<roccv::Tensor>>(*brightness.value().get().getTensor())
+                          : std::nullopt;
+    auto contrastTensor = contrast.has_value()
+                          ? std::optional<std::reference_wrapper<roccv::Tensor>>(*contrast.value().get().getTensor())
+                          : std::nullopt;
+    auto brightnessShiftTensor = brightnessShift.has_value()
+                          ? std::optional<std::reference_wrapper<roccv::Tensor>>(*brightnessShift.value().get().getTensor())
+                          : std::nullopt;
+    auto contrastCenterTensor = contrastCenter.has_value()
+                          ? std::optional<std::reference_wrapper<roccv::Tensor>>(*contrastCenter.value().get().getTensor())
+                          : std::nullopt;
+
+    auto outputTensor = std::make_shared<roccv::Tensor>(inputTensor->shape(), roccv::DataType(dtype), device);
+
+    roccv::BrightnessContrast op;
+    op(hipStream, *inputTensor, *outputTensor, brightnessTensor, contrastTensor, brightnessShiftTensor, contrastCenterTensor, device);
+    return PyTensor(outputTensor);                                        
+}
+
+void PyOpBrightnessContrast::ExecuteInto(PyTensor& output, PyTensor& input, std::optional<std::reference_wrapper<PyTensor>> brightness,
+                            std::optional<std::reference_wrapper<PyTensor>> contrast, std::optional<std::reference_wrapper<PyTensor>> brightnessShift,
+                            std::optional<std::reference_wrapper<PyTensor>> contrastCenter,
+                                            std::optional<std::reference_wrapper<PyStream>> stream, eDeviceType device) {
+    hipStream_t hipStream = stream.has_value() ? stream.value().get().getStream() : nullptr;
+    auto brightnessTensor = brightness.has_value()
+                          ? std::optional<std::reference_wrapper<roccv::Tensor>>(*brightness.value().get().getTensor())
+                          : std::nullopt;
+    auto contrastTensor = contrast.has_value()
+                          ? std::optional<std::reference_wrapper<roccv::Tensor>>(*contrast.value().get().getTensor())
+                          : std::nullopt;
+    auto brightnessShiftTensor = brightnessShift.has_value()
+                          ? std::optional<std::reference_wrapper<roccv::Tensor>>(*brightnessShift.value().get().getTensor())
+                          : std::nullopt;
+    auto contrastCenterTensor = contrastCenter.has_value()
+                          ? std::optional<std::reference_wrapper<roccv::Tensor>>(*contrastCenter.value().get().getTensor())
+                          : std::nullopt;
+
+    roccv::BrightnessContrast op;
+    op(hipStream, *input.getTensor(), *output.getTensor(), brightnessTensor, contrastTensor, brightnessShiftTensor, contrastCenterTensor, device);
+}
+
+
+void PyOpBrightnessContrast::Export(py::module& m) {
+    using namespace py::literals;
+    m.def("brightness_contrast", &PyOpBrightnessContrast::Execute, "src"_a, "dtype"_a,
+            "brightness"_a = py::none(), "contrast"_a = py::none(), "brightness_shift"_a = py::none(), "contrast_center"_a = py::none(),
+            py::kw_only(), "stream"_a = nullptr, "device"_a = eDeviceType::GPU, R"pbdoc(
+            
+            Executes the Brightness Contrast operation on the given HIP stream.
+
+            See also:
+                Refer to the rocCV C++ API reference for more information on this operation.
+            
+            Args:
+                src (rocpycv.Tensor): Input tensor containing one or more images.
+                dtype (eDataType): Datatype of the output tensor.
+                brightness (rocpycv.Tensor, optional): Brightness multipliers. Can contain 1 or N values where N is the number of input images. Default to 1.0.
+                contrast (rocpycv.Tensor, optional): Contrast multipliers. Can contain 1 or N values where N is the number of input images. Default to 1.0.
+                brightness_shift (rocpycv.Tensor, optional): Brightness shifts. Can contain 1 or N values where N is the number of input images. Default to 0.0.
+                contrast_center (rocpycv.Tensor, optional): Contrast centers. Can contain 1 or N values where N is the number of input images. Default to middle of input type range.
+                stream (rocpycv.Stream, optional): HIP stream to run this operation on.
+                device (rocpycv.Device, optional): The device to run this operation on. Defaults to GPU.
+
+            Returns:
+                rocpycv.Tensor: The output tensor.
+        )pbdoc");
+    m.def("brightness_contrast_into", &PyOpBrightnessContrast::ExecuteInto, "dst"_a, "src"_a,
+            "brightness"_a = py::none(), "contrast"_a = py::none(), "brightness_shift"_a = py::none(), "contrast_center"_a = py::none(),
+            py::kw_only(), "stream"_a = nullptr, "device"_a = eDeviceType::GPU, R"pbdoc(
+            
+            Executes the  Brightness Contrast operation on the given HIP stream.
+
+            See also:
+                Refer to the rocCV C++ API reference for more information on this operation.
+            
+            Args:
+                dst (rocpycv.Tensor): The output tensor which results are written to.
+                src (rocpycv.Tensor): Input tensor containing one or more images.
+                brightness (rocpycv.Tensor, optional): Brightness multipliers. Can contain 1 or N values where N is the number of input images. Default to 1.0.
+                contrast (rocpycv.Tensor, optional): Contrast multipliers. Can contain 1 or N values where N is the number of input images. Default to 1.0.
+                brightness_shift (rocpycv.Tensor, optional): Brightness shifts. Can contain 1 or N values where N is the number of input images. Default to 0.0.
+                contrast_center (rocpycv.Tensor, optional): Contrast centers. Can contain 1 or N values where N is the number of input images. Default to middle of input type range.
+                stream (rocpycv.Stream, optional): HIP stream to run this operation on.
+                device (rocpycv.Device, optional): The device to run this operation on. Defaults to GPU.
+
+            Returns:
+                None
+        )pbdoc");
+}

--- a/src/op_brightness_contrast.cpp
+++ b/src/op_brightness_contrast.cpp
@@ -33,9 +33,9 @@ THE SOFTWARE.
 
 namespace roccv {
 
-template <typename BC_DT, typename SRC_DT, typename DST_DT, int NC>
+template <typename BCWrappers, typename SRC_DT, typename DST_DT, int NC>
 void dispatch_brightness_contrast_channels(hipStream_t stream, const Tensor &input, const Tensor &output,
-                                            const GroupBCWrappers<BC_DT> &bc_wrappers, eDeviceType device) {
+                                            const BCWrappers &bc_wrappers, eDeviceType device) {
     
     using SRC_DT_NC = detail::MakeType<SRC_DT, NC>;
     using DST_DT_NC = detail::MakeType<DST_DT, NC>;
@@ -49,7 +49,7 @@ void dispatch_brightness_contrast_channels(hipStream_t stream, const Tensor &inp
             dim3 block(64, 16);
             dim3 grid((outputWrapper.width() + block.x - 1) / block.x, (outputWrapper.height() + block.y - 1) / block.y,
                       outputWrapper.batches());
-            //Kernels::Device::brightness_contrast<<<grid, block, 0, stream>>>(inputWrapper, outputWrapper, bc_wrappers);
+            Kernels::Device::brightness_contrast<<<grid, block, 0, stream>>>(inputWrapper, outputWrapper, bc_wrappers);
             break;
         }
         case eDeviceType::CPU: {
@@ -59,15 +59,15 @@ void dispatch_brightness_contrast_channels(hipStream_t stream, const Tensor &inp
     }
 }
 
-template <typename BC_DT, typename SRC_DT, typename DST_DT>
+template <typename BCWrappers, typename SRC_DT, typename DST_DT>
 void dispatch_brightness_contrast_output_dtype(hipStream_t stream, const Tensor &input, const Tensor &output,
-                                       const GroupBCWrappers<BC_DT> &bc_wrappers, eDeviceType device) {
+                                       const BCWrappers &bc_wrappers, eDeviceType device) {
 
     int64_t channels = output.shape(output.layout().channels_index());
     // 4) Select kernel dispatcher based on number of channels.
     // clang-format off
-    static const std::array<std::function<void(hipStream_t, const Tensor &, const Tensor &, const GroupBCWrappers<BC_DT> &, eDeviceType)>, 4>
-        funcs = {dispatch_brightness_contrast_channels<BC_DT, SRC_DT, DST_DT, 1>, dispatch_brightness_contrast_channels<BC_DT, SRC_DT, DST_DT, 2>, dispatch_brightness_contrast_channels<BC_DT, SRC_DT, DST_DT, 3>, dispatch_brightness_contrast_channels<BC_DT, SRC_DT, DST_DT, 4>};
+    static const std::array<std::function<void(hipStream_t, const Tensor &, const Tensor &, const BCWrappers &, eDeviceType)>, 4>
+        funcs = {dispatch_brightness_contrast_channels<BCWrappers, SRC_DT, DST_DT, 1>, dispatch_brightness_contrast_channels<BCWrappers, SRC_DT, DST_DT, 2>, dispatch_brightness_contrast_channels<BCWrappers, SRC_DT, DST_DT, 3>, dispatch_brightness_contrast_channels<BCWrappers, SRC_DT, DST_DT, 4>};
     // clang-format on
 
     auto func = funcs.at(channels - 1);
@@ -75,21 +75,21 @@ void dispatch_brightness_contrast_output_dtype(hipStream_t stream, const Tensor 
     func(stream, input, output, bc_wrappers, device);
 }
 
-template <typename BC_DT, typename SRC_DT>
+template <typename BCWrappers, typename SRC_DT>
 void dispatch_brightness_contrast_input_dtype(hipStream_t stream, const Tensor &input, const Tensor &output,
-                                            const GroupBCWrappers<BC_DT> &bc_wrappers, eDeviceType device) {
+                                            const BCWrappers &bc_wrappers, eDeviceType device) {
     
     eDataType output_dtype = output.dtype().etype();
     
     // 3) Select kernel dispatcher based on a base output datatype.
     // clang-format off
-    static const std::unordered_map<eDataType, std::function<void(hipStream_t, const Tensor &, const Tensor &, const GroupBCWrappers<BC_DT> &, eDeviceType)>>
+    static const std::unordered_map<eDataType, std::function<void(hipStream_t, const Tensor &, const Tensor &, const BCWrappers &, eDeviceType)>>
         funcs = {
-            {eDataType::DATA_TYPE_U8, dispatch_brightness_contrast_output_dtype<BC_DT, SRC_DT, uchar>},
-            {eDataType::DATA_TYPE_U16,  dispatch_brightness_contrast_output_dtype<BC_DT, SRC_DT, ushort>},
-            {eDataType::DATA_TYPE_S16,  dispatch_brightness_contrast_output_dtype<BC_DT, SRC_DT, short>},
-            {eDataType::DATA_TYPE_S32,  dispatch_brightness_contrast_output_dtype<BC_DT, SRC_DT, int>},
-            {eDataType::DATA_TYPE_F32, dispatch_brightness_contrast_output_dtype<BC_DT, SRC_DT, float>},
+            {eDataType::DATA_TYPE_U8, dispatch_brightness_contrast_output_dtype<BCWrappers, SRC_DT, uchar>},
+            {eDataType::DATA_TYPE_U16,  dispatch_brightness_contrast_output_dtype<BCWrappers, SRC_DT, ushort>},
+            {eDataType::DATA_TYPE_S16,  dispatch_brightness_contrast_output_dtype<BCWrappers, SRC_DT, short>},
+            {eDataType::DATA_TYPE_S32,  dispatch_brightness_contrast_output_dtype<BCWrappers, SRC_DT, int>},
+            {eDataType::DATA_TYPE_F32, dispatch_brightness_contrast_output_dtype<BCWrappers, SRC_DT, float>},
         };
     // clang-format on
     auto func = funcs.at(output_dtype);
@@ -98,21 +98,21 @@ void dispatch_brightness_contrast_input_dtype(hipStream_t stream, const Tensor &
 
 }
 
-template <typename BC_DT>
+template <typename BCWrappers>
 void dispatch_brightness_contrast_bc_dtype(hipStream_t stream, const Tensor &input, const Tensor &output,
-                                        const GroupBCWrappers<BC_DT> &bc_wrappers, eDeviceType device) {
+                                        const BCWrappers &bc_wrappers, eDeviceType device) {
     
     eDataType input_dtype = input.dtype().etype();
 
     // 2) Select kernel dispatcher based on a base input datatype.
     // clang-format off
-    static const std::unordered_map<eDataType, std::function<void(hipStream_t, const Tensor &, const Tensor &, const GroupBCWrappers<BC_DT> &, eDeviceType)>>
+    static const std::unordered_map<eDataType, std::function<void(hipStream_t, const Tensor &, const Tensor &, const BCWrappers &, eDeviceType)>>
         funcs = {
-            {eDataType::DATA_TYPE_U8, dispatch_brightness_contrast_input_dtype<BC_DT, uchar>},
-            {eDataType::DATA_TYPE_U16,  dispatch_brightness_contrast_input_dtype<BC_DT, ushort>},
-            {eDataType::DATA_TYPE_S16,  dispatch_brightness_contrast_input_dtype<BC_DT, short>},
-            {eDataType::DATA_TYPE_S32,  dispatch_brightness_contrast_input_dtype<BC_DT, int>},
-            {eDataType::DATA_TYPE_F32, dispatch_brightness_contrast_input_dtype<BC_DT, float>},
+            {eDataType::DATA_TYPE_U8, dispatch_brightness_contrast_input_dtype<BCWrappers, uchar>},
+            {eDataType::DATA_TYPE_U16,  dispatch_brightness_contrast_input_dtype<BCWrappers, ushort>},
+            {eDataType::DATA_TYPE_S16,  dispatch_brightness_contrast_input_dtype<BCWrappers, short>},
+            {eDataType::DATA_TYPE_S32,  dispatch_brightness_contrast_input_dtype<BCWrappers, int>},
+            {eDataType::DATA_TYPE_F32, dispatch_brightness_contrast_input_dtype<BCWrappers, float>},
         };
     // clang-format on
     auto func = funcs.at(input_dtype);
@@ -183,7 +183,7 @@ void BrightnessContrast::operator()(hipStream_t stream, const roccv::Tensor &inp
             BCWrapper<float>(brightnessShift, 0.0f),
             BCWrapper<float>(contrastCenter, compute_cc_default())
         };
-        dispatch_brightness_contrast_bc_dtype<float>(stream, input, output, wrappers, device);
+        dispatch_brightness_contrast_bc_dtype<GroupBCWrappers<float>>(stream, input, output, wrappers, device);
     } else if (bc_dtype == eDataType::DATA_TYPE_F64) {
         GroupBCWrappers<double> wrappers {
             BCWrapper<double>(brightness, 1.0),
@@ -191,7 +191,7 @@ void BrightnessContrast::operator()(hipStream_t stream, const roccv::Tensor &inp
             BCWrapper<double>(brightnessShift, 0.0),
             BCWrapper<double>(contrastCenter, compute_cc_default())
         };
-        dispatch_brightness_contrast_bc_dtype<double>(stream, input, output, wrappers, device);
+        dispatch_brightness_contrast_bc_dtype<GroupBCWrappers<double>>(stream, input, output, wrappers, device);
     } else {
         throw Exception("Not mapped to a defined function.", eStatusType::INVALID_OPERATION);
     }

--- a/src/op_brightness_contrast.cpp
+++ b/src/op_brightness_contrast.cpp
@@ -32,6 +32,65 @@ THE SOFTWARE.
 #include "kernels/device/brightness_contrast_device.hpp"
 #include "kernels/host/brightness_contrast_host.hpp"
 
+namespace {
+using namespace roccv;
+typedef enum eBCType {
+    BC_TYPE_DEFAULT = 0,    ///< Use default value.
+    BC_TYPE_BROADCAST = 1,  ///< Broadcast single value to all samples.
+    BC_TYPE_PER = 2         ///< Per-sample values.
+} eBCType;
+
+template <typename DT>
+class BCWrapper {
+   public:
+    BCWrapper(std::optional<std::reference_wrapper<const Tensor>> tensor_opt, DT default_val)
+        : default_value(default_val) {
+        if (!tensor_opt.has_value()) {
+            arg_type = eBCType::BC_TYPE_DEFAULT;
+            data = nullptr;
+            batch_stride = -1;
+        } else {
+            const Tensor &tensor = tensor_opt->get();
+            if (tensor.layout() != eTensorLayout::TENSOR_LAYOUT_N) {
+                throw Exception("The given tensor layout is not supported for BCWrapper", eStatusType::NOT_IMPLEMENTED);
+            }
+            arg_type =
+                (tensor.shape(tensor.layout().batch_index()) == 1) ? eBCType::BC_TYPE_BROADCAST : eBCType::BC_TYPE_PER;
+            TensorDataStrided tdata = tensor.exportData<TensorDataStrided>();
+            batch_stride = tdata.stride(tensor.layout().batch_index());
+            data = static_cast<unsigned char *>(tdata.basePtr());
+        }
+    }
+
+    __device__ __host__ const DT at(int64_t n) const {
+        switch (arg_type) {
+            case eBCType::BC_TYPE_BROADCAST:
+                return *(reinterpret_cast<DT *>(data));
+            case eBCType::BC_TYPE_PER:
+                return *(reinterpret_cast<DT *>(data + (batch_stride * n)));
+            default:
+                return default_value;
+        }
+    }
+
+   private:
+    DT default_value;
+    eBCType arg_type;
+    int64_t batch_stride;
+    unsigned char *data;
+};
+
+template <typename DT>
+struct GroupBCWrappers {
+    using ValueType = DT;
+
+    BCWrapper<DT> brightnessWrapper;
+    BCWrapper<DT> contrastWrapper;
+    BCWrapper<DT> brightnessShiftWrapper;
+    BCWrapper<DT> contrastCenterWrapper;
+};
+}  // namespace
+
 namespace roccv {
 
 template <typename BCWrappers, typename SRC_DT, typename DST_DT, int NC>

--- a/src/op_brightness_contrast.cpp
+++ b/src/op_brightness_contrast.cpp
@@ -1,0 +1,200 @@
+/**
+Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+#include "op_brightness_contrast.hpp"
+
+#include <functional>
+
+#include <hip/hip_runtime.h>
+#include "core/wrappers/image_wrapper.hpp"
+#include "common/validation_helpers.hpp"
+#include "core/detail/casting.hpp"
+#include "core/detail/type_traits.hpp"
+//#include "kernels/device/brightness_contrast_device.hpp"
+//#include "kernels/host/brightness_contrast_host.hpp"
+
+namespace roccv {
+
+template <typename BC_DT, typename SRC_DT, typename DST_DT, int NC>
+void dispatch_brightness_contrast_channels(hipStream_t stream, const Tensor &input, const Tensor &output,
+                                            const GroupBCWrappers<BC_DT> &bc_wrappers, eDeviceType device) {
+    
+    using SRC_DT_NC = detail::MakeType<SRC_DT, NC>;
+    using DST_DT_NC = detail::MakeType<DST_DT, NC>;
+
+    ImageWrapper<SRC_DT_NC> inputWrapper(input);
+    ImageWrapper<DST_DT_NC> outputWrapper(output);
+    
+    // Launch CPU/GPU kernel depending on requested device type.
+    switch (device) {
+        case eDeviceType::GPU: {
+            dim3 block(64, 16);
+            dim3 grid((outputWrapper.width() + block.x - 1) / block.x, (outputWrapper.height() + block.y - 1) / block.y,
+                      outputWrapper.batches());
+            //Kernels::Device::brightness_contrast<<<grid, block, 0, stream>>>(inputWrapper, outputWrapper, bc_wrappers);
+            break;
+        }
+        case eDeviceType::CPU: {
+            //Kernels::Host::brightness_contrast(inputWrapper, outputWrapper, bc_wrappers);
+            break;
+        }
+    }
+}
+
+template <typename BC_DT, typename SRC_DT, typename DST_DT>
+void dispatch_brightness_contrast_output_dtype(hipStream_t stream, const Tensor &input, const Tensor &output,
+                                       const GroupBCWrappers<BC_DT> &bc_wrappers, eDeviceType device) {
+
+    int64_t channels = output.shape(output.layout().channels_index());
+    // 4) Select kernel dispatcher based on number of channels.
+    // clang-format off
+    static const std::array<std::function<void(hipStream_t, const Tensor &, const Tensor &, const GroupBCWrappers<BC_DT> &, eDeviceType)>, 4>
+        funcs = {dispatch_brightness_contrast_channels<BC_DT, SRC_DT, DST_DT, 1>, dispatch_brightness_contrast_channels<BC_DT, SRC_DT, DST_DT, 2>, dispatch_brightness_contrast_channels<BC_DT, SRC_DT, DST_DT, 3>, dispatch_brightness_contrast_channels<BC_DT, SRC_DT, DST_DT, 4>};
+    // clang-format on
+
+    auto func = funcs.at(channels - 1);
+    if (func == 0) throw Exception("Not mapped to a defined function.", eStatusType::INVALID_OPERATION);
+    func(stream, input, output, bc_wrappers, device);
+}
+
+template <typename BC_DT, typename SRC_DT>
+void dispatch_brightness_contrast_input_dtype(hipStream_t stream, const Tensor &input, const Tensor &output,
+                                            const GroupBCWrappers<BC_DT> &bc_wrappers, eDeviceType device) {
+    
+    eDataType output_dtype = output.dtype().etype();
+    
+    // 3) Select kernel dispatcher based on a base output datatype.
+    // clang-format off
+    static const std::unordered_map<eDataType, std::function<void(hipStream_t, const Tensor &, const Tensor &, const GroupBCWrappers<BC_DT> &, eDeviceType)>>
+        funcs = {
+            {eDataType::DATA_TYPE_U8, dispatch_brightness_contrast_output_dtype<BC_DT, SRC_DT, uchar>},
+            {eDataType::DATA_TYPE_U16,  dispatch_brightness_contrast_output_dtype<BC_DT, SRC_DT, ushort>},
+            {eDataType::DATA_TYPE_S16,  dispatch_brightness_contrast_output_dtype<BC_DT, SRC_DT, short>},
+            {eDataType::DATA_TYPE_S32,  dispatch_brightness_contrast_output_dtype<BC_DT, SRC_DT, int>},
+            {eDataType::DATA_TYPE_F32, dispatch_brightness_contrast_output_dtype<BC_DT, SRC_DT, float>},
+        };
+    // clang-format on
+    auto func = funcs.at(output_dtype);
+    if (func == 0) throw Exception("Not mapped to a defined function.", eStatusType::INVALID_OPERATION);
+    func(stream, input, output, bc_wrappers, device);
+
+}
+
+template <typename BC_DT>
+void dispatch_brightness_contrast_bc_dtype(hipStream_t stream, const Tensor &input, const Tensor &output,
+                                        const GroupBCWrappers<BC_DT> &bc_wrappers, eDeviceType device) {
+    
+    eDataType input_dtype = input.dtype().etype();
+
+    // 2) Select kernel dispatcher based on a base input datatype.
+    // clang-format off
+    static const std::unordered_map<eDataType, std::function<void(hipStream_t, const Tensor &, const Tensor &, const GroupBCWrappers<BC_DT> &, eDeviceType)>>
+        funcs = {
+            {eDataType::DATA_TYPE_U8, dispatch_brightness_contrast_input_dtype<BC_DT, uchar>},
+            {eDataType::DATA_TYPE_U16,  dispatch_brightness_contrast_input_dtype<BC_DT, ushort>},
+            {eDataType::DATA_TYPE_S16,  dispatch_brightness_contrast_input_dtype<BC_DT, short>},
+            {eDataType::DATA_TYPE_S32,  dispatch_brightness_contrast_input_dtype<BC_DT, int>},
+            {eDataType::DATA_TYPE_F32, dispatch_brightness_contrast_input_dtype<BC_DT, float>},
+        };
+    // clang-format on
+    auto func = funcs.at(input_dtype);
+    if (func == 0) throw Exception("Not mapped to a defined function.", eStatusType::INVALID_OPERATION);
+    func(stream, input, output, bc_wrappers, device);
+
+}
+
+void BrightnessContrast::operator()(hipStream_t stream, const roccv::Tensor &input, const roccv::Tensor &output,
+                    std::optional<std::reference_wrapper<const Tensor>> brightness, 
+                    std::optional<std::reference_wrapper<const Tensor>> contrast,
+                    std::optional<std::reference_wrapper<const Tensor>> brightnessShift,
+                    std::optional<std::reference_wrapper<const Tensor>> contrastCenter,
+                    eDeviceType device) const {
+    
+    // Validate input tensor
+    CHECK_TENSOR_DEVICE(input, device);
+    CHECK_TENSOR_DATATYPES(input, DATA_TYPE_U8, DATA_TYPE_U16, DATA_TYPE_S16,
+                           DATA_TYPE_S32, DATA_TYPE_F32);
+    // TODO: copied over from convert to, verify these layouts/channels are the desired ones
+    CHECK_TENSOR_LAYOUT(input, TENSOR_LAYOUT_HWC, TENSOR_LAYOUT_NHWC);
+    CHECK_TENSOR_CHANNELS(input, 1, 2, 3, 4);
+
+    // Validate output tensor
+    CHECK_TENSOR_DATATYPES(output, DATA_TYPE_U8, DATA_TYPE_U16, DATA_TYPE_S16,
+                           DATA_TYPE_S32, DATA_TYPE_F32);
+    CHECK_TENSOR_COMPARISON(input.device() == output.device());
+    CHECK_TENSOR_COMPARISON(input.shape() == output.shape());
+
+    // Validate brightness/contrast params
+    eDataType input_dtype = input.dtype().etype();
+    int64_t input_batch = input.shape(input.layout().batch_index());
+    eDataType output_dtype = output.dtype().etype();
+    eDataType bc_dtype = (input_dtype == eDataType::DATA_TYPE_S32 || output_dtype == eDataType::DATA_TYPE_S32) ? eDataType::DATA_TYPE_F64 : eDataType::DATA_TYPE_F32; 
+
+    auto validate_bc_param = [&](const auto& param_opt) {
+      if (param_opt.has_value()) {
+        const Tensor& param = param_opt->get();
+        CHECK_TENSOR_DATATYPES(param, bc_dtype);
+        CHECK_TENSOR_LAYOUT(param, TENSOR_LAYOUT_N);
+        CHECK_TENSOR_COMPARISON(param.shape(param.layout().batch_index()) == 1 ||
+                                param.shape(param.layout().batch_index()) == input_batch);
+        CHECK_TENSOR_COMPARISON(input.device() == param.device());
+      }
+    };
+
+    validate_bc_param(brightness);
+    validate_bc_param(contrast);
+    validate_bc_param(brightnessShift);
+    validate_bc_param(contrastCenter);
+
+    auto compute_cc_default = [&]() -> double {
+        switch (input_dtype) {
+            case eDataType::DATA_TYPE_U8:  return 1u << (8 - 1);
+            case eDataType::DATA_TYPE_U16: return 1u << (16 - 1);
+            case eDataType::DATA_TYPE_S16: return 1u << (16 - 2);
+            case eDataType::DATA_TYPE_S32: return 1u << (32 - 2);
+            case eDataType::DATA_TYPE_F32: return 0.5;
+            default: return 0.5;
+        }
+    };
+
+    // 1) Select kernel dispatcher based on BC datatype
+    if (bc_dtype == eDataType::DATA_TYPE_F32) {
+        GroupBCWrappers<float> wrappers {
+            BCWrapper<float>(brightness, 1.0f),
+            BCWrapper<float>(contrast, 1.0f),
+            BCWrapper<float>(brightnessShift, 0.0f),
+            BCWrapper<float>(contrastCenter, compute_cc_default())
+        };
+        dispatch_brightness_contrast_bc_dtype<float>(stream, input, output, wrappers, device);
+    } else if (bc_dtype == eDataType::DATA_TYPE_F64) {
+        GroupBCWrappers<double> wrappers {
+            BCWrapper<double>(brightness, 1.0),
+            BCWrapper<double>(contrast, 1.0),
+            BCWrapper<double>(brightnessShift, 0.0),
+            BCWrapper<double>(contrastCenter, compute_cc_default())
+        };
+        dispatch_brightness_contrast_bc_dtype<double>(stream, input, output, wrappers, device);
+    } else {
+        throw Exception("Not mapped to a defined function.", eStatusType::INVALID_OPERATION);
+    }
+
+}
+}   // namespace roccv

--- a/src/op_brightness_contrast.cpp
+++ b/src/op_brightness_contrast.cpp
@@ -151,7 +151,7 @@ void BrightnessContrast::operator()(hipStream_t stream, const roccv::Tensor &inp
     auto validate_bc_param = [&](const auto& param_opt) {
       if (param_opt.has_value()) {
         const Tensor& param = param_opt->get();
-        CHECK_TENSOR_DATATYPES(param, bc_dtype);
+        CHECK_TENSOR_COMPARISON(param.dtype().etype() == bc_dtype);
         CHECK_TENSOR_LAYOUT(param, TENSOR_LAYOUT_N);
         CHECK_TENSOR_COMPARISON(param.shape(param.layout().batch_index()) == 1 ||
                                 param.shape(param.layout().batch_index()) == input_batch);

--- a/src/op_brightness_contrast.cpp
+++ b/src/op_brightness_contrast.cpp
@@ -21,13 +21,14 @@ THE SOFTWARE.
 */
 #include "op_brightness_contrast.hpp"
 
+#include <hip/hip_runtime.h>
+
 #include <functional>
 
-#include <hip/hip_runtime.h>
-#include "core/wrappers/image_wrapper.hpp"
 #include "common/validation_helpers.hpp"
 #include "core/detail/casting.hpp"
 #include "core/detail/type_traits.hpp"
+#include "core/wrappers/image_wrapper.hpp"
 #include "kernels/device/brightness_contrast_device.hpp"
 #include "kernels/host/brightness_contrast_host.hpp"
 
@@ -35,14 +36,13 @@ namespace roccv {
 
 template <typename BCWrappers, typename SRC_DT, typename DST_DT, int NC>
 void dispatch_brightness_contrast_channels(hipStream_t stream, const Tensor &input, const Tensor &output,
-                                            const BCWrappers &bc_wrappers, eDeviceType device) {
-    
+                                           const BCWrappers &bc_wrappers, eDeviceType device) {
     using SRC_DT_NC = detail::MakeType<SRC_DT, NC>;
     using DST_DT_NC = detail::MakeType<DST_DT, NC>;
 
     ImageWrapper<SRC_DT_NC> inputWrapper(input);
     ImageWrapper<DST_DT_NC> outputWrapper(output);
-    
+
     // Launch CPU/GPU kernel depending on requested device type.
     switch (device) {
         case eDeviceType::GPU: {
@@ -61,10 +61,9 @@ void dispatch_brightness_contrast_channels(hipStream_t stream, const Tensor &inp
 
 template <typename BCWrappers, typename SRC_DT, typename DST_DT>
 void dispatch_brightness_contrast_output_dtype(hipStream_t stream, const Tensor &input, const Tensor &output,
-                                       const BCWrappers &bc_wrappers, eDeviceType device) {
-
+                                               const BCWrappers &bc_wrappers, eDeviceType device) {
     int64_t channels = output.shape(output.layout().channels_index());
-    // 4) Select kernel dispatcher based on number of channels.
+    // Select kernel dispatcher based on number of channels.
     // clang-format off
     static const std::array<std::function<void(hipStream_t, const Tensor &, const Tensor &, const BCWrappers &, eDeviceType)>, 4>
         funcs = {dispatch_brightness_contrast_channels<BCWrappers, SRC_DT, DST_DT, 1>, dispatch_brightness_contrast_channels<BCWrappers, SRC_DT, DST_DT, 2>, dispatch_brightness_contrast_channels<BCWrappers, SRC_DT, DST_DT, 3>, dispatch_brightness_contrast_channels<BCWrappers, SRC_DT, DST_DT, 4>};
@@ -77,68 +76,60 @@ void dispatch_brightness_contrast_output_dtype(hipStream_t stream, const Tensor 
 
 template <typename BCWrappers, typename SRC_DT>
 void dispatch_brightness_contrast_input_dtype(hipStream_t stream, const Tensor &input, const Tensor &output,
-                                            const BCWrappers &bc_wrappers, eDeviceType device) {
-    
+                                              const BCWrappers &bc_wrappers, eDeviceType device) {
     eDataType output_dtype = output.dtype().etype();
-    
-    // 3) Select kernel dispatcher based on a base output datatype.
+
+    // Select kernel dispatcher based on a base output datatype.
     // clang-format off
     static const std::unordered_map<eDataType, std::function<void(hipStream_t, const Tensor &, const Tensor &, const BCWrappers &, eDeviceType)>>
         funcs = {
-            {eDataType::DATA_TYPE_U8, dispatch_brightness_contrast_output_dtype<BCWrappers, SRC_DT, uchar>},
-            {eDataType::DATA_TYPE_U16,  dispatch_brightness_contrast_output_dtype<BCWrappers, SRC_DT, ushort>},
-            {eDataType::DATA_TYPE_S16,  dispatch_brightness_contrast_output_dtype<BCWrappers, SRC_DT, short>},
-            {eDataType::DATA_TYPE_S32,  dispatch_brightness_contrast_output_dtype<BCWrappers, SRC_DT, int>},
+            {eDataType::DATA_TYPE_U8,  dispatch_brightness_contrast_output_dtype<BCWrappers, SRC_DT, uchar>},
+            {eDataType::DATA_TYPE_U16, dispatch_brightness_contrast_output_dtype<BCWrappers, SRC_DT, ushort>},
+            {eDataType::DATA_TYPE_S16, dispatch_brightness_contrast_output_dtype<BCWrappers, SRC_DT, short>},
+            {eDataType::DATA_TYPE_S32, dispatch_brightness_contrast_output_dtype<BCWrappers, SRC_DT, int>},
             {eDataType::DATA_TYPE_F32, dispatch_brightness_contrast_output_dtype<BCWrappers, SRC_DT, float>},
         };
     // clang-format on
     auto func = funcs.at(output_dtype);
     if (func == 0) throw Exception("Not mapped to a defined function.", eStatusType::INVALID_OPERATION);
     func(stream, input, output, bc_wrappers, device);
-
 }
 
 template <typename BCWrappers>
 void dispatch_brightness_contrast_bc_dtype(hipStream_t stream, const Tensor &input, const Tensor &output,
-                                        const BCWrappers &bc_wrappers, eDeviceType device) {
-    
+                                           const BCWrappers &bc_wrappers, eDeviceType device) {
     eDataType input_dtype = input.dtype().etype();
 
-    // 2) Select kernel dispatcher based on a base input datatype.
+    // Select kernel dispatcher based on a base input datatype.
     // clang-format off
     static const std::unordered_map<eDataType, std::function<void(hipStream_t, const Tensor &, const Tensor &, const BCWrappers &, eDeviceType)>>
         funcs = {
-            {eDataType::DATA_TYPE_U8, dispatch_brightness_contrast_input_dtype<BCWrappers, uchar>},
-            {eDataType::DATA_TYPE_U16,  dispatch_brightness_contrast_input_dtype<BCWrappers, ushort>},
-            {eDataType::DATA_TYPE_S16,  dispatch_brightness_contrast_input_dtype<BCWrappers, short>},
-            {eDataType::DATA_TYPE_S32,  dispatch_brightness_contrast_input_dtype<BCWrappers, int>},
+            {eDataType::DATA_TYPE_U8,  dispatch_brightness_contrast_input_dtype<BCWrappers, uchar>},
+            {eDataType::DATA_TYPE_U16, dispatch_brightness_contrast_input_dtype<BCWrappers, ushort>},
+            {eDataType::DATA_TYPE_S16, dispatch_brightness_contrast_input_dtype<BCWrappers, short>},
+            {eDataType::DATA_TYPE_S32, dispatch_brightness_contrast_input_dtype<BCWrappers, int>},
             {eDataType::DATA_TYPE_F32, dispatch_brightness_contrast_input_dtype<BCWrappers, float>},
         };
     // clang-format on
     auto func = funcs.at(input_dtype);
     if (func == 0) throw Exception("Not mapped to a defined function.", eStatusType::INVALID_OPERATION);
     func(stream, input, output, bc_wrappers, device);
-
 }
 
 void BrightnessContrast::operator()(hipStream_t stream, const roccv::Tensor &input, const roccv::Tensor &output,
-                    std::optional<std::reference_wrapper<const Tensor>> brightness, 
-                    std::optional<std::reference_wrapper<const Tensor>> contrast,
-                    std::optional<std::reference_wrapper<const Tensor>> brightnessShift,
-                    std::optional<std::reference_wrapper<const Tensor>> contrastCenter,
-                    eDeviceType device) const {
-    
+                                    std::optional<std::reference_wrapper<const Tensor>> brightness,
+                                    std::optional<std::reference_wrapper<const Tensor>> contrast,
+                                    std::optional<std::reference_wrapper<const Tensor>> brightnessShift,
+                                    std::optional<std::reference_wrapper<const Tensor>> contrastCenter,
+                                    eDeviceType device) const {
     // Validate input tensor
     CHECK_TENSOR_DEVICE(input, device);
-    CHECK_TENSOR_DATATYPES(input, DATA_TYPE_U8, DATA_TYPE_U16, DATA_TYPE_S16,
-                           DATA_TYPE_S32, DATA_TYPE_F32);
-    // TODO: copied over from convert to, verify these layouts/channels are the desired ones
+    CHECK_TENSOR_DATATYPES(input, DATA_TYPE_U8, DATA_TYPE_U16, DATA_TYPE_S16, DATA_TYPE_S32, DATA_TYPE_F32);
     CHECK_TENSOR_LAYOUT(input, TENSOR_LAYOUT_HWC, TENSOR_LAYOUT_NHWC);
     CHECK_TENSOR_CHANNELS(input, 1, 2, 3, 4);
 
     // Validate output tensor
-    CHECK_TENSOR_DATATYPES(output, DATA_TYPE_U8, DATA_TYPE_U16, DATA_TYPE_S16,
-                           DATA_TYPE_S32, DATA_TYPE_F32);
+    CHECK_TENSOR_DATATYPES(output, DATA_TYPE_U8, DATA_TYPE_U16, DATA_TYPE_S16, DATA_TYPE_S32, DATA_TYPE_F32);
     CHECK_TENSOR_COMPARISON(input.device() == output.device());
     CHECK_TENSOR_COMPARISON(input.shape() == output.shape());
 
@@ -146,17 +137,19 @@ void BrightnessContrast::operator()(hipStream_t stream, const roccv::Tensor &inp
     eDataType input_dtype = input.dtype().etype();
     int64_t input_batch = input.shape(input.layout().batch_index());
     eDataType output_dtype = output.dtype().etype();
-    eDataType bc_dtype = (input_dtype == eDataType::DATA_TYPE_S32 || output_dtype == eDataType::DATA_TYPE_S32) ? eDataType::DATA_TYPE_F64 : eDataType::DATA_TYPE_F32; 
+    eDataType bc_dtype = (input_dtype == eDataType::DATA_TYPE_S32 || output_dtype == eDataType::DATA_TYPE_S32)
+                             ? eDataType::DATA_TYPE_F64
+                             : eDataType::DATA_TYPE_F32;
 
-    auto validate_bc_param = [&](const auto& param_opt) {
-      if (param_opt.has_value()) {
-        const Tensor& param = param_opt->get();
-        CHECK_TENSOR_COMPARISON(param.dtype().etype() == bc_dtype);
-        CHECK_TENSOR_LAYOUT(param, TENSOR_LAYOUT_N);
-        CHECK_TENSOR_COMPARISON(param.shape(param.layout().batch_index()) == 1 ||
-                                param.shape(param.layout().batch_index()) == input_batch);
-        CHECK_TENSOR_COMPARISON(input.device() == param.device());
-      }
+    auto validate_bc_param = [&](const auto &param_opt) {
+        if (param_opt.has_value()) {
+            const Tensor &param = param_opt->get();
+            CHECK_TENSOR_COMPARISON(param.dtype().etype() == bc_dtype);
+            CHECK_TENSOR_LAYOUT(param, TENSOR_LAYOUT_N);
+            CHECK_TENSOR_COMPARISON(param.shape(param.layout().batch_index()) == 1 ||
+                                    param.shape(param.layout().batch_index()) == input_batch);
+            CHECK_TENSOR_COMPARISON(input.device() == param.device());
+        }
     };
 
     validate_bc_param(brightness);
@@ -166,35 +159,34 @@ void BrightnessContrast::operator()(hipStream_t stream, const roccv::Tensor &inp
 
     auto compute_cc_default = [&]() -> double {
         switch (input_dtype) {
-            case eDataType::DATA_TYPE_U8:  return 1u << (8 - 1);
-            case eDataType::DATA_TYPE_U16: return 1u << (16 - 1);
-            case eDataType::DATA_TYPE_S16: return 1u << (16 - 2);
-            case eDataType::DATA_TYPE_S32: return 1u << (32 - 2);
-            case eDataType::DATA_TYPE_F32: return 0.5;
-            default: return 0.5;
+            case eDataType::DATA_TYPE_U8:
+                return 1u << (8 - 1);
+            case eDataType::DATA_TYPE_U16:
+                return 1u << (16 - 1);
+            case eDataType::DATA_TYPE_S16:
+                return 1u << (16 - 2);
+            case eDataType::DATA_TYPE_S32:
+                return 1u << (32 - 2);
+            case eDataType::DATA_TYPE_F32:
+                return 0.5;
+            default:
+                return 0.5;
         }
     };
 
-    // 1) Select kernel dispatcher based on BC datatype
+    // Select kernel dispatcher based on BC datatype
     if (bc_dtype == eDataType::DATA_TYPE_F32) {
-        GroupBCWrappers<float> wrappers {
-            BCWrapper<float>(brightness, 1.0f),
-            BCWrapper<float>(contrast, 1.0f),
-            BCWrapper<float>(brightnessShift, 0.0f),
-            BCWrapper<float>(contrastCenter, compute_cc_default())
-        };
+        GroupBCWrappers<float> wrappers{BCWrapper<float>(brightness, 1.0f), BCWrapper<float>(contrast, 1.0f),
+                                        BCWrapper<float>(brightnessShift, 0.0f),
+                                        BCWrapper<float>(contrastCenter, static_cast<float>(compute_cc_default()))};
         dispatch_brightness_contrast_bc_dtype<GroupBCWrappers<float>>(stream, input, output, wrappers, device);
     } else if (bc_dtype == eDataType::DATA_TYPE_F64) {
-        GroupBCWrappers<double> wrappers {
-            BCWrapper<double>(brightness, 1.0),
-            BCWrapper<double>(contrast, 1.0),
-            BCWrapper<double>(brightnessShift, 0.0),
-            BCWrapper<double>(contrastCenter, compute_cc_default())
-        };
+        GroupBCWrappers<double> wrappers{BCWrapper<double>(brightness, 1.0), BCWrapper<double>(contrast, 1.0),
+                                         BCWrapper<double>(brightnessShift, 0.0),
+                                         BCWrapper<double>(contrastCenter, compute_cc_default())};
         dispatch_brightness_contrast_bc_dtype<GroupBCWrappers<double>>(stream, input, output, wrappers, device);
     } else {
         throw Exception("Not mapped to a defined function.", eStatusType::INVALID_OPERATION);
     }
-
 }
-}   // namespace roccv
+}  // namespace roccv

--- a/src/op_brightness_contrast.cpp
+++ b/src/op_brightness_contrast.cpp
@@ -28,8 +28,8 @@ THE SOFTWARE.
 #include "common/validation_helpers.hpp"
 #include "core/detail/casting.hpp"
 #include "core/detail/type_traits.hpp"
-//#include "kernels/device/brightness_contrast_device.hpp"
-//#include "kernels/host/brightness_contrast_host.hpp"
+#include "kernels/device/brightness_contrast_device.hpp"
+#include "kernels/host/brightness_contrast_host.hpp"
 
 namespace roccv {
 
@@ -53,7 +53,7 @@ void dispatch_brightness_contrast_channels(hipStream_t stream, const Tensor &inp
             break;
         }
         case eDeviceType::CPU: {
-            //Kernels::Host::brightness_contrast(inputWrapper, outputWrapper, bc_wrappers);
+            Kernels::Host::brightness_contrast(inputWrapper, outputWrapper, bc_wrappers);
             break;
         }
     }

--- a/tests/roccv/cpp/include/test_helpers.hpp
+++ b/tests/roccv/cpp/include/test_helpers.hpp
@@ -332,6 +332,32 @@ void FillVectorMask(std::vector<T>& vec, uint32_t seed = 12345) {
 }
 
 /**
+* @brief Fills a vector with random values in a specified range based on a provided seeded.
+*
+* @tparam T The underlying type of the vector data.
+* @param[out] vec The vector to fill with random data.
+* @param[in] min Minimum value (inclusive).
+* @param[in] max Maximum value (inclusive).
+* @param[in] seed A random seed. (Defaults to 12345)
+*/
+template <typename T>
+void FillVectorRange(std::vector<T>& vec, T min, T max, uint32_t seed = 12345) {
+    std::mt19937 eng(seed);
+
+    if constexpr (std::is_floating_point_v<T>) {
+        std::uniform_real_distribution<T> dist(min, max);
+        for (auto& val : vec) {
+            val = dist(eng);
+        }
+    } else {
+        std::uniform_int_distribution<T> dist(min, max);
+        for (auto& val : vec) {
+            val = dist(eng);
+        }
+    }
+}
+
+/**
  * @brief Compares a vector to a reference vector.
  *
  * @tparam T The base type of the vector data.

--- a/tests/roccv/cpp/include/test_helpers.hpp
+++ b/tests/roccv/cpp/include/test_helpers.hpp
@@ -332,14 +332,14 @@ void FillVectorMask(std::vector<T>& vec, uint32_t seed = 12345) {
 }
 
 /**
-* @brief Fills a vector with random values in a specified range based on a provided seeded.
-*
-* @tparam T The underlying type of the vector data.
-* @param[out] vec The vector to fill with random data.
-* @param[in] min Minimum value (inclusive).
-* @param[in] max Maximum value (inclusive).
-* @param[in] seed A random seed. (Defaults to 12345)
-*/
+ * @brief Fills a vector with random values in a specified range based on a provided seeded.
+ *
+ * @tparam T The underlying type of the vector data.
+ * @param[out] vec The vector to fill with random data.
+ * @param[in] min Minimum value (inclusive).
+ * @param[in] max Maximum value (inclusive).
+ * @param[in] seed A random seed. (Defaults to 12345)
+ */
 template <typename T>
 void FillVectorRange(std::vector<T>& vec, T min, T max, uint32_t seed = 12345) {
     std::mt19937 eng(seed);

--- a/tests/roccv/cpp/src/tests/operators/test_op_brightness_contrast.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_brightness_contrast.cpp
@@ -128,7 +128,7 @@ void TestCorrectness(int batchSize, int width, int height, ImageFormat inFormat,
 
     // Compare data in actual output versus the generated golden reference image
     // Using 1.0E-4 as the error threshold to account for FMA/non-FMA float divergence between CPU and GPU.
-    CompareVectorsNear(result, ref, 1.0E-4); // check this threshold
+    CompareVectorsNear(result, ref, 1.0E-4); // tightest threshold passing
 }
 
 template <typename SRC_DT, typename DEST_DT, typename BC_DT,
@@ -224,6 +224,98 @@ void TestCorrectnessDefaultsAndPer(int batchSize, int width, int height, ImageFo
     CompareVectorsNear(randResult, randRef, 1.0E-4); // check this threshold
 }
 
+void TestNegativeBrightnessContrast() {
+    TensorShape validShape(TensorLayout(eTensorLayout::TENSOR_LAYOUT_NHWC), {1, 1, 1, 1});
+    Tensor validGPUTensor(validShape, DataType(eDataType::DATA_TYPE_U8), eDeviceType::GPU);
+    Tensor validCPUTensor(validShape, DataType(eDataType::DATA_TYPE_U8), eDeviceType::CPU);
+
+    TensorShape bc_validOneShape(TensorLayout(eTensorLayout::TENSOR_LAYOUT_N), {1});
+
+    BrightnessContrast op;
+
+    {
+        // Test wrong device
+        Tensor bc_validCPUTensor(bc_validOneShape, DataType(eDataType::DATA_TYPE_F32), eDeviceType::CPU);
+
+        EXPECT_EXCEPTION(op(nullptr, validCPUTensor, validGPUTensor, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
+                            eDeviceType::GPU), eStatusType::INVALID_OPERATION);
+        EXPECT_EXCEPTION(op(nullptr, validGPUTensor, validCPUTensor, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
+                            eDeviceType::GPU), eStatusType::INVALID_COMBINATION);
+        EXPECT_EXCEPTION(op(nullptr, validGPUTensor, validGPUTensor, bc_validCPUTensor, bc_validCPUTensor, bc_validCPUTensor, bc_validCPUTensor,
+                            eDeviceType::GPU), eStatusType::INVALID_COMBINATION);
+    }
+
+    {
+        // Test unsupported input/output data type
+        Tensor invalidTensor(validGPUTensor.shape(), DataType(eDataType::DATA_TYPE_U32), eDeviceType::GPU);
+        EXPECT_EXCEPTION(op(nullptr, invalidTensor, validGPUTensor, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
+                            eDeviceType::GPU), eStatusType::NOT_IMPLEMENTED);
+        EXPECT_EXCEPTION(op(nullptr, validGPUTensor, invalidTensor, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
+                            eDeviceType::GPU), eStatusType::NOT_IMPLEMENTED);
+    }
+
+    {
+        // Test unsupported input/output layout
+        TensorShape invalidLayoutShape(TensorLayout(eTensorLayout::TENSOR_LAYOUT_NC), {1, 1});
+        Tensor invalidTensor(invalidLayoutShape, DataType(eDataType::DATA_TYPE_U8), eDeviceType::GPU);
+        EXPECT_EXCEPTION(op(nullptr, invalidTensor, validGPUTensor, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
+                            eDeviceType::GPU),  eStatusType::INVALID_COMBINATION);
+        EXPECT_EXCEPTION(op(nullptr, validGPUTensor, invalidTensor, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
+                            eDeviceType::GPU),  eStatusType::INVALID_COMBINATION);
+    }
+
+
+    {
+        // Test input/output shape mismatch
+        Tensor invalidTensor(TensorShape(validGPUTensor.layout(), {2, 2, 2, 2}), DataType(eDataType::DATA_TYPE_U8),
+                             eDeviceType::GPU);
+        EXPECT_EXCEPTION(op(nullptr, invalidTensor, validGPUTensor, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
+                            eDeviceType::GPU), eStatusType::INVALID_COMBINATION);
+    }
+
+    {
+        // Test brightness/contrast datatype mismatch with input/output
+        Tensor bc_validFloatTensor(bc_validOneShape, DataType(eDataType::DATA_TYPE_F32), eDeviceType::GPU);
+        Tensor bc_validDoubleTensor(bc_validOneShape, DataType(eDataType::DATA_TYPE_F64), eDeviceType::GPU);
+        Tensor bc_invalidCharTensor(bc_validOneShape, DataType(eDataType::DATA_TYPE_U8), eDeviceType::GPU);
+
+        Tensor validIntTensor(validShape, DataType(eDataType::DATA_TYPE_S32), eDeviceType::GPU);
+        Tensor validCharTensor(validShape, DataType(eDataType::DATA_TYPE_U8), eDeviceType::GPU);
+
+        EXPECT_EXCEPTION(op(nullptr, validCharTensor, validCharTensor, bc_invalidCharTensor, std::nullopt, std::nullopt, std::nullopt,
+                            eDeviceType::GPU),  eStatusType::INVALID_COMBINATION);
+
+        EXPECT_EXCEPTION(op(nullptr, validCharTensor, validCharTensor, std::nullopt, bc_validDoubleTensor, std::nullopt, std::nullopt,
+                            eDeviceType::GPU),  eStatusType::INVALID_COMBINATION);
+
+        EXPECT_EXCEPTION(op(nullptr, validIntTensor, validCharTensor, std::nullopt, std::nullopt, bc_validFloatTensor, std::nullopt,
+                            eDeviceType::GPU),  eStatusType::INVALID_COMBINATION);
+
+        EXPECT_EXCEPTION(op(nullptr, validCharTensor, validIntTensor, std::nullopt, std::nullopt, std::nullopt, bc_validFloatTensor,
+                            eDeviceType::GPU),  eStatusType::INVALID_COMBINATION);
+    }
+
+    {
+        // Test brightness/contrast bad shape
+        TensorShape bc_mismatchBatchShape(TensorLayout(eTensorLayout::TENSOR_LAYOUT_N), {5});
+        TensorShape bc_invalidLayoutShape(TensorLayout(eTensorLayout::TENSOR_LAYOUT_NC), {1, 1});
+        Tensor bc_invalidBatchTensor(bc_mismatchBatchShape, DataType(eDataType::DATA_TYPE_F32), eDeviceType::GPU);
+        Tensor bc_invalidLayoutTensor(bc_invalidLayoutShape, DataType(eDataType::DATA_TYPE_F32), eDeviceType::GPU);
+
+        EXPECT_EXCEPTION(op(nullptr, validGPUTensor, validGPUTensor, bc_invalidBatchTensor, std::nullopt, std::nullopt, std::nullopt,
+                            eDeviceType::GPU),  eStatusType::INVALID_COMBINATION);
+
+        EXPECT_EXCEPTION(op(nullptr, validGPUTensor, validGPUTensor, std::nullopt, bc_invalidBatchTensor, std::nullopt, std::nullopt,
+                            eDeviceType::GPU),  eStatusType::INVALID_COMBINATION);
+
+        EXPECT_EXCEPTION(op(nullptr, validGPUTensor, validGPUTensor, std::nullopt, std::nullopt, bc_invalidLayoutTensor, std::nullopt,
+                            eDeviceType::GPU),  eStatusType::INVALID_COMBINATION);
+
+        EXPECT_EXCEPTION(op(nullptr, validGPUTensor, validGPUTensor, std::nullopt, std::nullopt, std::nullopt, bc_invalidLayoutTensor,
+                            eDeviceType::GPU),  eStatusType::INVALID_COMBINATION);
+    }
+}
+
 
 }  // namespace
 
@@ -232,8 +324,10 @@ int main(int argc, char** argv) {
     (void)argv;
     TEST_CASES_BEGIN();
 
-    // TODO also add negative tests
-    // todo different image sizes?
+    // todo test against convert to just for fun?
+
+    // Test negative operator cases
+    TEST_CASE(TestNegativeBrightnessContrast());
 
     // CPU correctness tests
     // 1 Channel
@@ -257,24 +351,24 @@ int main(int argc, char** argv) {
     TEST_CASE((TestCorrectnessDefaultsAndPer<uchar1, int1, double>(1, 480, 360, FMT_U8, FMT_S32, eDeviceType::CPU)));
 
     // 3 Channels
-    TEST_CASE((TestCorrectness<uchar3, uchar3, float>(1, 360, 480, FMT_RGB8, FMT_RGB8, 1.5f, 1.2f, 0.1f, 100.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<ushort3, ushort3, float>(1, 360, 480, FMT_RGB16, FMT_RGB16, 1.5f, 1.2f, 0.1f, 30000.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<short3, short3, float>(1, 360, 480, FMT_RGBs16, FMT_RGBs16, 1.5f, 1.2f, 0.1f, 10000.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<int3, int3, double>(1, 360, 480, FMT_RGBs32, FMT_RGBs32, 1.5, 1.2, 0.1, 1000000000.0, eDataType::DATA_TYPE_F64, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<float3, float3, float>(1, 360, 480, FMT_RGBf32, FMT_RGBf32, 1.5f, 1.2f, 0.1f, 0.6f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uchar3, uchar3, float>(1, 640, 480, FMT_RGB8, FMT_RGB8, 1.5f, 1.2f, 0.1f, 100.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<ushort3, ushort3, float>(1, 640, 480, FMT_RGB16, FMT_RGB16, 1.5f, 1.2f, 0.1f, 30000.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<short3, short3, float>(1, 640, 480, FMT_RGBs16, FMT_RGBs16, 1.5f, 1.2f, 0.1f, 10000.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<int3, int3, double>(1, 640, 480, FMT_RGBs32, FMT_RGBs32, 1.5, 1.2, 0.1, 1000000000.0, eDataType::DATA_TYPE_F64, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<float3, float3, float>(1, 640, 480, FMT_RGBf32, FMT_RGBf32, 1.5f, 1.2f, 0.1f, 0.6f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
 
-    TEST_CASE((TestCorrectness<uchar3, ushort3, float>(1, 480, 360, FMT_RGB8, FMT_RGB16, 1.5f, 1.2f, 0.1f, 100.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<ushort3, uchar3, float>(1, 480, 360, FMT_RGB16, FMT_RGB8, 1.5f, 1.2f, 0.1f, 30000.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<short3, uchar3, float>(1, 480, 360, FMT_RGBs16, FMT_RGB8, 1.5f, 1.2f, 0.1f, 10000.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<ushort3, short3, float>(1, 480, 360, FMT_RGB16, FMT_RGBs16, 1.5f, 1.2f, 0.1f, 30000.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<short3, ushort3, float>(1, 480, 360, FMT_RGBs16, FMT_RGB16, 1.5f, 1.2f, 0.1f, 10000.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<uchar3, int3, double>(1, 480, 360, FMT_RGB8, FMT_RGBs32, 1.5, 1.2, 0.1, 100.0, eDataType::DATA_TYPE_F64, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<int3, uchar3, double>(1, 480, 360, FMT_RGBs32, FMT_RGB8, 1.5, 1.2, 0.1, 1000000000.0, eDataType::DATA_TYPE_F64, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<uchar3, float3, float>(1, 480, 360, FMT_RGB8, FMT_RGBf32, 1.5f, 1.2f, 0.1f, 100.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<float3, uchar3, float>(1, 480, 360, FMT_RGBf32, FMT_RGB8, 1.5f, 1.2f, 0.1f, 0.6f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uchar3, ushort3, float>(1, 480, 640, FMT_RGB8, FMT_RGB16, 1.5f, 1.2f, 0.1f, 100.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<ushort3, uchar3, float>(1, 480, 640, FMT_RGB16, FMT_RGB8, 1.5f, 1.2f, 0.1f, 30000.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<short3, uchar3, float>(1, 480, 640, FMT_RGBs16, FMT_RGB8, 1.5f, 1.2f, 0.1f, 10000.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<ushort3, short3, float>(1, 480, 640, FMT_RGB16, FMT_RGBs16, 1.5f, 1.2f, 0.1f, 30000.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<short3, ushort3, float>(1, 480, 640, FMT_RGBs16, FMT_RGB16, 1.5f, 1.2f, 0.1f, 10000.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uchar3, int3, double>(1, 480, 640, FMT_RGB8, FMT_RGBs32, 1.5, 1.2, 0.1, 100.0, eDataType::DATA_TYPE_F64, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<int3, uchar3, double>(1, 480, 640, FMT_RGBs32, FMT_RGB8, 1.5, 1.2, 0.1, 1000000000.0, eDataType::DATA_TYPE_F64, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uchar3, float3, float>(1, 480, 640, FMT_RGB8, FMT_RGBf32, 1.5f, 1.2f, 0.1f, 100.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<float3, uchar3, float>(1, 480, 640, FMT_RGBf32, FMT_RGB8, 1.5f, 1.2f, 0.1f, 0.6f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
 
-    TEST_CASE((TestCorrectnessDefaultsAndPer<float3, float3, float> (1, 480, 360, FMT_RGBf32, FMT_RGBf32,  eDeviceType::CPU)));
-    TEST_CASE((TestCorrectnessDefaultsAndPer<uchar3, int3, double>(1, 480, 360, FMT_RGB8, FMT_RGBs32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectnessDefaultsAndPer<float3, float3, float> (1, 480, 640, FMT_RGBf32, FMT_RGBf32,  eDeviceType::CPU)));
+    TEST_CASE((TestCorrectnessDefaultsAndPer<uchar3, int3, double>(1, 480, 640, FMT_RGB8, FMT_RGBs32, eDeviceType::CPU)));
 
     // 4 Channels
     TEST_CASE((TestCorrectness<uchar4, uchar4, float>(1, 360, 480, FMT_RGBA8, FMT_RGBA8, 1.5f, 1.2f, 0.1f, 100.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
@@ -338,24 +432,24 @@ int main(int argc, char** argv) {
     TEST_CASE((TestCorrectnessDefaultsAndPer<uchar3, int3, double>(1, 480, 360, FMT_RGB8, FMT_RGBs32, eDeviceType::GPU)));
 
     // 4 Channels
-    TEST_CASE((TestCorrectness<uchar4, uchar4, float>(1, 360, 480, FMT_RGBA8, FMT_RGBA8, 1.5f, 1.2f, 0.1f, 100.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<ushort4, ushort4, float>(1, 360, 480, FMT_RGBA16, FMT_RGBA16, 1.5f, 1.2f, 0.1f, 30000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<short4, short4, float>(1, 360, 480, FMT_RGBAs16, FMT_RGBAs16, 1.5f, 1.2f, 0.1f, 10000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<int4, int4, double>(1, 360, 480, FMT_RGBAs32, FMT_RGBAs32, 1.5, 1.2, 0.1, 1000000000.0, eDataType::DATA_TYPE_F64, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<float4, float4, float>(1, 360, 480, FMT_RGBAf32, FMT_RGBAf32, 1.5f, 1.2f, 0.1f, 0.6f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<uchar4, uchar4, float>(1, 1920, 1080, FMT_RGBA8, FMT_RGBA8, 1.5f, 1.2f, 0.1f, 100.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<ushort4, ushort4, float>(1, 1920, 1080, FMT_RGBA16, FMT_RGBA16, 1.5f, 1.2f, 0.1f, 30000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<short4, short4, float>(1, 1920, 1080, FMT_RGBAs16, FMT_RGBAs16, 1.5f, 1.2f, 0.1f, 10000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<int4, int4, double>(1, 1920, 1080, FMT_RGBAs32, FMT_RGBAs32, 1.5, 1.2, 0.1, 1000000000.0, eDataType::DATA_TYPE_F64, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<float4, float4, float>(1, 1920, 1080, FMT_RGBAf32, FMT_RGBAf32, 1.5f, 1.2f, 0.1f, 0.6f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
 
-    TEST_CASE((TestCorrectness<uchar4, ushort4, float>(1, 480, 360, FMT_RGBA8, FMT_RGBA16, 1.5f, 1.2f, 0.1f, 100.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<ushort4, uchar4, float>(1, 480, 360, FMT_RGBA16, FMT_RGBA8, 1.5f, 1.2f, 0.1f, 30000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<short4, uchar4, float>(1, 480, 360, FMT_RGBAs16, FMT_RGBA8, 1.5f, 1.2f, 0.1f, 10000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<ushort4, short4, float>(1, 480, 360, FMT_RGBA16, FMT_RGBAs16, 1.5f, 1.2f, 0.1f, 30000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<short4, ushort4, float>(1, 480, 360, FMT_RGBAs16, FMT_RGBA16, 1.5f, 1.2f, 0.1f, 10000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<uchar4, int4, double>(1, 480, 360, FMT_RGBA8, FMT_RGBAs32, 1.5, 1.2, 0.1, 100.0, eDataType::DATA_TYPE_F64, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<int4, uchar4, double>(1, 480, 360, FMT_RGBAs32, FMT_RGBA8, 1.5, 1.2, 0.1, 1000000000.0, eDataType::DATA_TYPE_F64, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<uchar4, float4, float>(1, 480, 360, FMT_RGBA8, FMT_RGBAf32, 1.5f, 1.2f, 0.1f, 100.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<float4, uchar4, float>(1, 480, 360, FMT_RGBAf32, FMT_RGBA8, 1.5f, 1.2f, 0.1f, 0.6f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<uchar4, ushort4, float>(1, 1080, 1920, FMT_RGBA8, FMT_RGBA16, 1.5f, 1.2f, 0.1f, 100.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<ushort4, uchar4, float>(1, 1080, 1920, FMT_RGBA16, FMT_RGBA8, 1.5f, 1.2f, 0.1f, 30000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<short4, uchar4, float>(1, 1080, 1920, FMT_RGBAs16, FMT_RGBA8, 1.5f, 1.2f, 0.1f, 10000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<ushort4, short4, float>(1, 1080, 1920, FMT_RGBA16, FMT_RGBAs16, 1.5f, 1.2f, 0.1f, 30000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<short4, ushort4, float>(1, 1080, 1920, FMT_RGBAs16, FMT_RGBA16, 1.5f, 1.2f, 0.1f, 10000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<uchar4, int4, double>(1, 1080, 1920, FMT_RGBA8, FMT_RGBAs32, 1.5, 1.2, 0.1, 100.0, eDataType::DATA_TYPE_F64, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<int4, uchar4, double>(1, 1080, 1920, FMT_RGBAs32, FMT_RGBA8, 1.5, 1.2, 0.1, 1000000000.0, eDataType::DATA_TYPE_F64, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<uchar4, float4, float>(1, 1080, 1920, FMT_RGBA8, FMT_RGBAf32, 1.5f, 1.2f, 0.1f, 100.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<float4, uchar4, float>(1, 1080, 1920, FMT_RGBAf32, FMT_RGBA8, 1.5f, 1.2f, 0.1f, 0.6f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
 
-    TEST_CASE((TestCorrectnessDefaultsAndPer<float4, float4, float> (1, 480, 360, FMT_RGBAf32, FMT_RGBAf32,  eDeviceType::GPU)));
-    TEST_CASE((TestCorrectnessDefaultsAndPer<uchar4, int4, double>(1, 480, 360, FMT_RGBA8, FMT_RGBAs32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectnessDefaultsAndPer<float4, float4, float> (1, 3840, 2160, FMT_RGBAf32, FMT_RGBAf32,  eDeviceType::GPU)));
+    TEST_CASE((TestCorrectnessDefaultsAndPer<uchar4, int4, double>(1, 2160, 3840, FMT_RGBA8, FMT_RGBAs32, eDeviceType::GPU)));
 
     TEST_CASES_END();
 }

--- a/tests/roccv/cpp/src/tests/operators/test_op_brightness_contrast.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_brightness_contrast.cpp
@@ -324,8 +324,6 @@ int main(int argc, char** argv) {
     (void)argv;
     TEST_CASES_BEGIN();
 
-    // todo test against convert to just for fun?
-
     // Test negative operator cases
     TEST_CASE(TestNegativeBrightnessContrast());
 

--- a/tests/roccv/cpp/src/tests/operators/test_op_brightness_contrast.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_brightness_contrast.cpp
@@ -1,0 +1,361 @@
+/**
+Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#include <core/detail/casting.hpp>
+#include <core/detail/type_traits.hpp>
+#include <core/wrappers/image_wrapper.hpp>
+#include <op_brightness_contrast.hpp>
+
+#include "test_helpers.hpp"
+
+using namespace roccv;
+using namespace roccv::tests;
+
+// Keep all non-entrypoint functions in an anonymous namespace to prevent redefinition errors across translation units.
+namespace {
+
+/**
+ * @brief Verified golden C++ model for the ConvertTo operation.
+ *
+ * @tparam T Vectorized datatype of the image's pixels.
+ * @tparam BT Base type of the image's data.
+ * @param[in] input An input vector containing image data.
+ * @param[in] batchSize The number of images in the batch.
+ * @param[in] width Image width.
+ * @param[in] height Image height.
+ * @param[in] channels Number of channels in the image.
+ * @param[in] alpha Scalar for output data.
+ * @param[in] beta Offset for the data.
+ * @return Vector containing the results of the operation.
+ */
+template <typename SRC_DT, typename DEST_DT, typename BC_DT, typename BT_SRC = detail::BaseType<SRC_DT>,
+          typename BT_DEST = detail::BaseType<DEST_DT>>
+std::vector<BT_DEST> GoldenBrightnessContrast(std::vector<BT_SRC>& input, int32_t batchSize, int32_t width, int32_t height,
+                                     std::vector<BC_DT>& brightness,std::vector<BC_DT>& contrast, std::vector<BC_DT>& brightnessShift, std::vector<BC_DT>& contrastCenter) {
+    // Create an output vector the same size as the input vector
+    std::vector<BT_DEST> output(input.size());
+
+    // Wrap input/output vectors for simplified data access
+    ImageWrapper<SRC_DT> src(input, batchSize, width, height);
+    ImageWrapper<DEST_DT> dst(output, batchSize, width, height);
+
+    using work_type = detail::MakeType<BC_DT, detail::NumElements<DEST_DT>>;
+
+    for (int b = 0; b < batchSize; ++b) {
+        BC_DT brt = brightness[b];
+        BC_DT contr = contrast[b];
+        BC_DT brtShift = brightnessShift[b];
+        BC_DT contrCenter = contrastCenter[b];
+
+        for (int y = 0; y < height; ++y) {
+            for (int x = 0; x < width; ++x) {
+                work_type src_val = detail::StaticCast<work_type>(src.at(b, y, x, 0));
+                work_type result = brtShift + brt * (contrCenter + contr * (src_val - contrCenter));
+                dst.at(b, y, x, 0) = detail::SaturateCast<DEST_DT>(result);
+            }
+        }
+    }
+    return output;
+}
+
+template <typename SRC_DT, typename DEST_DT, typename BC_DT,
+        typename BT_SRC = detail::BaseType<SRC_DT>, typename BT_DEST = detail::BaseType<DEST_DT>>
+void TestCorrectness(int batchSize, int width, int height, ImageFormat inFormat, ImageFormat outFormat, BC_DT brightness,
+                     BC_DT contrast, BC_DT brightnessShift, BC_DT contrastCenter, eDataType bc_edt, eDeviceType device) {
+    // Create input and output tensor based on test parameters
+    Tensor input(batchSize, {width, height}, inFormat, device);
+    Tensor output(batchSize, {width, height}, outFormat, device);
+
+    // Create a vector and fill it with random data.
+    std::vector<BT_SRC> inputData(input.shape().size());
+    FillVector(inputData);
+
+    // Copy generated input data into input tensor
+    CopyVectorIntoTensor(input, inputData);
+    
+    // Create brightness/contrast tensors
+    TensorShape shape(TensorLayout(eTensorLayout::TENSOR_LAYOUT_N), {batchSize});
+    Tensor brightnessTensor(shape, DataType(bc_edt), device);
+    Tensor contrastTensor(shape, DataType(bc_edt), device);
+    Tensor brightnessShiftTensor(shape, DataType(bc_edt), device);
+    Tensor contrastCenterTensor(shape, DataType(bc_edt), device);
+
+    // Create BC vectors according to params and use to fill in tensors
+    std::vector<BC_DT> brightnessData(batchSize, brightness);
+    std::vector<BC_DT> contrastData(batchSize, contrast);
+    std::vector<BC_DT> brightnessShiftData(batchSize, brightnessShift);
+    std::vector<BC_DT> contrastCenterData(batchSize, contrastCenter);
+
+    CopyVectorIntoTensor(brightnessTensor, brightnessData);
+    CopyVectorIntoTensor(contrastTensor, contrastData);
+    CopyVectorIntoTensor(brightnessShiftTensor, brightnessShiftData);
+    CopyVectorIntoTensor(contrastCenterTensor, contrastCenterData);
+
+    // Calculate golden output reference
+    std::vector<BT_DEST> ref = GoldenBrightnessContrast<SRC_DT, DEST_DT, BC_DT>(inputData, batchSize, width, height, brightnessData, contrastData, brightnessShiftData, contrastCenterData);
+ 
+    // Run roccv::Brightness Contrast operator to obtain actual results
+    hipStream_t stream;
+    HIP_VALIDATE_NO_ERRORS(hipStreamCreate(&stream));
+
+    BrightnessContrast op;
+    op(stream, input, output, brightnessTensor, contrastTensor, brightnessShiftTensor, contrastCenterTensor, device);
+    HIP_VALIDATE_NO_ERRORS(hipStreamSynchronize(stream));
+    HIP_VALIDATE_NO_ERRORS(hipStreamDestroy(stream));
+
+    // Copy data from output tensor into a host allocated vector
+    std::vector<BT_DEST> result(output.shape().size());
+    CopyTensorIntoVector(result, output);
+
+    // Compare data in actual output versus the generated golden reference image
+    // Using 1.0E-4 as the error threshold to account for FMA/non-FMA float divergence between CPU and GPU.
+    CompareVectorsNear(result, ref, 1.0E-4); // check this threshold
+}
+
+template <typename SRC_DT, typename DEST_DT, typename BC_DT,
+        typename BT_SRC = detail::BaseType<SRC_DT>, typename BT_DEST = detail::BaseType<DEST_DT>>
+void TestCorrectnessDefaultsAndPer(int batchSize, int width, int height, ImageFormat inFormat, ImageFormat outFormat, eDeviceType device) {
+    // Create input and output tensor based on test parameters
+    Tensor input(batchSize, {width, height}, inFormat, device);
+    Tensor defaultOutput(batchSize, {width, height}, outFormat, device);
+    Tensor randOutput(batchSize, {width, height}, outFormat, device);
+
+    // Create a vector and fill it with random data.
+    std::vector<BT_SRC> inputData(input.shape().size());
+    FillVector(inputData);
+
+    // Copy generated input data into input tensor
+    CopyVectorIntoTensor(input, inputData);
+
+    // Create BC vectors according to default vals
+    eDataType input_dtype = input.dtype().etype();
+    auto compute_cc_default = [&]() -> double {
+        switch (input_dtype) {
+            case eDataType::DATA_TYPE_U8:  return 1u << (8 - 1);
+            case eDataType::DATA_TYPE_U16: return 1u << (16 - 1);
+            case eDataType::DATA_TYPE_S16: return 1u << (16 - 2);
+            case eDataType::DATA_TYPE_S32: return 1u << (32 - 2);
+            case eDataType::DATA_TYPE_F32: return 0.5;
+            default: return 0.5;
+        }
+    };
+    BC_DT trueContrastCenter = static_cast<BC_DT>(compute_cc_default());
+    std::vector<BC_DT> brightnessDataDefault(batchSize, static_cast<BC_DT>(1.0));
+    std::vector<BC_DT> contrastDataDefault(batchSize, static_cast<BC_DT>(1.0));
+    std::vector<BC_DT> brightnessShiftDataDefault(batchSize, static_cast<BC_DT>(0.0));
+    std::vector<BC_DT> contrastCenterDataDefault(batchSize, trueContrastCenter);
+
+    // Create BC vectors with rand values different per sample, use to fill in tensors
+    std::vector<BC_DT> brightnessDataRand(batchSize);
+    std::vector<BC_DT> contrastDataRand(batchSize);
+    std::vector<BC_DT> brightnessShiftDataRand(batchSize);
+    std::vector<BC_DT> contrastCenterDataRand(batchSize);
+    FillVectorRange(brightnessDataRand, static_cast<BC_DT>(0.5), static_cast<BC_DT>(2.0));
+    FillVectorRange(contrastDataRand, static_cast<BC_DT>(0.5), static_cast<BC_DT>(2.0));
+    FillVectorRange(brightnessShiftDataRand, static_cast<BC_DT>(-0.25), static_cast<BC_DT>(0.25));
+    BC_DT centerOffset = trueContrastCenter * static_cast<BC_DT>(0.1);
+    FillVectorRange(contrastCenterDataRand,
+                  trueContrastCenter - centerOffset,
+                  trueContrastCenter + centerOffset);
+ 
+    constexpr eDataType bc_edt = std::is_same_v<BC_DT, double>
+      ? eDataType::DATA_TYPE_F64
+      : eDataType::DATA_TYPE_F32;
+    TensorShape shape(TensorLayout(eTensorLayout::TENSOR_LAYOUT_N), {batchSize});
+    Tensor brightnessTensor(shape, DataType(bc_edt), device);
+    Tensor contrastTensor(shape, DataType(bc_edt), device);
+    Tensor brightnessShiftTensor(shape, DataType(bc_edt), device);
+    Tensor contrastCenterTensor(shape, DataType(bc_edt), device);
+    CopyVectorIntoTensor(brightnessTensor, brightnessDataRand);
+    CopyVectorIntoTensor(contrastTensor, contrastDataRand);
+    CopyVectorIntoTensor(brightnessShiftTensor, brightnessShiftDataRand);
+    CopyVectorIntoTensor(contrastCenterTensor, contrastCenterDataRand);
+    
+    // Calculate golden output reference for default vals
+    std::vector<BT_DEST> defaultRef = GoldenBrightnessContrast<SRC_DT, DEST_DT, BC_DT>(inputData, batchSize, width, height,
+                                                                                        brightnessDataDefault, contrastDataDefault, brightnessShiftDataDefault, contrastCenterDataDefault);
+    // Calculate golden output reference for random per sample vals
+    std::vector<BT_DEST> randRef = GoldenBrightnessContrast<SRC_DT, DEST_DT, BC_DT>(inputData, batchSize, width, height,
+                                                                                    brightnessDataRand, contrastDataRand, brightnessShiftDataRand, contrastCenterDataRand);
+ 
+    // Run roccv::Brightness Contrast operator to obtain actual results using default vals
+    hipStream_t stream;
+    HIP_VALIDATE_NO_ERRORS(hipStreamCreate(&stream));
+    BrightnessContrast op;
+
+    op(stream, input, defaultOutput, std::nullopt, std::nullopt, std::nullopt, std::nullopt, device);
+    HIP_VALIDATE_NO_ERRORS(hipStreamSynchronize(stream));
+
+    // Copy data from output tensor into a host allocated vector
+    std::vector<BT_DEST> defaultResult(defaultOutput.shape().size());
+    CopyTensorIntoVector(defaultResult, defaultOutput);
+
+    // Run roccv::Brightness Contrast operator to obtain actual results using rand per sample vals
+    op(stream, input, randOutput, brightnessTensor, contrastTensor, brightnessShiftTensor, contrastCenterTensor, device);
+    HIP_VALIDATE_NO_ERRORS(hipStreamSynchronize(stream));
+    HIP_VALIDATE_NO_ERRORS(hipStreamDestroy(stream));
+
+    // Copy data from output tensor into a host allocated vector
+    std::vector<BT_DEST> randResult(randOutput.shape().size());
+    CopyTensorIntoVector(randResult, randOutput);
+
+    // Compare data in actual output versus the generated golden reference image
+    // Using 1.0E-4 as the error threshold to account for FMA/non-FMA float divergence between CPU and GPU.
+    CompareVectorsNear(defaultResult, defaultRef, 1.0E-4); // check this threshold
+    CompareVectorsNear(randResult, randRef, 1.0E-4); // check this threshold
+}
+
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    (void)argc;
+    (void)argv;
+    TEST_CASES_BEGIN();
+
+    // TODO also add negative tests
+    // todo different image sizes?
+
+    // CPU correctness tests
+    // 1 Channel
+    TEST_CASE((TestCorrectness<uchar1, uchar1, float>(1, 360, 480, FMT_U8, FMT_U8, 1.5f, 1.2f, 0.1f, 100.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<ushort1, ushort1, float>(1, 360, 480, FMT_U16, FMT_U16, 1.5f, 1.2f, 0.1f, 30000.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<short1, short1, float>(1, 360, 480, FMT_S16, FMT_S16, 1.5f, 1.2f, 0.1f, 10000.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<int1, int1, double>(1, 360, 480, FMT_S32, FMT_S32, 1.5, 1.2, 0.1, 1000000000.0, eDataType::DATA_TYPE_F64, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<float1, float1, float>(1, 360, 480, FMT_F32, FMT_F32, 1.5f, 1.2f, 0.1f, 0.6f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+
+    TEST_CASE((TestCorrectness<uchar1, ushort1, float>(1, 480, 360, FMT_U8, FMT_U16, 1.5f, 1.2f, 0.1f, 100.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<ushort1, uchar1, float>(1, 480, 360, FMT_U16, FMT_U8, 1.5f, 1.2f, 0.1f, 30000.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<short1, uchar1, float>(1, 480, 360, FMT_S16, FMT_U8, 1.5f, 1.2f, 0.1f, 10000.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<ushort1, short1, float>(1, 480, 360, FMT_U16, FMT_S16, 1.5f, 1.2f, 0.1f, 30000.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<short1, ushort1, float>(1, 480, 360, FMT_S16, FMT_U16, 1.5f, 1.2f, 0.1f, 10000.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uchar1, int1, double>(1, 480, 360, FMT_U8, FMT_S32, 1.5, 1.2, 0.1, 100.0, eDataType::DATA_TYPE_F64, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<int1, uchar1, double>(1, 480, 360, FMT_S32, FMT_U8, 1.5, 1.2, 0.1, 1000000000.0, eDataType::DATA_TYPE_F64, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uchar1, float1, float>(1, 480, 360, FMT_U8, FMT_F32, 1.5f, 1.2f, 0.1f, 100.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<float1, uchar1, float>(1, 480, 360, FMT_F32, FMT_U8, 1.5f, 1.2f, 0.1f, 0.6f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+
+    TEST_CASE((TestCorrectnessDefaultsAndPer<float1, float1, float> (1, 480, 360, FMT_F32, FMT_F32,  eDeviceType::CPU)));
+    TEST_CASE((TestCorrectnessDefaultsAndPer<uchar1, int1, double>(1, 480, 360, FMT_U8, FMT_S32, eDeviceType::CPU)));
+
+    // 3 Channels
+    TEST_CASE((TestCorrectness<uchar3, uchar3, float>(1, 360, 480, FMT_RGB8, FMT_RGB8, 1.5f, 1.2f, 0.1f, 100.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<ushort3, ushort3, float>(1, 360, 480, FMT_RGB16, FMT_RGB16, 1.5f, 1.2f, 0.1f, 30000.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<short3, short3, float>(1, 360, 480, FMT_RGBs16, FMT_RGBs16, 1.5f, 1.2f, 0.1f, 10000.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<int3, int3, double>(1, 360, 480, FMT_RGBs32, FMT_RGBs32, 1.5, 1.2, 0.1, 1000000000.0, eDataType::DATA_TYPE_F64, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<float3, float3, float>(1, 360, 480, FMT_RGBf32, FMT_RGBf32, 1.5f, 1.2f, 0.1f, 0.6f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+
+    TEST_CASE((TestCorrectness<uchar3, ushort3, float>(1, 480, 360, FMT_RGB8, FMT_RGB16, 1.5f, 1.2f, 0.1f, 100.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<ushort3, uchar3, float>(1, 480, 360, FMT_RGB16, FMT_RGB8, 1.5f, 1.2f, 0.1f, 30000.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<short3, uchar3, float>(1, 480, 360, FMT_RGBs16, FMT_RGB8, 1.5f, 1.2f, 0.1f, 10000.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<ushort3, short3, float>(1, 480, 360, FMT_RGB16, FMT_RGBs16, 1.5f, 1.2f, 0.1f, 30000.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<short3, ushort3, float>(1, 480, 360, FMT_RGBs16, FMT_RGB16, 1.5f, 1.2f, 0.1f, 10000.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uchar3, int3, double>(1, 480, 360, FMT_RGB8, FMT_RGBs32, 1.5, 1.2, 0.1, 100.0, eDataType::DATA_TYPE_F64, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<int3, uchar3, double>(1, 480, 360, FMT_RGBs32, FMT_RGB8, 1.5, 1.2, 0.1, 1000000000.0, eDataType::DATA_TYPE_F64, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uchar3, float3, float>(1, 480, 360, FMT_RGB8, FMT_RGBf32, 1.5f, 1.2f, 0.1f, 100.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<float3, uchar3, float>(1, 480, 360, FMT_RGBf32, FMT_RGB8, 1.5f, 1.2f, 0.1f, 0.6f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+
+    TEST_CASE((TestCorrectnessDefaultsAndPer<float3, float3, float> (1, 480, 360, FMT_RGBf32, FMT_RGBf32,  eDeviceType::CPU)));
+    TEST_CASE((TestCorrectnessDefaultsAndPer<uchar3, int3, double>(1, 480, 360, FMT_RGB8, FMT_RGBs32, eDeviceType::CPU)));
+
+    // 4 Channels
+    TEST_CASE((TestCorrectness<uchar4, uchar4, float>(1, 360, 480, FMT_RGBA8, FMT_RGBA8, 1.5f, 1.2f, 0.1f, 100.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<ushort4, ushort4, float>(1, 360, 480, FMT_RGBA16, FMT_RGBA16, 1.5f, 1.2f, 0.1f, 30000.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<short4, short4, float>(1, 360, 480, FMT_RGBAs16, FMT_RGBAs16, 1.5f, 1.2f, 0.1f, 10000.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<int4, int4, double>(1, 360, 480, FMT_RGBAs32, FMT_RGBAs32, 1.5, 1.2, 0.1, 1000000000.0, eDataType::DATA_TYPE_F64, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<float4, float4, float>(1, 360, 480, FMT_RGBAf32, FMT_RGBAf32, 1.5f, 1.2f, 0.1f, 0.6f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+
+    TEST_CASE((TestCorrectness<uchar4, ushort4, float>(1, 480, 360, FMT_RGBA8, FMT_RGBA16, 1.5f, 1.2f, 0.1f, 100.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<ushort4, uchar4, float>(1, 480, 360, FMT_RGBA16, FMT_RGBA8, 1.5f, 1.2f, 0.1f, 30000.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<short4, uchar4, float>(1, 480, 360, FMT_RGBAs16, FMT_RGBA8, 1.5f, 1.2f, 0.1f, 10000.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<ushort4, short4, float>(1, 480, 360, FMT_RGBA16, FMT_RGBAs16, 1.5f, 1.2f, 0.1f, 30000.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<short4, ushort4, float>(1, 480, 360, FMT_RGBAs16, FMT_RGBA16, 1.5f, 1.2f, 0.1f, 10000.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uchar4, int4, double>(1, 480, 360, FMT_RGBA8, FMT_RGBAs32, 1.5, 1.2, 0.1, 100.0, eDataType::DATA_TYPE_F64, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<int4, uchar4, double>(1, 480, 360, FMT_RGBAs32, FMT_RGBA8, 1.5, 1.2, 0.1, 1000000000.0, eDataType::DATA_TYPE_F64, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uchar4, float4, float>(1, 480, 360, FMT_RGBA8, FMT_RGBAf32, 1.5f, 1.2f, 0.1f, 100.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<float4, uchar4, float>(1, 480, 360, FMT_RGBAf32, FMT_RGBA8, 1.5f, 1.2f, 0.1f, 0.6f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+
+    TEST_CASE((TestCorrectnessDefaultsAndPer<float4, float4, float> (1, 480, 360, FMT_RGBAf32, FMT_RGBAf32,  eDeviceType::CPU)));
+    TEST_CASE((TestCorrectnessDefaultsAndPer<uchar4, int4, double>(1, 480, 360, FMT_RGBA8, FMT_RGBAs32, eDeviceType::CPU)));
+
+    // GPU Correctness Tests
+     // 1 Channel
+    TEST_CASE((TestCorrectness<uchar1, uchar1, float>(1, 360, 480, FMT_U8, FMT_U8, 1.5f, 1.2f, 0.1f, 100.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<ushort1, ushort1, float>(1, 360, 480, FMT_U16, FMT_U16, 1.5f, 1.2f, 0.1f, 30000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<short1, short1, float>(1, 360, 480, FMT_S16, FMT_S16, 1.5f, 1.2f, 0.1f, 10000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<int1, int1, double>(1, 360, 480, FMT_S32, FMT_S32, 1.5, 1.2, 0.1, 1000000000.0, eDataType::DATA_TYPE_F64, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<float1, float1, float>(1, 360, 480, FMT_F32, FMT_F32, 1.5f, 1.2f, 0.1f, 0.6f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+
+    TEST_CASE((TestCorrectness<uchar1, ushort1, float>(1, 480, 360, FMT_U8, FMT_U16, 1.5f, 1.2f, 0.1f, 100.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<ushort1, uchar1, float>(1, 480, 360, FMT_U16, FMT_U8, 1.5f, 1.2f, 0.1f, 30000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<short1, uchar1, float>(1, 480, 360, FMT_S16, FMT_U8, 1.5f, 1.2f, 0.1f, 10000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<ushort1, short1, float>(1, 480, 360, FMT_U16, FMT_S16, 1.5f, 1.2f, 0.1f, 30000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<short1, ushort1, float>(1, 480, 360, FMT_S16, FMT_U16, 1.5f, 1.2f, 0.1f, 10000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<uchar1, int1, double>(1, 480, 360, FMT_U8, FMT_S32, 1.5, 1.2, 0.1, 100.0, eDataType::DATA_TYPE_F64, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<int1, uchar1, double>(1, 480, 360, FMT_S32, FMT_U8, 1.5, 1.2, 0.1, 1000000000.0, eDataType::DATA_TYPE_F64, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<uchar1, float1, float>(1, 480, 360, FMT_U8, FMT_F32, 1.5f, 1.2f, 0.1f, 100.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<float1, uchar1, float>(1, 480, 360, FMT_F32, FMT_U8, 1.5f, 1.2f, 0.1f, 0.6f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+
+    TEST_CASE((TestCorrectnessDefaultsAndPer<float1, float1, float> (1, 480, 360, FMT_F32, FMT_F32,  eDeviceType::GPU)));
+    TEST_CASE((TestCorrectnessDefaultsAndPer<uchar1, int1, double>(1, 480, 360, FMT_U8, FMT_S32, eDeviceType::GPU)));
+
+    // 3 Channels
+    TEST_CASE((TestCorrectness<uchar3, uchar3, float>(1, 360, 480, FMT_RGB8, FMT_RGB8, 1.5f, 1.2f, 0.1f, 100.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<ushort3, ushort3, float>(1, 360, 480, FMT_RGB16, FMT_RGB16, 1.5f, 1.2f, 0.1f, 30000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<short3, short3, float>(1, 360, 480, FMT_RGBs16, FMT_RGBs16, 1.5f, 1.2f, 0.1f, 10000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<int3, int3, double>(1, 360, 480, FMT_RGBs32, FMT_RGBs32, 1.5, 1.2, 0.1, 1000000000.0, eDataType::DATA_TYPE_F64, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<float3, float3, float>(1, 360, 480, FMT_RGBf32, FMT_RGBf32, 1.5f, 1.2f, 0.1f, 0.6f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+
+    TEST_CASE((TestCorrectness<uchar3, ushort3, float>(1, 480, 360, FMT_RGB8, FMT_RGB16, 1.5f, 1.2f, 0.1f, 100.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<ushort3, uchar3, float>(1, 480, 360, FMT_RGB16, FMT_RGB8, 1.5f, 1.2f, 0.1f, 30000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<short3, uchar3, float>(1, 480, 360, FMT_RGBs16, FMT_RGB8, 1.5f, 1.2f, 0.1f, 10000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<ushort3, short3, float>(1, 480, 360, FMT_RGB16, FMT_RGBs16, 1.5f, 1.2f, 0.1f, 30000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<short3, ushort3, float>(1, 480, 360, FMT_RGBs16, FMT_RGB16, 1.5f, 1.2f, 0.1f, 10000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<uchar3, int3, double>(1, 480, 360, FMT_RGB8, FMT_RGBs32, 1.5, 1.2, 0.1, 100.0, eDataType::DATA_TYPE_F64, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<int3, uchar3, double>(1, 480, 360, FMT_RGBs32, FMT_RGB8, 1.5, 1.2, 0.1, 1000000000.0, eDataType::DATA_TYPE_F64, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<uchar3, float3, float>(1, 480, 360, FMT_RGB8, FMT_RGBf32, 1.5f, 1.2f, 0.1f, 100.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<float3, uchar3, float>(1, 480, 360, FMT_RGBf32, FMT_RGB8, 1.5f, 1.2f, 0.1f, 0.6f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+
+    TEST_CASE((TestCorrectnessDefaultsAndPer<float3, float3, float> (1, 480, 360, FMT_RGBf32, FMT_RGBf32,  eDeviceType::GPU)));
+    TEST_CASE((TestCorrectnessDefaultsAndPer<uchar3, int3, double>(1, 480, 360, FMT_RGB8, FMT_RGBs32, eDeviceType::GPU)));
+
+    // 4 Channels
+    TEST_CASE((TestCorrectness<uchar4, uchar4, float>(1, 360, 480, FMT_RGBA8, FMT_RGBA8, 1.5f, 1.2f, 0.1f, 100.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<ushort4, ushort4, float>(1, 360, 480, FMT_RGBA16, FMT_RGBA16, 1.5f, 1.2f, 0.1f, 30000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<short4, short4, float>(1, 360, 480, FMT_RGBAs16, FMT_RGBAs16, 1.5f, 1.2f, 0.1f, 10000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<int4, int4, double>(1, 360, 480, FMT_RGBAs32, FMT_RGBAs32, 1.5, 1.2, 0.1, 1000000000.0, eDataType::DATA_TYPE_F64, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<float4, float4, float>(1, 360, 480, FMT_RGBAf32, FMT_RGBAf32, 1.5f, 1.2f, 0.1f, 0.6f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+
+    TEST_CASE((TestCorrectness<uchar4, ushort4, float>(1, 480, 360, FMT_RGBA8, FMT_RGBA16, 1.5f, 1.2f, 0.1f, 100.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<ushort4, uchar4, float>(1, 480, 360, FMT_RGBA16, FMT_RGBA8, 1.5f, 1.2f, 0.1f, 30000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<short4, uchar4, float>(1, 480, 360, FMT_RGBAs16, FMT_RGBA8, 1.5f, 1.2f, 0.1f, 10000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<ushort4, short4, float>(1, 480, 360, FMT_RGBA16, FMT_RGBAs16, 1.5f, 1.2f, 0.1f, 30000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<short4, ushort4, float>(1, 480, 360, FMT_RGBAs16, FMT_RGBA16, 1.5f, 1.2f, 0.1f, 10000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<uchar4, int4, double>(1, 480, 360, FMT_RGBA8, FMT_RGBAs32, 1.5, 1.2, 0.1, 100.0, eDataType::DATA_TYPE_F64, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<int4, uchar4, double>(1, 480, 360, FMT_RGBAs32, FMT_RGBA8, 1.5, 1.2, 0.1, 1000000000.0, eDataType::DATA_TYPE_F64, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<uchar4, float4, float>(1, 480, 360, FMT_RGBA8, FMT_RGBAf32, 1.5f, 1.2f, 0.1f, 100.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<float4, uchar4, float>(1, 480, 360, FMT_RGBAf32, FMT_RGBA8, 1.5f, 1.2f, 0.1f, 0.6f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+
+    TEST_CASE((TestCorrectnessDefaultsAndPer<float4, float4, float> (1, 480, 360, FMT_RGBAf32, FMT_RGBAf32,  eDeviceType::GPU)));
+    TEST_CASE((TestCorrectnessDefaultsAndPer<uchar4, int4, double>(1, 480, 360, FMT_RGBA8, FMT_RGBAs32, eDeviceType::GPU)));
+
+    TEST_CASES_END();
+}

--- a/tests/roccv/cpp/src/tests/operators/test_op_brightness_contrast.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_brightness_contrast.cpp
@@ -386,8 +386,8 @@ int main(int argc, char** argv) {
     TEST_CASE((TestCorrectness<float1, uchar1, float>(1, 480, 360, FMT_F32, FMT_U8, 1.5f, 1.2f, 0.1f, 0.6f,
                                                       eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
 
-    TEST_CASE((TestCorrectnessDefaultsAndPer<float1, float1, float>(1, 480, 360, FMT_F32, FMT_F32, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectnessDefaultsAndPer<uchar1, int1, double>(1, 480, 360, FMT_U8, FMT_S32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectnessDefaultsAndPer<float1, float1, float>(3, 480, 360, FMT_F32, FMT_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectnessDefaultsAndPer<uchar1, int1, double>(3, 480, 360, FMT_U8, FMT_S32, eDeviceType::CPU)));
 
     // 3 Channels
     TEST_CASE((TestCorrectness<uchar3, uchar3, float>(1, 640, 480, FMT_RGB8, FMT_RGB8, 1.5f, 1.2f, 0.1f, 100.0f,
@@ -421,9 +421,9 @@ int main(int argc, char** argv) {
                                                       eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
 
     TEST_CASE(
-        (TestCorrectnessDefaultsAndPer<float3, float3, float>(1, 480, 640, FMT_RGBf32, FMT_RGBf32, eDeviceType::CPU)));
+        (TestCorrectnessDefaultsAndPer<float3, float3, float>(3, 480, 640, FMT_RGBf32, FMT_RGBf32, eDeviceType::CPU)));
     TEST_CASE(
-        (TestCorrectnessDefaultsAndPer<uchar3, int3, double>(1, 480, 640, FMT_RGB8, FMT_RGBs32, eDeviceType::CPU)));
+        (TestCorrectnessDefaultsAndPer<uchar3, int3, double>(3, 480, 640, FMT_RGB8, FMT_RGBs32, eDeviceType::CPU)));
 
     // 4 Channels
     TEST_CASE((TestCorrectness<uchar4, uchar4, float>(1, 360, 480, FMT_RGBA8, FMT_RGBA8, 1.5f, 1.2f, 0.1f, 100.0f,
@@ -457,9 +457,9 @@ int main(int argc, char** argv) {
                                                       eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
 
     TEST_CASE((
-        TestCorrectnessDefaultsAndPer<float4, float4, float>(1, 480, 360, FMT_RGBAf32, FMT_RGBAf32, eDeviceType::CPU)));
+        TestCorrectnessDefaultsAndPer<float4, float4, float>(3, 480, 360, FMT_RGBAf32, FMT_RGBAf32, eDeviceType::CPU)));
     TEST_CASE(
-        (TestCorrectnessDefaultsAndPer<uchar4, int4, double>(1, 480, 360, FMT_RGBA8, FMT_RGBAs32, eDeviceType::CPU)));
+        (TestCorrectnessDefaultsAndPer<uchar4, int4, double>(3, 480, 360, FMT_RGBA8, FMT_RGBAs32, eDeviceType::CPU)));
 
     // GPU Correctness Tests
     // 1 Channel
@@ -493,8 +493,8 @@ int main(int argc, char** argv) {
     TEST_CASE((TestCorrectness<float1, uchar1, float>(1, 480, 360, FMT_F32, FMT_U8, 1.5f, 1.2f, 0.1f, 0.6f,
                                                       eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
 
-    TEST_CASE((TestCorrectnessDefaultsAndPer<float1, float1, float>(1, 480, 360, FMT_F32, FMT_F32, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectnessDefaultsAndPer<uchar1, int1, double>(1, 480, 360, FMT_U8, FMT_S32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectnessDefaultsAndPer<float1, float1, float>(3, 480, 360, FMT_F32, FMT_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectnessDefaultsAndPer<uchar1, int1, double>(3, 480, 360, FMT_U8, FMT_S32, eDeviceType::GPU)));
 
     // 3 Channels
     TEST_CASE((TestCorrectness<uchar3, uchar3, float>(1, 360, 480, FMT_RGB8, FMT_RGB8, 1.5f, 1.2f, 0.1f, 100.0f,
@@ -528,9 +528,9 @@ int main(int argc, char** argv) {
                                                       eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
 
     TEST_CASE(
-        (TestCorrectnessDefaultsAndPer<float3, float3, float>(1, 480, 360, FMT_RGBf32, FMT_RGBf32, eDeviceType::GPU)));
+        (TestCorrectnessDefaultsAndPer<float3, float3, float>(3, 480, 360, FMT_RGBf32, FMT_RGBf32, eDeviceType::GPU)));
     TEST_CASE(
-        (TestCorrectnessDefaultsAndPer<uchar3, int3, double>(1, 480, 360, FMT_RGB8, FMT_RGBs32, eDeviceType::GPU)));
+        (TestCorrectnessDefaultsAndPer<uchar3, int3, double>(3, 480, 360, FMT_RGB8, FMT_RGBs32, eDeviceType::GPU)));
 
     // 4 Channels
     TEST_CASE((TestCorrectness<uchar4, uchar4, float>(1, 1920, 1080, FMT_RGBA8, FMT_RGBA8, 1.5f, 1.2f, 0.1f, 100.0f,
@@ -563,10 +563,10 @@ int main(int argc, char** argv) {
     TEST_CASE((TestCorrectness<float4, uchar4, float>(1, 1080, 1920, FMT_RGBAf32, FMT_RGBA8, 1.5f, 1.2f, 0.1f, 0.6f,
                                                       eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
 
-    TEST_CASE((TestCorrectnessDefaultsAndPer<float4, float4, float>(1, 3840, 2160, FMT_RGBAf32, FMT_RGBAf32,
+    TEST_CASE((TestCorrectnessDefaultsAndPer<float4, float4, float>(3, 3840, 2160, FMT_RGBAf32, FMT_RGBAf32,
                                                                     eDeviceType::GPU)));
     TEST_CASE(
-        (TestCorrectnessDefaultsAndPer<uchar4, int4, double>(1, 2160, 3840, FMT_RGBA8, FMT_RGBAs32, eDeviceType::GPU)));
+        (TestCorrectnessDefaultsAndPer<uchar4, int4, double>(3, 2160, 3840, FMT_RGBA8, FMT_RGBAs32, eDeviceType::GPU)));
 
     TEST_CASES_END();
 }

--- a/tests/roccv/cpp/src/tests/operators/test_op_brightness_contrast.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_brightness_contrast.cpp
@@ -34,23 +34,29 @@ using namespace roccv::tests;
 namespace {
 
 /**
- * @brief Verified golden C++ model for the ConvertTo operation.
+ * @brief Golden model for the Brightness Contrast operation.
  *
- * @tparam T Vectorized datatype of the image's pixels.
- * @tparam BT Base type of the image's data.
+ * @tparam SRC_DT Vectorized datatype of the source image's pixels.
+ * @tparam DEST_DT Vectorized datatype of the destination image's pixels.
+ * @tparam BC_DT Datatype of the brightness/contrast parameters.
+ * @tparam BT_SRC Base type of the source image's data.
+ * @tparam BT_DEST Base type of the destination image's data.
  * @param[in] input An input vector containing image data.
  * @param[in] batchSize The number of images in the batch.
  * @param[in] width Image width.
  * @param[in] height Image height.
- * @param[in] channels Number of channels in the image.
- * @param[in] alpha Scalar for output data.
- * @param[in] beta Offset for the data.
+ * @param[in] brightness Vector of brightness multiplier values (one per image in the batch).
+ * @param[in] contrast Vector of contrast multiplier values (one per image in the batch).
+ * @param[in] brightnessShift Vector of brightness offset values (one per image in the batch).
+ * @param[in] contrastCenter Vector of contrast center points (one per image in the batch).
  * @return Vector containing the results of the operation.
  */
 template <typename SRC_DT, typename DEST_DT, typename BC_DT, typename BT_SRC = detail::BaseType<SRC_DT>,
           typename BT_DEST = detail::BaseType<DEST_DT>>
-std::vector<BT_DEST> GoldenBrightnessContrast(std::vector<BT_SRC>& input, int32_t batchSize, int32_t width, int32_t height,
-                                     std::vector<BC_DT>& brightness,std::vector<BC_DT>& contrast, std::vector<BC_DT>& brightnessShift, std::vector<BC_DT>& contrastCenter) {
+std::vector<BT_DEST> GoldenBrightnessContrast(std::vector<BT_SRC>& input, int32_t batchSize, int32_t width,
+                                              int32_t height, std::vector<BC_DT>& brightness,
+                                              std::vector<BC_DT>& contrast, std::vector<BC_DT>& brightnessShift,
+                                              std::vector<BC_DT>& contrastCenter) {
     // Create an output vector the same size as the input vector
     std::vector<BT_DEST> output(input.size());
 
@@ -77,10 +83,11 @@ std::vector<BT_DEST> GoldenBrightnessContrast(std::vector<BT_SRC>& input, int32_
     return output;
 }
 
-template <typename SRC_DT, typename DEST_DT, typename BC_DT,
-        typename BT_SRC = detail::BaseType<SRC_DT>, typename BT_DEST = detail::BaseType<DEST_DT>>
-void TestCorrectness(int batchSize, int width, int height, ImageFormat inFormat, ImageFormat outFormat, BC_DT brightness,
-                     BC_DT contrast, BC_DT brightnessShift, BC_DT contrastCenter, eDataType bc_edt, eDeviceType device) {
+template <typename SRC_DT, typename DEST_DT, typename BC_DT, typename BT_SRC = detail::BaseType<SRC_DT>,
+          typename BT_DEST = detail::BaseType<DEST_DT>>
+void TestCorrectness(int batchSize, int width, int height, ImageFormat inFormat, ImageFormat outFormat,
+                     BC_DT brightness, BC_DT contrast, BC_DT brightnessShift, BC_DT contrastCenter, eDataType bc_edt,
+                     eDeviceType device) {
     // Create input and output tensor based on test parameters
     Tensor input(batchSize, {width, height}, inFormat, device);
     Tensor output(batchSize, {width, height}, outFormat, device);
@@ -91,7 +98,7 @@ void TestCorrectness(int batchSize, int width, int height, ImageFormat inFormat,
 
     // Copy generated input data into input tensor
     CopyVectorIntoTensor(input, inputData);
-    
+
     // Create brightness/contrast tensors
     TensorShape shape(TensorLayout(eTensorLayout::TENSOR_LAYOUT_N), {batchSize});
     Tensor brightnessTensor(shape, DataType(bc_edt), device);
@@ -99,7 +106,7 @@ void TestCorrectness(int batchSize, int width, int height, ImageFormat inFormat,
     Tensor brightnessShiftTensor(shape, DataType(bc_edt), device);
     Tensor contrastCenterTensor(shape, DataType(bc_edt), device);
 
-    // Create BC vectors according to params and use to fill in tensors
+    // Create BC vectors filled with passed in values, use to fill in tensors
     std::vector<BC_DT> brightnessData(batchSize, brightness);
     std::vector<BC_DT> contrastData(batchSize, contrast);
     std::vector<BC_DT> brightnessShiftData(batchSize, brightnessShift);
@@ -111,12 +118,12 @@ void TestCorrectness(int batchSize, int width, int height, ImageFormat inFormat,
     CopyVectorIntoTensor(contrastCenterTensor, contrastCenterData);
 
     // Calculate golden output reference
-    std::vector<BT_DEST> ref = GoldenBrightnessContrast<SRC_DT, DEST_DT, BC_DT>(inputData, batchSize, width, height, brightnessData, contrastData, brightnessShiftData, contrastCenterData);
- 
+    std::vector<BT_DEST> ref = GoldenBrightnessContrast<SRC_DT, DEST_DT, BC_DT>(
+        inputData, batchSize, width, height, brightnessData, contrastData, brightnessShiftData, contrastCenterData);
+
     // Run roccv::Brightness Contrast operator to obtain actual results
     hipStream_t stream;
     HIP_VALIDATE_NO_ERRORS(hipStreamCreate(&stream));
-
     BrightnessContrast op;
     op(stream, input, output, brightnessTensor, contrastTensor, brightnessShiftTensor, contrastCenterTensor, device);
     HIP_VALIDATE_NO_ERRORS(hipStreamSynchronize(stream));
@@ -128,13 +135,14 @@ void TestCorrectness(int batchSize, int width, int height, ImageFormat inFormat,
 
     // Compare data in actual output versus the generated golden reference image
     // Using 1.0E-4 as the error threshold to account for FMA/non-FMA float divergence between CPU and GPU.
-    CompareVectorsNear(result, ref, 1.0E-4); // tightest threshold passing
+    CompareVectorsNear(result, ref, 1.0E-4);  // tightest threshold passing
 }
 
-template <typename SRC_DT, typename DEST_DT, typename BC_DT,
-        typename BT_SRC = detail::BaseType<SRC_DT>, typename BT_DEST = detail::BaseType<DEST_DT>>
-void TestCorrectnessDefaultsAndPer(int batchSize, int width, int height, ImageFormat inFormat, ImageFormat outFormat, eDeviceType device) {
-    // Create input and output tensor based on test parameters
+template <typename SRC_DT, typename DEST_DT, typename BC_DT, typename BT_SRC = detail::BaseType<SRC_DT>,
+          typename BT_DEST = detail::BaseType<DEST_DT>>
+void TestCorrectnessDefaultsAndPer(int batchSize, int width, int height, ImageFormat inFormat, ImageFormat outFormat,
+                                   eDeviceType device) {
+    // Create input and output tensors based on test parameters
     Tensor input(batchSize, {width, height}, inFormat, device);
     Tensor defaultOutput(batchSize, {width, height}, outFormat, device);
     Tensor randOutput(batchSize, {width, height}, outFormat, device);
@@ -148,14 +156,21 @@ void TestCorrectnessDefaultsAndPer(int batchSize, int width, int height, ImageFo
 
     // Create BC vectors according to default vals
     eDataType input_dtype = input.dtype().etype();
+    // Note: this same lambda is used in the actual op (dependency?)
     auto compute_cc_default = [&]() -> double {
         switch (input_dtype) {
-            case eDataType::DATA_TYPE_U8:  return 1u << (8 - 1);
-            case eDataType::DATA_TYPE_U16: return 1u << (16 - 1);
-            case eDataType::DATA_TYPE_S16: return 1u << (16 - 2);
-            case eDataType::DATA_TYPE_S32: return 1u << (32 - 2);
-            case eDataType::DATA_TYPE_F32: return 0.5;
-            default: return 0.5;
+            case eDataType::DATA_TYPE_U8:
+                return 1u << (8 - 1);
+            case eDataType::DATA_TYPE_U16:
+                return 1u << (16 - 1);
+            case eDataType::DATA_TYPE_S16:
+                return 1u << (16 - 2);
+            case eDataType::DATA_TYPE_S32:
+                return 1u << (32 - 2);
+            case eDataType::DATA_TYPE_F32:
+                return 0.5;
+            default:
+                return 0.5;
         }
     };
     BC_DT trueContrastCenter = static_cast<BC_DT>(compute_cc_default());
@@ -173,13 +188,9 @@ void TestCorrectnessDefaultsAndPer(int batchSize, int width, int height, ImageFo
     FillVectorRange(contrastDataRand, static_cast<BC_DT>(0.5), static_cast<BC_DT>(2.0));
     FillVectorRange(brightnessShiftDataRand, static_cast<BC_DT>(-0.25), static_cast<BC_DT>(0.25));
     BC_DT centerOffset = trueContrastCenter * static_cast<BC_DT>(0.1);
-    FillVectorRange(contrastCenterDataRand,
-                  trueContrastCenter - centerOffset,
-                  trueContrastCenter + centerOffset);
- 
-    constexpr eDataType bc_edt = std::is_same_v<BC_DT, double>
-      ? eDataType::DATA_TYPE_F64
-      : eDataType::DATA_TYPE_F32;
+    FillVectorRange(contrastCenterDataRand, trueContrastCenter - centerOffset, trueContrastCenter + centerOffset);
+
+    constexpr eDataType bc_edt = std::is_same_v<BC_DT, double> ? eDataType::DATA_TYPE_F64 : eDataType::DATA_TYPE_F32;
     TensorShape shape(TensorLayout(eTensorLayout::TENSOR_LAYOUT_N), {batchSize});
     Tensor brightnessTensor(shape, DataType(bc_edt), device);
     Tensor contrastTensor(shape, DataType(bc_edt), device);
@@ -189,19 +200,20 @@ void TestCorrectnessDefaultsAndPer(int batchSize, int width, int height, ImageFo
     CopyVectorIntoTensor(contrastTensor, contrastDataRand);
     CopyVectorIntoTensor(brightnessShiftTensor, brightnessShiftDataRand);
     CopyVectorIntoTensor(contrastCenterTensor, contrastCenterDataRand);
-    
+
     // Calculate golden output reference for default vals
-    std::vector<BT_DEST> defaultRef = GoldenBrightnessContrast<SRC_DT, DEST_DT, BC_DT>(inputData, batchSize, width, height,
-                                                                                        brightnessDataDefault, contrastDataDefault, brightnessShiftDataDefault, contrastCenterDataDefault);
+    std::vector<BT_DEST> defaultRef = GoldenBrightnessContrast<SRC_DT, DEST_DT, BC_DT>(
+        inputData, batchSize, width, height, brightnessDataDefault, contrastDataDefault, brightnessShiftDataDefault,
+        contrastCenterDataDefault);
     // Calculate golden output reference for random per sample vals
-    std::vector<BT_DEST> randRef = GoldenBrightnessContrast<SRC_DT, DEST_DT, BC_DT>(inputData, batchSize, width, height,
-                                                                                    brightnessDataRand, contrastDataRand, brightnessShiftDataRand, contrastCenterDataRand);
- 
+    std::vector<BT_DEST> randRef = GoldenBrightnessContrast<SRC_DT, DEST_DT, BC_DT>(
+        inputData, batchSize, width, height, brightnessDataRand, contrastDataRand, brightnessShiftDataRand,
+        contrastCenterDataRand);
+
     // Run roccv::Brightness Contrast operator to obtain actual results using default vals
     hipStream_t stream;
     HIP_VALIDATE_NO_ERRORS(hipStreamCreate(&stream));
     BrightnessContrast op;
-
     op(stream, input, defaultOutput, std::nullopt, std::nullopt, std::nullopt, std::nullopt, device);
     HIP_VALIDATE_NO_ERRORS(hipStreamSynchronize(stream));
 
@@ -210,7 +222,8 @@ void TestCorrectnessDefaultsAndPer(int batchSize, int width, int height, ImageFo
     CopyTensorIntoVector(defaultResult, defaultOutput);
 
     // Run roccv::Brightness Contrast operator to obtain actual results using rand per sample vals
-    op(stream, input, randOutput, brightnessTensor, contrastTensor, brightnessShiftTensor, contrastCenterTensor, device);
+    op(stream, input, randOutput, brightnessTensor, contrastTensor, brightnessShiftTensor, contrastCenterTensor,
+       device);
     HIP_VALIDATE_NO_ERRORS(hipStreamSynchronize(stream));
     HIP_VALIDATE_NO_ERRORS(hipStreamDestroy(stream));
 
@@ -220,8 +233,8 @@ void TestCorrectnessDefaultsAndPer(int batchSize, int width, int height, ImageFo
 
     // Compare data in actual output versus the generated golden reference image
     // Using 1.0E-4 as the error threshold to account for FMA/non-FMA float divergence between CPU and GPU.
-    CompareVectorsNear(defaultResult, defaultRef, 1.0E-4); // check this threshold
-    CompareVectorsNear(randResult, randRef, 1.0E-4); // check this threshold
+    CompareVectorsNear(defaultResult, defaultRef, 1.0E-4);
+    CompareVectorsNear(randResult, randRef, 1.0E-4);
 }
 
 void TestNegativeBrightnessContrast() {
@@ -237,40 +250,47 @@ void TestNegativeBrightnessContrast() {
         // Test wrong device
         Tensor bc_validCPUTensor(bc_validOneShape, DataType(eDataType::DATA_TYPE_F32), eDeviceType::CPU);
 
-        EXPECT_EXCEPTION(op(nullptr, validCPUTensor, validGPUTensor, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
-                            eDeviceType::GPU), eStatusType::INVALID_OPERATION);
-        EXPECT_EXCEPTION(op(nullptr, validGPUTensor, validCPUTensor, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
-                            eDeviceType::GPU), eStatusType::INVALID_COMBINATION);
-        EXPECT_EXCEPTION(op(nullptr, validGPUTensor, validGPUTensor, bc_validCPUTensor, bc_validCPUTensor, bc_validCPUTensor, bc_validCPUTensor,
-                            eDeviceType::GPU), eStatusType::INVALID_COMBINATION);
+        EXPECT_EXCEPTION(op(nullptr, validCPUTensor, validGPUTensor, std::nullopt, std::nullopt, std::nullopt,
+                            std::nullopt, eDeviceType::GPU),
+                         eStatusType::INVALID_OPERATION);
+        EXPECT_EXCEPTION(op(nullptr, validGPUTensor, validCPUTensor, std::nullopt, std::nullopt, std::nullopt,
+                            std::nullopt, eDeviceType::GPU),
+                         eStatusType::INVALID_COMBINATION);
+        EXPECT_EXCEPTION(op(nullptr, validGPUTensor, validGPUTensor, bc_validCPUTensor, bc_validCPUTensor,
+                            bc_validCPUTensor, bc_validCPUTensor, eDeviceType::GPU),
+                         eStatusType::INVALID_COMBINATION);
     }
 
     {
         // Test unsupported input/output data type
         Tensor invalidTensor(validGPUTensor.shape(), DataType(eDataType::DATA_TYPE_U32), eDeviceType::GPU);
-        EXPECT_EXCEPTION(op(nullptr, invalidTensor, validGPUTensor, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
-                            eDeviceType::GPU), eStatusType::NOT_IMPLEMENTED);
-        EXPECT_EXCEPTION(op(nullptr, validGPUTensor, invalidTensor, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
-                            eDeviceType::GPU), eStatusType::NOT_IMPLEMENTED);
+        EXPECT_EXCEPTION(op(nullptr, invalidTensor, validGPUTensor, std::nullopt, std::nullopt, std::nullopt,
+                            std::nullopt, eDeviceType::GPU),
+                         eStatusType::NOT_IMPLEMENTED);
+        EXPECT_EXCEPTION(op(nullptr, validGPUTensor, invalidTensor, std::nullopt, std::nullopt, std::nullopt,
+                            std::nullopt, eDeviceType::GPU),
+                         eStatusType::NOT_IMPLEMENTED);
     }
 
     {
         // Test unsupported input/output layout
         TensorShape invalidLayoutShape(TensorLayout(eTensorLayout::TENSOR_LAYOUT_NC), {1, 1});
         Tensor invalidTensor(invalidLayoutShape, DataType(eDataType::DATA_TYPE_U8), eDeviceType::GPU);
-        EXPECT_EXCEPTION(op(nullptr, invalidTensor, validGPUTensor, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
-                            eDeviceType::GPU),  eStatusType::INVALID_COMBINATION);
-        EXPECT_EXCEPTION(op(nullptr, validGPUTensor, invalidTensor, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
-                            eDeviceType::GPU),  eStatusType::INVALID_COMBINATION);
+        EXPECT_EXCEPTION(op(nullptr, invalidTensor, validGPUTensor, std::nullopt, std::nullopt, std::nullopt,
+                            std::nullopt, eDeviceType::GPU),
+                         eStatusType::INVALID_COMBINATION);
+        EXPECT_EXCEPTION(op(nullptr, validGPUTensor, invalidTensor, std::nullopt, std::nullopt, std::nullopt,
+                            std::nullopt, eDeviceType::GPU),
+                         eStatusType::INVALID_COMBINATION);
     }
-
 
     {
         // Test input/output shape mismatch
         Tensor invalidTensor(TensorShape(validGPUTensor.layout(), {2, 2, 2, 2}), DataType(eDataType::DATA_TYPE_U8),
                              eDeviceType::GPU);
-        EXPECT_EXCEPTION(op(nullptr, invalidTensor, validGPUTensor, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
-                            eDeviceType::GPU), eStatusType::INVALID_COMBINATION);
+        EXPECT_EXCEPTION(op(nullptr, invalidTensor, validGPUTensor, std::nullopt, std::nullopt, std::nullopt,
+                            std::nullopt, eDeviceType::GPU),
+                         eStatusType::INVALID_COMBINATION);
     }
 
     {
@@ -282,17 +302,21 @@ void TestNegativeBrightnessContrast() {
         Tensor validIntTensor(validShape, DataType(eDataType::DATA_TYPE_S32), eDeviceType::GPU);
         Tensor validCharTensor(validShape, DataType(eDataType::DATA_TYPE_U8), eDeviceType::GPU);
 
-        EXPECT_EXCEPTION(op(nullptr, validCharTensor, validCharTensor, bc_invalidCharTensor, std::nullopt, std::nullopt, std::nullopt,
-                            eDeviceType::GPU),  eStatusType::INVALID_COMBINATION);
+        EXPECT_EXCEPTION(op(nullptr, validCharTensor, validCharTensor, bc_invalidCharTensor, std::nullopt, std::nullopt,
+                            std::nullopt, eDeviceType::GPU),
+                         eStatusType::INVALID_COMBINATION);
 
-        EXPECT_EXCEPTION(op(nullptr, validCharTensor, validCharTensor, std::nullopt, bc_validDoubleTensor, std::nullopt, std::nullopt,
-                            eDeviceType::GPU),  eStatusType::INVALID_COMBINATION);
+        EXPECT_EXCEPTION(op(nullptr, validCharTensor, validCharTensor, std::nullopt, bc_validDoubleTensor, std::nullopt,
+                            std::nullopt, eDeviceType::GPU),
+                         eStatusType::INVALID_COMBINATION);
 
-        EXPECT_EXCEPTION(op(nullptr, validIntTensor, validCharTensor, std::nullopt, std::nullopt, bc_validFloatTensor, std::nullopt,
-                            eDeviceType::GPU),  eStatusType::INVALID_COMBINATION);
+        EXPECT_EXCEPTION(op(nullptr, validIntTensor, validCharTensor, std::nullopt, std::nullopt, bc_validFloatTensor,
+                            std::nullopt, eDeviceType::GPU),
+                         eStatusType::INVALID_COMBINATION);
 
-        EXPECT_EXCEPTION(op(nullptr, validCharTensor, validIntTensor, std::nullopt, std::nullopt, std::nullopt, bc_validFloatTensor,
-                            eDeviceType::GPU),  eStatusType::INVALID_COMBINATION);
+        EXPECT_EXCEPTION(op(nullptr, validCharTensor, validIntTensor, std::nullopt, std::nullopt, std::nullopt,
+                            bc_validFloatTensor, eDeviceType::GPU),
+                         eStatusType::INVALID_COMBINATION);
     }
 
     {
@@ -302,20 +326,23 @@ void TestNegativeBrightnessContrast() {
         Tensor bc_invalidBatchTensor(bc_mismatchBatchShape, DataType(eDataType::DATA_TYPE_F32), eDeviceType::GPU);
         Tensor bc_invalidLayoutTensor(bc_invalidLayoutShape, DataType(eDataType::DATA_TYPE_F32), eDeviceType::GPU);
 
-        EXPECT_EXCEPTION(op(nullptr, validGPUTensor, validGPUTensor, bc_invalidBatchTensor, std::nullopt, std::nullopt, std::nullopt,
-                            eDeviceType::GPU),  eStatusType::INVALID_COMBINATION);
+        EXPECT_EXCEPTION(op(nullptr, validGPUTensor, validGPUTensor, bc_invalidBatchTensor, std::nullopt, std::nullopt,
+                            std::nullopt, eDeviceType::GPU),
+                         eStatusType::INVALID_COMBINATION);
 
-        EXPECT_EXCEPTION(op(nullptr, validGPUTensor, validGPUTensor, std::nullopt, bc_invalidBatchTensor, std::nullopt, std::nullopt,
-                            eDeviceType::GPU),  eStatusType::INVALID_COMBINATION);
+        EXPECT_EXCEPTION(op(nullptr, validGPUTensor, validGPUTensor, std::nullopt, bc_invalidBatchTensor, std::nullopt,
+                            std::nullopt, eDeviceType::GPU),
+                         eStatusType::INVALID_COMBINATION);
 
-        EXPECT_EXCEPTION(op(nullptr, validGPUTensor, validGPUTensor, std::nullopt, std::nullopt, bc_invalidLayoutTensor, std::nullopt,
-                            eDeviceType::GPU),  eStatusType::INVALID_COMBINATION);
+        EXPECT_EXCEPTION(op(nullptr, validGPUTensor, validGPUTensor, std::nullopt, std::nullopt, bc_invalidLayoutTensor,
+                            std::nullopt, eDeviceType::GPU),
+                         eStatusType::INVALID_COMBINATION);
 
-        EXPECT_EXCEPTION(op(nullptr, validGPUTensor, validGPUTensor, std::nullopt, std::nullopt, std::nullopt, bc_invalidLayoutTensor,
-                            eDeviceType::GPU),  eStatusType::INVALID_COMBINATION);
+        EXPECT_EXCEPTION(op(nullptr, validGPUTensor, validGPUTensor, std::nullopt, std::nullopt, std::nullopt,
+                            bc_invalidLayoutTensor, eDeviceType::GPU),
+                         eStatusType::INVALID_COMBINATION);
     }
 }
-
 
 }  // namespace
 
@@ -329,125 +356,217 @@ int main(int argc, char** argv) {
 
     // CPU correctness tests
     // 1 Channel
-    TEST_CASE((TestCorrectness<uchar1, uchar1, float>(1, 360, 480, FMT_U8, FMT_U8, 1.5f, 1.2f, 0.1f, 100.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<ushort1, ushort1, float>(1, 360, 480, FMT_U16, FMT_U16, 1.5f, 1.2f, 0.1f, 30000.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<short1, short1, float>(1, 360, 480, FMT_S16, FMT_S16, 1.5f, 1.2f, 0.1f, 10000.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<int1, int1, double>(1, 360, 480, FMT_S32, FMT_S32, 1.5, 1.2, 0.1, 1000000000.0, eDataType::DATA_TYPE_F64, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<float1, float1, float>(1, 360, 480, FMT_F32, FMT_F32, 1.5f, 1.2f, 0.1f, 0.6f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uchar1, uchar1, float>(1, 360, 480, FMT_U8, FMT_U8, 1.5f, 1.2f, 0.1f, 100.0f,
+                                                      eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<ushort1, ushort1, float>(1, 360, 480, FMT_U16, FMT_U16, 1.5f, 1.2f, 0.1f, 30000.0f,
+                                                        eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<short1, short1, float>(1, 360, 480, FMT_S16, FMT_S16, 1.5f, 1.2f, 0.1f, 10000.0f,
+                                                      eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<int1, int1, double>(1, 360, 480, FMT_S32, FMT_S32, 1.5, 1.2, 0.1, 1000000000.0,
+                                                   eDataType::DATA_TYPE_F64, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<float1, float1, float>(1, 360, 480, FMT_F32, FMT_F32, 1.5f, 1.2f, 0.1f, 0.6f,
+                                                      eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
 
-    TEST_CASE((TestCorrectness<uchar1, ushort1, float>(1, 480, 360, FMT_U8, FMT_U16, 1.5f, 1.2f, 0.1f, 100.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<ushort1, uchar1, float>(1, 480, 360, FMT_U16, FMT_U8, 1.5f, 1.2f, 0.1f, 30000.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<short1, uchar1, float>(1, 480, 360, FMT_S16, FMT_U8, 1.5f, 1.2f, 0.1f, 10000.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<ushort1, short1, float>(1, 480, 360, FMT_U16, FMT_S16, 1.5f, 1.2f, 0.1f, 30000.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<short1, ushort1, float>(1, 480, 360, FMT_S16, FMT_U16, 1.5f, 1.2f, 0.1f, 10000.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<uchar1, int1, double>(1, 480, 360, FMT_U8, FMT_S32, 1.5, 1.2, 0.1, 100.0, eDataType::DATA_TYPE_F64, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<int1, uchar1, double>(1, 480, 360, FMT_S32, FMT_U8, 1.5, 1.2, 0.1, 1000000000.0, eDataType::DATA_TYPE_F64, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<uchar1, float1, float>(1, 480, 360, FMT_U8, FMT_F32, 1.5f, 1.2f, 0.1f, 100.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<float1, uchar1, float>(1, 480, 360, FMT_F32, FMT_U8, 1.5f, 1.2f, 0.1f, 0.6f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uchar1, ushort1, float>(1, 480, 360, FMT_U8, FMT_U16, 1.5f, 1.2f, 0.1f, 100.0f,
+                                                       eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<ushort1, uchar1, float>(1, 480, 360, FMT_U16, FMT_U8, 1.5f, 1.2f, 0.1f, 30000.0f,
+                                                       eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<short1, uchar1, float>(1, 480, 360, FMT_S16, FMT_U8, 1.5f, 1.2f, 0.1f, 10000.0f,
+                                                      eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<ushort1, short1, float>(1, 480, 360, FMT_U16, FMT_S16, 1.5f, 1.2f, 0.1f, 30000.0f,
+                                                       eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<short1, ushort1, float>(1, 480, 360, FMT_S16, FMT_U16, 1.5f, 1.2f, 0.1f, 10000.0f,
+                                                       eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uchar1, int1, double>(1, 480, 360, FMT_U8, FMT_S32, 1.5, 1.2, 0.1, 100.0,
+                                                     eDataType::DATA_TYPE_F64, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<int1, uchar1, double>(1, 480, 360, FMT_S32, FMT_U8, 1.5, 1.2, 0.1, 1000000000.0,
+                                                     eDataType::DATA_TYPE_F64, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uchar1, float1, float>(1, 480, 360, FMT_U8, FMT_F32, 1.5f, 1.2f, 0.1f, 100.0f,
+                                                      eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<float1, uchar1, float>(1, 480, 360, FMT_F32, FMT_U8, 1.5f, 1.2f, 0.1f, 0.6f,
+                                                      eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
 
-    TEST_CASE((TestCorrectnessDefaultsAndPer<float1, float1, float> (1, 480, 360, FMT_F32, FMT_F32,  eDeviceType::CPU)));
+    TEST_CASE((TestCorrectnessDefaultsAndPer<float1, float1, float>(1, 480, 360, FMT_F32, FMT_F32, eDeviceType::CPU)));
     TEST_CASE((TestCorrectnessDefaultsAndPer<uchar1, int1, double>(1, 480, 360, FMT_U8, FMT_S32, eDeviceType::CPU)));
 
     // 3 Channels
-    TEST_CASE((TestCorrectness<uchar3, uchar3, float>(1, 640, 480, FMT_RGB8, FMT_RGB8, 1.5f, 1.2f, 0.1f, 100.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<ushort3, ushort3, float>(1, 640, 480, FMT_RGB16, FMT_RGB16, 1.5f, 1.2f, 0.1f, 30000.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<short3, short3, float>(1, 640, 480, FMT_RGBs16, FMT_RGBs16, 1.5f, 1.2f, 0.1f, 10000.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<int3, int3, double>(1, 640, 480, FMT_RGBs32, FMT_RGBs32, 1.5, 1.2, 0.1, 1000000000.0, eDataType::DATA_TYPE_F64, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<float3, float3, float>(1, 640, 480, FMT_RGBf32, FMT_RGBf32, 1.5f, 1.2f, 0.1f, 0.6f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uchar3, uchar3, float>(1, 640, 480, FMT_RGB8, FMT_RGB8, 1.5f, 1.2f, 0.1f, 100.0f,
+                                                      eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<ushort3, ushort3, float>(1, 640, 480, FMT_RGB16, FMT_RGB16, 1.5f, 1.2f, 0.1f, 30000.0f,
+                                                        eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<short3, short3, float>(1, 640, 480, FMT_RGBs16, FMT_RGBs16, 1.5f, 1.2f, 0.1f, 10000.0f,
+                                                      eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<int3, int3, double>(1, 640, 480, FMT_RGBs32, FMT_RGBs32, 1.5, 1.2, 0.1, 1000000000.0,
+                                                   eDataType::DATA_TYPE_F64, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<float3, float3, float>(1, 640, 480, FMT_RGBf32, FMT_RGBf32, 1.5f, 1.2f, 0.1f, 0.6f,
+                                                      eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
 
-    TEST_CASE((TestCorrectness<uchar3, ushort3, float>(1, 480, 640, FMT_RGB8, FMT_RGB16, 1.5f, 1.2f, 0.1f, 100.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<ushort3, uchar3, float>(1, 480, 640, FMT_RGB16, FMT_RGB8, 1.5f, 1.2f, 0.1f, 30000.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<short3, uchar3, float>(1, 480, 640, FMT_RGBs16, FMT_RGB8, 1.5f, 1.2f, 0.1f, 10000.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<ushort3, short3, float>(1, 480, 640, FMT_RGB16, FMT_RGBs16, 1.5f, 1.2f, 0.1f, 30000.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<short3, ushort3, float>(1, 480, 640, FMT_RGBs16, FMT_RGB16, 1.5f, 1.2f, 0.1f, 10000.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<uchar3, int3, double>(1, 480, 640, FMT_RGB8, FMT_RGBs32, 1.5, 1.2, 0.1, 100.0, eDataType::DATA_TYPE_F64, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<int3, uchar3, double>(1, 480, 640, FMT_RGBs32, FMT_RGB8, 1.5, 1.2, 0.1, 1000000000.0, eDataType::DATA_TYPE_F64, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<uchar3, float3, float>(1, 480, 640, FMT_RGB8, FMT_RGBf32, 1.5f, 1.2f, 0.1f, 100.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<float3, uchar3, float>(1, 480, 640, FMT_RGBf32, FMT_RGB8, 1.5f, 1.2f, 0.1f, 0.6f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uchar3, ushort3, float>(1, 480, 640, FMT_RGB8, FMT_RGB16, 1.5f, 1.2f, 0.1f, 100.0f,
+                                                       eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<ushort3, uchar3, float>(1, 480, 640, FMT_RGB16, FMT_RGB8, 1.5f, 1.2f, 0.1f, 30000.0f,
+                                                       eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<short3, uchar3, float>(1, 480, 640, FMT_RGBs16, FMT_RGB8, 1.5f, 1.2f, 0.1f, 10000.0f,
+                                                      eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<ushort3, short3, float>(1, 480, 640, FMT_RGB16, FMT_RGBs16, 1.5f, 1.2f, 0.1f, 30000.0f,
+                                                       eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<short3, ushort3, float>(1, 480, 640, FMT_RGBs16, FMT_RGB16, 1.5f, 1.2f, 0.1f, 10000.0f,
+                                                       eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uchar3, int3, double>(1, 480, 640, FMT_RGB8, FMT_RGBs32, 1.5, 1.2, 0.1, 100.0,
+                                                     eDataType::DATA_TYPE_F64, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<int3, uchar3, double>(1, 480, 640, FMT_RGBs32, FMT_RGB8, 1.5, 1.2, 0.1, 1000000000.0,
+                                                     eDataType::DATA_TYPE_F64, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uchar3, float3, float>(1, 480, 640, FMT_RGB8, FMT_RGBf32, 1.5f, 1.2f, 0.1f, 100.0f,
+                                                      eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<float3, uchar3, float>(1, 480, 640, FMT_RGBf32, FMT_RGB8, 1.5f, 1.2f, 0.1f, 0.6f,
+                                                      eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
 
-    TEST_CASE((TestCorrectnessDefaultsAndPer<float3, float3, float> (1, 480, 640, FMT_RGBf32, FMT_RGBf32,  eDeviceType::CPU)));
-    TEST_CASE((TestCorrectnessDefaultsAndPer<uchar3, int3, double>(1, 480, 640, FMT_RGB8, FMT_RGBs32, eDeviceType::CPU)));
+    TEST_CASE(
+        (TestCorrectnessDefaultsAndPer<float3, float3, float>(1, 480, 640, FMT_RGBf32, FMT_RGBf32, eDeviceType::CPU)));
+    TEST_CASE(
+        (TestCorrectnessDefaultsAndPer<uchar3, int3, double>(1, 480, 640, FMT_RGB8, FMT_RGBs32, eDeviceType::CPU)));
 
     // 4 Channels
-    TEST_CASE((TestCorrectness<uchar4, uchar4, float>(1, 360, 480, FMT_RGBA8, FMT_RGBA8, 1.5f, 1.2f, 0.1f, 100.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<ushort4, ushort4, float>(1, 360, 480, FMT_RGBA16, FMT_RGBA16, 1.5f, 1.2f, 0.1f, 30000.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<short4, short4, float>(1, 360, 480, FMT_RGBAs16, FMT_RGBAs16, 1.5f, 1.2f, 0.1f, 10000.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<int4, int4, double>(1, 360, 480, FMT_RGBAs32, FMT_RGBAs32, 1.5, 1.2, 0.1, 1000000000.0, eDataType::DATA_TYPE_F64, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<float4, float4, float>(1, 360, 480, FMT_RGBAf32, FMT_RGBAf32, 1.5f, 1.2f, 0.1f, 0.6f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uchar4, uchar4, float>(1, 360, 480, FMT_RGBA8, FMT_RGBA8, 1.5f, 1.2f, 0.1f, 100.0f,
+                                                      eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<ushort4, ushort4, float>(1, 360, 480, FMT_RGBA16, FMT_RGBA16, 1.5f, 1.2f, 0.1f, 30000.0f,
+                                                        eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<short4, short4, float>(1, 360, 480, FMT_RGBAs16, FMT_RGBAs16, 1.5f, 1.2f, 0.1f, 10000.0f,
+                                                      eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<int4, int4, double>(1, 360, 480, FMT_RGBAs32, FMT_RGBAs32, 1.5, 1.2, 0.1, 1000000000.0,
+                                                   eDataType::DATA_TYPE_F64, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<float4, float4, float>(1, 360, 480, FMT_RGBAf32, FMT_RGBAf32, 1.5f, 1.2f, 0.1f, 0.6f,
+                                                      eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
 
-    TEST_CASE((TestCorrectness<uchar4, ushort4, float>(1, 480, 360, FMT_RGBA8, FMT_RGBA16, 1.5f, 1.2f, 0.1f, 100.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<ushort4, uchar4, float>(1, 480, 360, FMT_RGBA16, FMT_RGBA8, 1.5f, 1.2f, 0.1f, 30000.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<short4, uchar4, float>(1, 480, 360, FMT_RGBAs16, FMT_RGBA8, 1.5f, 1.2f, 0.1f, 10000.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<ushort4, short4, float>(1, 480, 360, FMT_RGBA16, FMT_RGBAs16, 1.5f, 1.2f, 0.1f, 30000.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<short4, ushort4, float>(1, 480, 360, FMT_RGBAs16, FMT_RGBA16, 1.5f, 1.2f, 0.1f, 10000.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<uchar4, int4, double>(1, 480, 360, FMT_RGBA8, FMT_RGBAs32, 1.5, 1.2, 0.1, 100.0, eDataType::DATA_TYPE_F64, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<int4, uchar4, double>(1, 480, 360, FMT_RGBAs32, FMT_RGBA8, 1.5, 1.2, 0.1, 1000000000.0, eDataType::DATA_TYPE_F64, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<uchar4, float4, float>(1, 480, 360, FMT_RGBA8, FMT_RGBAf32, 1.5f, 1.2f, 0.1f, 100.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<float4, uchar4, float>(1, 480, 360, FMT_RGBAf32, FMT_RGBA8, 1.5f, 1.2f, 0.1f, 0.6f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uchar4, ushort4, float>(1, 480, 360, FMT_RGBA8, FMT_RGBA16, 1.5f, 1.2f, 0.1f, 100.0f,
+                                                       eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<ushort4, uchar4, float>(1, 480, 360, FMT_RGBA16, FMT_RGBA8, 1.5f, 1.2f, 0.1f, 30000.0f,
+                                                       eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<short4, uchar4, float>(1, 480, 360, FMT_RGBAs16, FMT_RGBA8, 1.5f, 1.2f, 0.1f, 10000.0f,
+                                                      eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<ushort4, short4, float>(1, 480, 360, FMT_RGBA16, FMT_RGBAs16, 1.5f, 1.2f, 0.1f, 30000.0f,
+                                                       eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<short4, ushort4, float>(1, 480, 360, FMT_RGBAs16, FMT_RGBA16, 1.5f, 1.2f, 0.1f, 10000.0f,
+                                                       eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uchar4, int4, double>(1, 480, 360, FMT_RGBA8, FMT_RGBAs32, 1.5, 1.2, 0.1, 100.0,
+                                                     eDataType::DATA_TYPE_F64, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<int4, uchar4, double>(1, 480, 360, FMT_RGBAs32, FMT_RGBA8, 1.5, 1.2, 0.1, 1000000000.0,
+                                                     eDataType::DATA_TYPE_F64, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<uchar4, float4, float>(1, 480, 360, FMT_RGBA8, FMT_RGBAf32, 1.5f, 1.2f, 0.1f, 100.0f,
+                                                      eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectness<float4, uchar4, float>(1, 480, 360, FMT_RGBAf32, FMT_RGBA8, 1.5f, 1.2f, 0.1f, 0.6f,
+                                                      eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
 
-    TEST_CASE((TestCorrectnessDefaultsAndPer<float4, float4, float> (1, 480, 360, FMT_RGBAf32, FMT_RGBAf32,  eDeviceType::CPU)));
-    TEST_CASE((TestCorrectnessDefaultsAndPer<uchar4, int4, double>(1, 480, 360, FMT_RGBA8, FMT_RGBAs32, eDeviceType::CPU)));
+    TEST_CASE((
+        TestCorrectnessDefaultsAndPer<float4, float4, float>(1, 480, 360, FMT_RGBAf32, FMT_RGBAf32, eDeviceType::CPU)));
+    TEST_CASE(
+        (TestCorrectnessDefaultsAndPer<uchar4, int4, double>(1, 480, 360, FMT_RGBA8, FMT_RGBAs32, eDeviceType::CPU)));
 
     // GPU Correctness Tests
-     // 1 Channel
-    TEST_CASE((TestCorrectness<uchar1, uchar1, float>(1, 360, 480, FMT_U8, FMT_U8, 1.5f, 1.2f, 0.1f, 100.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<ushort1, ushort1, float>(1, 360, 480, FMT_U16, FMT_U16, 1.5f, 1.2f, 0.1f, 30000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<short1, short1, float>(1, 360, 480, FMT_S16, FMT_S16, 1.5f, 1.2f, 0.1f, 10000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<int1, int1, double>(1, 360, 480, FMT_S32, FMT_S32, 1.5, 1.2, 0.1, 1000000000.0, eDataType::DATA_TYPE_F64, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<float1, float1, float>(1, 360, 480, FMT_F32, FMT_F32, 1.5f, 1.2f, 0.1f, 0.6f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    // 1 Channel
+    TEST_CASE((TestCorrectness<uchar1, uchar1, float>(1, 360, 480, FMT_U8, FMT_U8, 1.5f, 1.2f, 0.1f, 100.0f,
+                                                      eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<ushort1, ushort1, float>(1, 360, 480, FMT_U16, FMT_U16, 1.5f, 1.2f, 0.1f, 30000.0f,
+                                                        eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<short1, short1, float>(1, 360, 480, FMT_S16, FMT_S16, 1.5f, 1.2f, 0.1f, 10000.0f,
+                                                      eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<int1, int1, double>(1, 360, 480, FMT_S32, FMT_S32, 1.5, 1.2, 0.1, 1000000000.0,
+                                                   eDataType::DATA_TYPE_F64, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<float1, float1, float>(1, 360, 480, FMT_F32, FMT_F32, 1.5f, 1.2f, 0.1f, 0.6f,
+                                                      eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
 
-    TEST_CASE((TestCorrectness<uchar1, ushort1, float>(1, 480, 360, FMT_U8, FMT_U16, 1.5f, 1.2f, 0.1f, 100.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<ushort1, uchar1, float>(1, 480, 360, FMT_U16, FMT_U8, 1.5f, 1.2f, 0.1f, 30000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<short1, uchar1, float>(1, 480, 360, FMT_S16, FMT_U8, 1.5f, 1.2f, 0.1f, 10000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<ushort1, short1, float>(1, 480, 360, FMT_U16, FMT_S16, 1.5f, 1.2f, 0.1f, 30000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<short1, ushort1, float>(1, 480, 360, FMT_S16, FMT_U16, 1.5f, 1.2f, 0.1f, 10000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<uchar1, int1, double>(1, 480, 360, FMT_U8, FMT_S32, 1.5, 1.2, 0.1, 100.0, eDataType::DATA_TYPE_F64, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<int1, uchar1, double>(1, 480, 360, FMT_S32, FMT_U8, 1.5, 1.2, 0.1, 1000000000.0, eDataType::DATA_TYPE_F64, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<uchar1, float1, float>(1, 480, 360, FMT_U8, FMT_F32, 1.5f, 1.2f, 0.1f, 100.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<float1, uchar1, float>(1, 480, 360, FMT_F32, FMT_U8, 1.5f, 1.2f, 0.1f, 0.6f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<uchar1, ushort1, float>(1, 480, 360, FMT_U8, FMT_U16, 1.5f, 1.2f, 0.1f, 100.0f,
+                                                       eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<ushort1, uchar1, float>(1, 480, 360, FMT_U16, FMT_U8, 1.5f, 1.2f, 0.1f, 30000.0f,
+                                                       eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<short1, uchar1, float>(1, 480, 360, FMT_S16, FMT_U8, 1.5f, 1.2f, 0.1f, 10000.0f,
+                                                      eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<ushort1, short1, float>(1, 480, 360, FMT_U16, FMT_S16, 1.5f, 1.2f, 0.1f, 30000.0f,
+                                                       eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<short1, ushort1, float>(1, 480, 360, FMT_S16, FMT_U16, 1.5f, 1.2f, 0.1f, 10000.0f,
+                                                       eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<uchar1, int1, double>(1, 480, 360, FMT_U8, FMT_S32, 1.5, 1.2, 0.1, 100.0,
+                                                     eDataType::DATA_TYPE_F64, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<int1, uchar1, double>(1, 480, 360, FMT_S32, FMT_U8, 1.5, 1.2, 0.1, 1000000000.0,
+                                                     eDataType::DATA_TYPE_F64, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<uchar1, float1, float>(1, 480, 360, FMT_U8, FMT_F32, 1.5f, 1.2f, 0.1f, 100.0f,
+                                                      eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<float1, uchar1, float>(1, 480, 360, FMT_F32, FMT_U8, 1.5f, 1.2f, 0.1f, 0.6f,
+                                                      eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
 
-    TEST_CASE((TestCorrectnessDefaultsAndPer<float1, float1, float> (1, 480, 360, FMT_F32, FMT_F32,  eDeviceType::GPU)));
+    TEST_CASE((TestCorrectnessDefaultsAndPer<float1, float1, float>(1, 480, 360, FMT_F32, FMT_F32, eDeviceType::GPU)));
     TEST_CASE((TestCorrectnessDefaultsAndPer<uchar1, int1, double>(1, 480, 360, FMT_U8, FMT_S32, eDeviceType::GPU)));
 
     // 3 Channels
-    TEST_CASE((TestCorrectness<uchar3, uchar3, float>(1, 360, 480, FMT_RGB8, FMT_RGB8, 1.5f, 1.2f, 0.1f, 100.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<ushort3, ushort3, float>(1, 360, 480, FMT_RGB16, FMT_RGB16, 1.5f, 1.2f, 0.1f, 30000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<short3, short3, float>(1, 360, 480, FMT_RGBs16, FMT_RGBs16, 1.5f, 1.2f, 0.1f, 10000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<int3, int3, double>(1, 360, 480, FMT_RGBs32, FMT_RGBs32, 1.5, 1.2, 0.1, 1000000000.0, eDataType::DATA_TYPE_F64, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<float3, float3, float>(1, 360, 480, FMT_RGBf32, FMT_RGBf32, 1.5f, 1.2f, 0.1f, 0.6f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<uchar3, uchar3, float>(1, 360, 480, FMT_RGB8, FMT_RGB8, 1.5f, 1.2f, 0.1f, 100.0f,
+                                                      eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<ushort3, ushort3, float>(1, 360, 480, FMT_RGB16, FMT_RGB16, 1.5f, 1.2f, 0.1f, 30000.0f,
+                                                        eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<short3, short3, float>(1, 360, 480, FMT_RGBs16, FMT_RGBs16, 1.5f, 1.2f, 0.1f, 10000.0f,
+                                                      eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<int3, int3, double>(1, 360, 480, FMT_RGBs32, FMT_RGBs32, 1.5, 1.2, 0.1, 1000000000.0,
+                                                   eDataType::DATA_TYPE_F64, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<float3, float3, float>(1, 360, 480, FMT_RGBf32, FMT_RGBf32, 1.5f, 1.2f, 0.1f, 0.6f,
+                                                      eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
 
-    TEST_CASE((TestCorrectness<uchar3, ushort3, float>(1, 480, 360, FMT_RGB8, FMT_RGB16, 1.5f, 1.2f, 0.1f, 100.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<ushort3, uchar3, float>(1, 480, 360, FMT_RGB16, FMT_RGB8, 1.5f, 1.2f, 0.1f, 30000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<short3, uchar3, float>(1, 480, 360, FMT_RGBs16, FMT_RGB8, 1.5f, 1.2f, 0.1f, 10000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<ushort3, short3, float>(1, 480, 360, FMT_RGB16, FMT_RGBs16, 1.5f, 1.2f, 0.1f, 30000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<short3, ushort3, float>(1, 480, 360, FMT_RGBs16, FMT_RGB16, 1.5f, 1.2f, 0.1f, 10000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<uchar3, int3, double>(1, 480, 360, FMT_RGB8, FMT_RGBs32, 1.5, 1.2, 0.1, 100.0, eDataType::DATA_TYPE_F64, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<int3, uchar3, double>(1, 480, 360, FMT_RGBs32, FMT_RGB8, 1.5, 1.2, 0.1, 1000000000.0, eDataType::DATA_TYPE_F64, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<uchar3, float3, float>(1, 480, 360, FMT_RGB8, FMT_RGBf32, 1.5f, 1.2f, 0.1f, 100.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<float3, uchar3, float>(1, 480, 360, FMT_RGBf32, FMT_RGB8, 1.5f, 1.2f, 0.1f, 0.6f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<uchar3, ushort3, float>(1, 480, 360, FMT_RGB8, FMT_RGB16, 1.5f, 1.2f, 0.1f, 100.0f,
+                                                       eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<ushort3, uchar3, float>(1, 480, 360, FMT_RGB16, FMT_RGB8, 1.5f, 1.2f, 0.1f, 30000.0f,
+                                                       eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<short3, uchar3, float>(1, 480, 360, FMT_RGBs16, FMT_RGB8, 1.5f, 1.2f, 0.1f, 10000.0f,
+                                                      eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<ushort3, short3, float>(1, 480, 360, FMT_RGB16, FMT_RGBs16, 1.5f, 1.2f, 0.1f, 30000.0f,
+                                                       eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<short3, ushort3, float>(1, 480, 360, FMT_RGBs16, FMT_RGB16, 1.5f, 1.2f, 0.1f, 10000.0f,
+                                                       eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<uchar3, int3, double>(1, 480, 360, FMT_RGB8, FMT_RGBs32, 1.5, 1.2, 0.1, 100.0,
+                                                     eDataType::DATA_TYPE_F64, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<int3, uchar3, double>(1, 480, 360, FMT_RGBs32, FMT_RGB8, 1.5, 1.2, 0.1, 1000000000.0,
+                                                     eDataType::DATA_TYPE_F64, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<uchar3, float3, float>(1, 480, 360, FMT_RGB8, FMT_RGBf32, 1.5f, 1.2f, 0.1f, 100.0f,
+                                                      eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<float3, uchar3, float>(1, 480, 360, FMT_RGBf32, FMT_RGB8, 1.5f, 1.2f, 0.1f, 0.6f,
+                                                      eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
 
-    TEST_CASE((TestCorrectnessDefaultsAndPer<float3, float3, float> (1, 480, 360, FMT_RGBf32, FMT_RGBf32,  eDeviceType::GPU)));
-    TEST_CASE((TestCorrectnessDefaultsAndPer<uchar3, int3, double>(1, 480, 360, FMT_RGB8, FMT_RGBs32, eDeviceType::GPU)));
+    TEST_CASE(
+        (TestCorrectnessDefaultsAndPer<float3, float3, float>(1, 480, 360, FMT_RGBf32, FMT_RGBf32, eDeviceType::GPU)));
+    TEST_CASE(
+        (TestCorrectnessDefaultsAndPer<uchar3, int3, double>(1, 480, 360, FMT_RGB8, FMT_RGBs32, eDeviceType::GPU)));
 
     // 4 Channels
-    TEST_CASE((TestCorrectness<uchar4, uchar4, float>(1, 1920, 1080, FMT_RGBA8, FMT_RGBA8, 1.5f, 1.2f, 0.1f, 100.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<ushort4, ushort4, float>(1, 1920, 1080, FMT_RGBA16, FMT_RGBA16, 1.5f, 1.2f, 0.1f, 30000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<short4, short4, float>(1, 1920, 1080, FMT_RGBAs16, FMT_RGBAs16, 1.5f, 1.2f, 0.1f, 10000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<int4, int4, double>(1, 1920, 1080, FMT_RGBAs32, FMT_RGBAs32, 1.5, 1.2, 0.1, 1000000000.0, eDataType::DATA_TYPE_F64, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<float4, float4, float>(1, 1920, 1080, FMT_RGBAf32, FMT_RGBAf32, 1.5f, 1.2f, 0.1f, 0.6f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<uchar4, uchar4, float>(1, 1920, 1080, FMT_RGBA8, FMT_RGBA8, 1.5f, 1.2f, 0.1f, 100.0f,
+                                                      eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<ushort4, ushort4, float>(1, 1920, 1080, FMT_RGBA16, FMT_RGBA16, 1.5f, 1.2f, 0.1f,
+                                                        30000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<short4, short4, float>(1, 1920, 1080, FMT_RGBAs16, FMT_RGBAs16, 1.5f, 1.2f, 0.1f,
+                                                      10000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<int4, int4, double>(1, 1920, 1080, FMT_RGBAs32, FMT_RGBAs32, 1.5, 1.2, 0.1, 1000000000.0,
+                                                   eDataType::DATA_TYPE_F64, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<float4, float4, float>(1, 1920, 1080, FMT_RGBAf32, FMT_RGBAf32, 1.5f, 1.2f, 0.1f, 0.6f,
+                                                      eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
 
-    TEST_CASE((TestCorrectness<uchar4, ushort4, float>(1, 1080, 1920, FMT_RGBA8, FMT_RGBA16, 1.5f, 1.2f, 0.1f, 100.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<ushort4, uchar4, float>(1, 1080, 1920, FMT_RGBA16, FMT_RGBA8, 1.5f, 1.2f, 0.1f, 30000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<short4, uchar4, float>(1, 1080, 1920, FMT_RGBAs16, FMT_RGBA8, 1.5f, 1.2f, 0.1f, 10000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<ushort4, short4, float>(1, 1080, 1920, FMT_RGBA16, FMT_RGBAs16, 1.5f, 1.2f, 0.1f, 30000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<short4, ushort4, float>(1, 1080, 1920, FMT_RGBAs16, FMT_RGBA16, 1.5f, 1.2f, 0.1f, 10000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<uchar4, int4, double>(1, 1080, 1920, FMT_RGBA8, FMT_RGBAs32, 1.5, 1.2, 0.1, 100.0, eDataType::DATA_TYPE_F64, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<int4, uchar4, double>(1, 1080, 1920, FMT_RGBAs32, FMT_RGBA8, 1.5, 1.2, 0.1, 1000000000.0, eDataType::DATA_TYPE_F64, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<uchar4, float4, float>(1, 1080, 1920, FMT_RGBA8, FMT_RGBAf32, 1.5f, 1.2f, 0.1f, 100.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<float4, uchar4, float>(1, 1080, 1920, FMT_RGBAf32, FMT_RGBA8, 1.5f, 1.2f, 0.1f, 0.6f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<uchar4, ushort4, float>(1, 1080, 1920, FMT_RGBA8, FMT_RGBA16, 1.5f, 1.2f, 0.1f, 100.0f,
+                                                       eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<ushort4, uchar4, float>(1, 1080, 1920, FMT_RGBA16, FMT_RGBA8, 1.5f, 1.2f, 0.1f, 30000.0f,
+                                                       eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<short4, uchar4, float>(1, 1080, 1920, FMT_RGBAs16, FMT_RGBA8, 1.5f, 1.2f, 0.1f, 10000.0f,
+                                                      eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<ushort4, short4, float>(1, 1080, 1920, FMT_RGBA16, FMT_RGBAs16, 1.5f, 1.2f, 0.1f,
+                                                       30000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<short4, ushort4, float>(1, 1080, 1920, FMT_RGBAs16, FMT_RGBA16, 1.5f, 1.2f, 0.1f,
+                                                       10000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<uchar4, int4, double>(1, 1080, 1920, FMT_RGBA8, FMT_RGBAs32, 1.5, 1.2, 0.1, 100.0,
+                                                     eDataType::DATA_TYPE_F64, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<int4, uchar4, double>(1, 1080, 1920, FMT_RGBAs32, FMT_RGBA8, 1.5, 1.2, 0.1, 1000000000.0,
+                                                     eDataType::DATA_TYPE_F64, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<uchar4, float4, float>(1, 1080, 1920, FMT_RGBA8, FMT_RGBAf32, 1.5f, 1.2f, 0.1f, 100.0f,
+                                                      eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectness<float4, uchar4, float>(1, 1080, 1920, FMT_RGBAf32, FMT_RGBA8, 1.5f, 1.2f, 0.1f, 0.6f,
+                                                      eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
 
-    TEST_CASE((TestCorrectnessDefaultsAndPer<float4, float4, float> (1, 3840, 2160, FMT_RGBAf32, FMT_RGBAf32,  eDeviceType::GPU)));
-    TEST_CASE((TestCorrectnessDefaultsAndPer<uchar4, int4, double>(1, 2160, 3840, FMT_RGBA8, FMT_RGBAs32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectnessDefaultsAndPer<float4, float4, float>(1, 3840, 2160, FMT_RGBAf32, FMT_RGBAf32,
+                                                                    eDeviceType::GPU)));
+    TEST_CASE(
+        (TestCorrectnessDefaultsAndPer<uchar4, int4, double>(1, 2160, 3840, FMT_RGBA8, FMT_RGBAs32, eDeviceType::GPU)));
 
     TEST_CASES_END();
 }

--- a/tests/roccv/python/test_op_brightness_contrast.py
+++ b/tests/roccv/python/test_op_brightness_contrast.py
@@ -39,7 +39,7 @@ def test_op_brightness_contrast(samples, height, width, channels, device, dtype,
     input = generate_tensor(samples, width, height, channels, dtype, device)
     stream = rocpycv.Stream()
 
-    # test (random) passed in params
+    # test with random brightness contrast params
     bc_dtype = rocpycv.eDataType.F64 if (dtype == rocpycv.eDataType.S32 or out_dtype == rocpycv.eDataType.S32) else rocpycv.eDataType.F32
     brightness = generate_tensor_generic([1], rocpycv.eTensorLayout.N, bc_dtype, device)
     contrast = generate_tensor_generic([1], rocpycv.eTensorLayout.N, bc_dtype, device)
@@ -52,7 +52,7 @@ def test_op_brightness_contrast(samples, height, width, channels, device, dtype,
     stream.synchronize()
     compare_tensors(output, output_golden)
 
-    # test defaults
+    # test defaults(no passed in bc params)
     output_golden_default = rocpycv.Tensor([samples, height, width, channels], rocpycv.eTensorLayout.NHWC, out_dtype, device)
     rocpycv.brightness_contrast_into(output_golden_default, input, stream=stream, device=device)
     output_default = rocpycv.brightness_contrast(input, out_dtype, stream=stream, device=device)

--- a/tests/roccv/python/test_op_brightness_contrast.py
+++ b/tests/roccv/python/test_op_brightness_contrast.py
@@ -1,0 +1,61 @@
+# ##############################################################################
+# Copyright (c)  - 2026 Advanced Micro Devices, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# ##############################################################################
+
+import pytest
+import rocpycv
+
+from test_helpers import generate_tensor, generate_tensor_generic, compare_tensors
+
+@pytest.mark.parametrize("device", [rocpycv.eDeviceType.GPU, rocpycv.eDeviceType.CPU])
+@pytest.mark.parametrize("dtype", [rocpycv.eDataType.U8, rocpycv.eDataType.U16, rocpycv.eDataType.S16, rocpycv.eDataType.S32, rocpycv.eDataType.F32])
+@pytest.mark.parametrize("out_dtype", [rocpycv.eDataType.U8, rocpycv.eDataType.U16, rocpycv.eDataType.S16, rocpycv.eDataType.S32, rocpycv.eDataType.F32])
+@pytest.mark.parametrize("channels", [1, 3, 4])
+@pytest.mark.parametrize("samples,height,width", [
+    (1, 45, 23),
+    (3, 67, 85),
+    (7, 25, 95)
+])
+def test_op_brightness_contrast(samples, height, width, channels, device, dtype, out_dtype):
+    input = generate_tensor(samples, width, height, channels, dtype, device)
+    stream = rocpycv.Stream()
+
+    # test (random) passed in params
+    bc_dtype = rocpycv.eDataType.F64 if (dtype == rocpycv.eDataType.S32 or out_dtype == rocpycv.eDataType.S32) else rocpycv.eDataType.F32
+    brightness = generate_tensor_generic([1], rocpycv.eTensorLayout.N, bc_dtype, device)
+    contrast = generate_tensor_generic([1], rocpycv.eTensorLayout.N, bc_dtype, device)
+    brightness_shift = generate_tensor_generic([1], rocpycv.eTensorLayout.N, bc_dtype, device)
+    contrast_center = generate_tensor_generic([1], rocpycv.eTensorLayout.N, bc_dtype, device)
+
+    output_golden = rocpycv.Tensor([samples, height, width, channels], rocpycv.eTensorLayout.NHWC, out_dtype, device)
+    rocpycv.brightness_contrast_into(output_golden, input, brightness, contrast, brightness_shift, contrast_center, stream=stream, device=device)
+    output = rocpycv.brightness_contrast(input, out_dtype, brightness, contrast, brightness_shift, contrast_center, stream=stream, device=device)
+    stream.synchronize()
+    compare_tensors(output, output_golden)
+
+    # test defaults
+    output_golden_default = rocpycv.Tensor([samples, height, width, channels], rocpycv.eTensorLayout.NHWC, out_dtype, device)
+    rocpycv.brightness_contrast_into(output_golden_default, input, stream=stream, device=device)
+    output_default = rocpycv.brightness_contrast(input, out_dtype, stream=stream, device=device)
+    stream.synchronize()
+    
+    compare_tensors(output_default, output_golden_default)


### PR DESCRIPTION
## Motivation

Initial implementation of the Brightness Contrast operator.

## Technical Details

Added host and device kernels for the operator, Python bindings, and test cases for both C++ and Python.

## Test Plan

Tests added for C++ and Python implementations.

## Test Result

C++ and Python tests all pass.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
