### PR TITLE
[Bugfix] Fix TensorWrapData ownership semantics

### DIFF
--- a/include/core/tensor.hpp
+++ b/include/core/tensor.hpp
@@ -22,6 +22,7 @@ THE SOFTWARE.
 #pragma once
 
 #include <array>
+#include <functional>
 #include <memory>
 
 #include "core/data_type.hpp"
@@ -239,11 +240,23 @@ class Tensor {
 };
 
 /**
- * @brief Wraps TensorData object into a Tensor object.
- *
- * @param[in] data The tensor data to wrap.
- * @return The resulting Tensor with the provided TensorData.
+ * @brief Cleanup function invoked with the wrapped TensorData when the last reference to a wrapped Tensor is destroyed.
+ * Provides callers a hook to free externally-allocated memory according to how it was allocated.
  */
-extern Tensor TensorWrapData(const TensorData &tensor_data);
+using TensorDataCleanupFunc = std::function<void(const TensorData &)>;
+
+/**
+ * @brief Wraps a TensorData object into a Tensor object without taking ownership of the underlying memory.
+ *
+ * By default the resulting Tensor is a non-owning view: the wrapped memory is left untouched once the Tensor (and any
+ * views derived from it) goes out of scope. To tie cleanup of the external memory to the Tensor's lifetime, provide a
+ * cleanup function, which is invoked with the wrapped TensorData when the last reference is destroyed.
+ *
+ * @param[in] tensor_data The tensor data to wrap.
+ * @param[in] cleanup An optional cleanup function responsible for freeing the wrapped memory. Defaults to no cleanup
+ * (non-owning view).
+ * @return The resulting Tensor wrapping the provided TensorData.
+ */
+extern Tensor TensorWrapData(const TensorData &tensor_data, TensorDataCleanupFunc cleanup = {});
 
 }  // namespace roccv

--- a/include/core/tensor.hpp
+++ b/include/core/tensor.hpp
@@ -31,7 +31,6 @@ THE SOFTWARE.
 #include "core/util_enums.h"
 #include "tensor_data.hpp"
 #include "tensor_requirements.hpp"
-#include "tensor_storage.hpp"
 
 namespace roccv {
 
@@ -39,6 +38,13 @@ class ImageFormat;
 struct Size2D;
 class TensorShape;
 class TensorLayout;
+class TensorStorage;
+
+/**
+ * @brief Cleanup function invoked with the wrapped TensorData when the last reference to a wrapped Tensor is destroyed.
+ * Provides callers a hook to free externally-allocated memory according to how it was allocated.
+ */
+using TensorDataCleanupFunc = std::function<void(const TensorData &)>;
 
 class Tensor {
    public:
@@ -53,16 +59,6 @@ class Tensor {
      */
     explicit Tensor(const TensorRequirements &reqs);
     explicit Tensor(const TensorRequirements &reqs, const IAllocator &alloc);
-
-    /**
-     * @brief Constructs a Tensor object given a list of requirements and the underlying data as a TensorStorage
-     * pointer. This constructor will not automatically allocate data.
-     *
-     * @param[in] reqs An object representing the requirements for this tensor.
-     * @param[in] data A TensorStorage object for the tensor's underlying data.
-     */
-    explicit Tensor(const TensorRequirements &reqs, std::shared_ptr<TensorStorage> data);
-    explicit Tensor(const TensorRequirements &reqs, std::shared_ptr<TensorStorage> data, const IAllocator &alloc);
 
     /**
      * @brief Constructs a tensor object and allocates the appropriate amount of memory on the specified device.
@@ -234,16 +230,20 @@ class Tensor {
     static std::array<int64_t, ROCCV_TENSOR_MAX_RANK> CalcStrides(const TensorShape &shape, const DataType &dtype);
 
    private:
+    /**
+     * @brief Constructs a Tensor that shares an existing TensorStorage rather than allocating new memory. Used
+     * internally to create views over existing storage (e.g. reshape() and TensorWrapData()).
+     *
+     * @param[in] reqs An object representing the requirements for this tensor.
+     * @param[in] data The shared storage backing this tensor.
+     */
+    explicit Tensor(const TensorRequirements &reqs, std::shared_ptr<TensorStorage> data);
+
+    friend Tensor TensorWrapData(const TensorData &tensor_data, TensorDataCleanupFunc cleanup);
+
     TensorRequirements m_requirements;      // Tensor metadata
     std::shared_ptr<TensorStorage> m_data;  // Stores raw tensor data
-    const IAllocator &m_allocator;
 };
-
-/**
- * @brief Cleanup function invoked with the wrapped TensorData when the last reference to a wrapped Tensor is destroyed.
- * Provides callers a hook to free externally-allocated memory according to how it was allocated.
- */
-using TensorDataCleanupFunc = std::function<void(const TensorData &)>;
 
 /**
  * @brief Wraps a TensorData object into a Tensor object without taking ownership of the underlying memory.

--- a/include/core/tensor_data.hpp
+++ b/include/core/tensor_data.hpp
@@ -96,7 +96,12 @@ class TensorData {
             return std::nullopt;
         }
 
-        return std::make_optional<Derived>(m_shape, m_dtype, m_buffer);
+        // Reconstruct the derived view, then carry over the concrete buffer type from the source. The
+        // (shape, dtype, buffer) constructor cannot recover the buffer type for non-leaf targets (e.g.
+        // TensorDataStrided), so it must be propagated explicitly to keep device() accurate.
+        Derived derived(m_shape, m_dtype, m_buffer);
+        derived.m_bufferType = m_bufferType;
+        return derived;
     }
 
     static bool IsCompatibleKind(TensorBufferType bufferType);
@@ -106,7 +111,6 @@ class TensorData {
 
     TensorShape m_shape;
     DataType m_dtype;
-    eDeviceType m_deviceType;
     TensorBufferType m_bufferType;
     TensorBuffer m_buffer;
 };

--- a/include/core/tensor_storage.hpp
+++ b/include/core/tensor_storage.hpp
@@ -23,31 +23,40 @@
 
 #include <stdlib.h>
 
+#include <functional>
+
 #include "core/detail/allocators/i_allocator.hpp"
 #include "core/util_enums.h"
 
 namespace roccv {
+
 /**
- * @brief Stores the underlying data of a tensor and is responsible for allocation/freeing of tensor memory. Agnostic to
- * the tensor's metadata (shape, datatype, etc.)
+ * @brief Cleanup function invoked on the raw data pointer when the owning TensorStorage is destroyed. Used to delegate
+ * how (and whether) the underlying memory is freed.
+ */
+using TensorStorageCleanupFunc = std::function<void(void*)>;
+
+/**
+ * @brief Stores the underlying data of a tensor and is responsible for freeing of tensor memory when a cleanup function
+ * is provided. Agnostic to the tensor's metadata (shape, datatype, etc.)
  *
  */
 class TensorStorage {
    public:
     /**
-     * @brief Creates a new TensorStorage object and takes ownership of the data pointer.
+     * @brief Creates a new TensorStorage object wrapping an existing data pointer. Whether the memory is freed on
+     * destruction is determined entirely by the provided cleanup function. If no cleanup function is provided, this
+     * storage is a non-owning view and the underlying memory is left untouched on destruction.
      *
-     * @param data A pointer to allocated memory.
-     * @param device The device which the allocated memory is on.
-     * @param ownership Whether this object should own <data> (responsible for freeing it once it goes out of scope).
-     * Default is eOwnership::OWNING.
+     * @param data A pointer to existing memory.
+     * @param cleanup An optional cleanup function invoked with <data> when this object is destroyed. Defaults to an
+     * empty function (non-owning view).
      */
-    explicit TensorStorage(void* data, eDeviceType device, eOwnership ownership = eOwnership::OWNING);
-    explicit TensorStorage(void* data, eDeviceType device, const IAllocator& alloc,
-                           eOwnership ownership = eOwnership::OWNING);
+    explicit TensorStorage(void* data, TensorStorageCleanupFunc cleanup = {});
 
     /**
-     * @brief Creates a new TensorStorage object and allocates the requested number of bytes.
+     * @brief Creates a new TensorStorage object and allocates the requested number of bytes. The allocated memory is
+     * owned by this object and freed on destruction.
      *
      * @param bytes Number of bytes to allocate.
      * @param device The device to allocate the memory on.
@@ -64,18 +73,9 @@ class TensorStorage {
      */
     void* data() const;
 
-    /**
-     * @brief Retrieves the device that the tensor data is allocated on.
-     *
-     * @return eDeviceType
-     */
-    eDeviceType device() const;
-
    private:
-    eDeviceType m_device;
-    eOwnership m_ownership;
     void* m_data;
-    const IAllocator& m_allocator;
+    TensorStorageCleanupFunc m_cleanup;
 };
 
 }  // namespace roccv

--- a/include/core/util_enums.h
+++ b/include/core/util_enums.h
@@ -68,9 +68,3 @@ typedef enum eChannelType {
  *
  */
 enum class eDeviceType { GPU = 0, CPU = 1 };
-
-/**
- * @brief Describes whether a container should own a resource or only be a view for a resource.
- *
- */
-enum class eOwnership { OWNING = 0, VIEW = 1 };

--- a/python/src/py_tensor.cpp
+++ b/python/src/py_tensor.cpp
@@ -117,13 +117,22 @@ std::shared_ptr<PyTensor> PyTensor::fromDLPack(pybind11::object src, eTensorLayo
         shapeData[i] = dlTensor.shape[i];
     }
 
-    // Create a non-owning roccv::Tensor based on the received data
+    // Create a non-owning roccv::Tensor based on the received data. The lifetime of the underlying memory remains the
+    // responsibility of the DLPack producer; we keep the DLManagedTensor in PyTensor and invoke its deleter on
+    // destruction. TensorWrapData is therefore called without a cleanup function.
     roccv::TensorShape shape(roccv::TensorLayout(layout), shapeData);
+    roccv::DataType dtype(DLTypeToRoccvType(dlTensor.dtype));
     eDeviceType device = DLDeviceToRoccvDevice(dlTensor.device);
-    roccv::TensorRequirements reqs =
-        roccv::Tensor::CalcRequirements(shape, roccv::DataType(DLTypeToRoccvType(dlTensor.dtype)), device);
-    auto data = std::make_shared<roccv::TensorStorage>(dlTensor.data, device, eOwnership::VIEW);
-    auto tensor = std::make_shared<roccv::Tensor>(reqs, data);
+
+    // Build a strided tensor data descriptor over the wrapped buffer. Strides are computed as contiguous to match
+    // historical behavior.
+    roccv::TensorDataStrided::Buffer buffer;
+    buffer.basePtr = dlTensor.data;
+    buffer.strides = roccv::Tensor::CalcStrides(shape, dtype);
+
+    auto tensor = std::make_shared<roccv::Tensor>(
+        device == eDeviceType::GPU ? roccv::TensorWrapData(roccv::TensorDataStridedHip(shape, dtype, buffer))
+                                   : roccv::TensorWrapData(roccv::TensorDataStridedHost(shape, dtype, buffer)));
 
     return std::make_shared<PyTensor>(tensor, dlManagedTensor);
 }

--- a/python/src/py_tensor.cpp
+++ b/python/src/py_tensor.cpp
@@ -125,9 +125,10 @@ std::shared_ptr<PyTensor> PyTensor::fromDLPack(pybind11::object src, eTensorLayo
     eDeviceType device = DLDeviceToRoccvDevice(dlTensor.device);
 
     // Build a strided tensor data descriptor over the wrapped buffer. Strides are computed as contiguous to match
-    // historical behavior.
+    // historical behavior. Per the DLPack spec, the first element is located at data + byte_offset, so the offset must
+    // be applied to obtain the true base pointer.
     roccv::TensorDataStrided::Buffer buffer;
-    buffer.basePtr = dlTensor.data;
+    buffer.basePtr = static_cast<void*>(static_cast<uint8_t*>(dlTensor.data) + dlTensor.byte_offset);
     buffer.strides = roccv::Tensor::CalcStrides(shape, dtype);
 
     auto tensor = std::make_shared<roccv::Tensor>(

--- a/samples/cropandresize/cpp/main.cpp
+++ b/samples/cropandresize/cpp/main.cpp
@@ -136,8 +136,12 @@ int main(int argc, char *argv[]) {
     roccv::TensorDataStridedHip inData(roccv::TensorShape{inReqs.shape, inReqs.rank, inReqs.layout},
                                        roccv::DataType{inReqs.dtype}, inBuf);
 
-    // Wrap tensor data in a rocCV tensor for use with the rocCV operators.
-    roccv::Tensor inTensor = roccv::TensorWrapData(inData);
+    // Wrap tensor data in a rocCV tensor for use with the rocCV operators. TensorWrapData does not take ownership of
+    // the wrapped buffer, so a cleanup function is provided to free the memory allocated above once the tensor (and any
+    // views of it) goes out of scope.
+    roccv::Tensor inTensor = roccv::TensorWrapData(inData, [](const roccv::TensorData &data) {
+        CHECK_HIP_ERROR(hipFree(data.cast<roccv::TensorDataStrided>()->basePtr()));
+    });
 
     // tag: Image Loading
     uint8_t *gpuInput = reinterpret_cast<uint8_t *>(inBuf.basePtr);

--- a/src/core/tensor.cpp
+++ b/src/core/tensor.cpp
@@ -179,7 +179,7 @@ std::array<int64_t, ROCCV_TENSOR_MAX_RANK> Tensor::CalcStrides(const TensorShape
     return strides;
 }
 
-Tensor TensorWrapData(const TensorData& tensor_data) {
+Tensor TensorWrapData(const TensorData& tensor_data, TensorDataCleanupFunc cleanup) {
     auto tensorDataStrided = tensor_data.cast<TensorDataStrided>();
     if (!tensorDataStrided.has_value()) {
         throw Exception("TensorData could not be cast to TensorDataStrided. Tensors can only wrap strided tensor data.",
@@ -190,11 +190,20 @@ Tensor TensorWrapData(const TensorData& tensor_data) {
     for (int i = 0; i < tensorDataStrided->rank(); i++) {
         strides[i] = tensorDataStrided->stride(i);
     }
-    TensorRequirements reqs = Tensor::CalcRequirements(tensorDataStrided->shape(), tensorDataStrided->dtype(), strides,
-                                                       tensorDataStrided->device());
+    // Note: the device is read from the original tensor_data rather than the casted TensorDataStrided. Casting to the
+    // base TensorDataStrided reconstructs the object and loses the concrete device (defaulting to GPU), so the dynamic
+    // type's device must be used here.
+    TensorRequirements reqs =
+        Tensor::CalcRequirements(tensorDataStrided->shape(), tensorDataStrided->dtype(), strides, tensor_data.device());
 
-    auto data =
-        std::make_shared<TensorStorage>(tensorDataStrided->basePtr(), tensorDataStrided->device(), eOwnership::OWNING);
+    // By default the wrapped data is non-owning (empty cleanup). If a caller-provided cleanup function is given, adapt
+    // it to operate on the raw pointer by capturing a copy of the strided tensor data descriptor.
+    TensorStorageCleanupFunc storageCleanup;
+    if (cleanup) {
+        storageCleanup = [cleanup, data = tensorDataStrided.value()](void*) { cleanup(data); };
+    }
+
+    auto data = std::make_shared<TensorStorage>(tensorDataStrided->basePtr(), std::move(storageCleanup));
     return Tensor(reqs, data);
 }
 

--- a/src/core/tensor.cpp
+++ b/src/core/tensor.cpp
@@ -33,6 +33,7 @@ THE SOFTWARE.
 #include "core/tensor_layout.hpp"
 #include "core/tensor_requirements.hpp"
 #include "core/tensor_shape.hpp"
+#include "core/tensor_storage.hpp"
 #include "core/util_enums.h"
 #include "operator_types.h"
 
@@ -41,15 +42,13 @@ namespace roccv {
 // Constructor definitions
 Tensor::Tensor(const TensorRequirements& reqs) : Tensor(reqs, GlobalContext().getDefaultAllocator()) {}
 
-Tensor::Tensor(const TensorRequirements& reqs, const IAllocator& alloc) : m_requirements(reqs), m_allocator(alloc) {
+Tensor::Tensor(const TensorRequirements& reqs, const IAllocator& alloc) : m_requirements(reqs) {
     size_t numBytes = reqs.device == eDeviceType::GPU ? reqs.res.deviceMem.bytes : reqs.res.hostMem.bytes;
     m_data = std::make_shared<TensorStorage>(numBytes, reqs.device, alloc);
 }
-Tensor::Tensor(const TensorRequirements& reqs, std::shared_ptr<TensorStorage> data)
-    : Tensor(reqs, data, GlobalContext().getDefaultAllocator()) {}
 
-Tensor::Tensor(const TensorRequirements& reqs, std::shared_ptr<TensorStorage> data, const IAllocator& alloc)
-    : m_requirements(reqs), m_data(data), m_allocator(alloc) {}
+Tensor::Tensor(const TensorRequirements& reqs, std::shared_ptr<TensorStorage> data)
+    : m_requirements(reqs), m_data(std::move(data)) {}
 
 Tensor::Tensor(const TensorShape& shape, DataType dtype, eDeviceType device)
     : Tensor(shape, dtype, GlobalContext().getDefaultAllocator(), device) {}
@@ -63,10 +62,7 @@ Tensor::Tensor(int num_images, Size2D image_size, ImageFormat fmt, eDeviceType d
 Tensor::Tensor(int num_images, Size2D image_size, ImageFormat fmt, const IAllocator& alloc, eDeviceType device)
     : Tensor(CalcRequirements(num_images, image_size, fmt, device), alloc) {}
 
-Tensor::Tensor(Tensor&& other)
-    : m_requirements(std::move(other.m_requirements)),
-      m_data(std::move(other.m_data)),
-      m_allocator(other.m_allocator) {}
+Tensor::Tensor(Tensor&& other) : m_requirements(std::move(other.m_requirements)), m_data(std::move(other.m_data)) {}
 
 // Member definitions
 int Tensor::rank() const { return m_requirements.rank; }

--- a/src/core/tensor.cpp
+++ b/src/core/tensor.cpp
@@ -387,9 +387,7 @@ void Tensor::copyToHostAsync(void* dst, hipStream_t stream) const {
 }
 
 void Tensor::copyToAsync(const Tensor& dst, hipStream_t stream) const {
-    // Source and destination must describe the same logical data; only their padding (row pitch) may differ.
-    if (rank() != dst.rank() || m_requirements.shape != dst.m_requirements.shape ||
-        dtype().size() != dst.dtype().size()) {
+    if (shape() != dst.shape() || dtype().size() != dst.dtype().size()) {
         throw Exception("Source and destination tensors must have the same shape and element size for a copy.",
                         eStatusType::INVALID_VALUE);
     }
@@ -486,7 +484,7 @@ Tensor TensorWrapData(const TensorData& tensor_data, TensorDataCleanupFunc clean
                         eStatusType::INVALID_VALUE);
     }
 
-    std::array<int64_t, ROCCV_TENSOR_MAX_RANK> strides;
+    std::array<int64_t, ROCCV_TENSOR_MAX_RANK> strides{};
     for (int i = 0; i < tensorDataStrided->rank(); i++) {
         strides[i] = tensorDataStrided->stride(i);
     }

--- a/src/core/tensor.cpp
+++ b/src/core/tensor.cpp
@@ -186,9 +186,6 @@ Tensor TensorWrapData(const TensorData& tensor_data, TensorDataCleanupFunc clean
     for (int i = 0; i < tensorDataStrided->rank(); i++) {
         strides[i] = tensorDataStrided->stride(i);
     }
-    // Note: the device is read from the original tensor_data rather than the casted TensorDataStrided. Casting to the
-    // base TensorDataStrided reconstructs the object and loses the concrete device (defaulting to GPU), so the dynamic
-    // type's device must be used here.
     TensorRequirements reqs =
         Tensor::CalcRequirements(tensorDataStrided->shape(), tensorDataStrided->dtype(), strides, tensor_data.device());
 

--- a/src/core/tensor_data.cpp
+++ b/src/core/tensor_data.cpp
@@ -23,6 +23,8 @@ THE SOFTWARE.
 #include "core/tensor_data.hpp"
 
 #include "core/data_type.hpp"
+#include "core/exception.hpp"
+#include "core/status_type.h"
 #include "core/tensor_buffer.hpp"
 #include "core/util_enums.h"
 
@@ -36,14 +38,21 @@ int64_t TensorData::shape(int d) const& { return m_shape[d]; }
 
 const DataType& TensorData::dtype() const { return m_dtype; }
 
-eDeviceType TensorData::device() const { return m_deviceType; }
+eDeviceType TensorData::device() const {
+    // Device is derived from the buffer type; there is no separate device field to keep in sync.
+    switch (m_bufferType) {
+        case TensorBufferType::TENSOR_BUFFER_STRIDED_HIP:
+            return eDeviceType::GPU;
+        case TensorBufferType::TENSOR_BUFFER_STRIDED_HOST:
+            return eDeviceType::CPU;
+        default:
+            throw Exception("TensorData has no associated device (buffer type is not set).",
+                            eStatusType::INVALID_VALUE);
+    }
+}
 
 TensorData::TensorData(const TensorShape& tshape, const DataType& dtype, const TensorBuffer& buffer)
-    : m_shape(tshape),
-      m_dtype(dtype),
-      m_deviceType(eDeviceType::GPU),
-      m_bufferType(TensorBufferType::TENSOR_BUFFER_NONE),
-      m_buffer(buffer) {}
+    : m_shape(tshape), m_dtype(dtype), m_bufferType(TensorBufferType::TENSOR_BUFFER_NONE), m_buffer(buffer) {}
 
 bool TensorData::IsCompatibleKind(TensorBufferType bufferType) {
     return bufferType != TensorBufferType::TENSOR_BUFFER_NONE;
@@ -64,7 +73,6 @@ int64_t TensorDataStrided::stride(int d) const { return m_buffer.strided.strides
 TensorDataStridedHip::TensorDataStridedHip(const TensorShape& shape, const DataType& dtype, const TensorBuffer& buffer)
     : TensorDataStrided(shape, dtype, buffer) {
     m_bufferType = TensorBufferType::TENSOR_BUFFER_STRIDED_HIP;
-    m_deviceType = eDeviceType::GPU;
 }
 
 TensorDataStridedHip::TensorDataStridedHip(const TensorShape& shape, const DataType& dtype,
@@ -79,7 +87,6 @@ TensorDataStridedHost::TensorDataStridedHost(const TensorShape& shape, const Dat
                                              const TensorBuffer& buffer)
     : TensorDataStrided(shape, dtype, buffer) {
     m_bufferType = TensorBufferType::TENSOR_BUFFER_STRIDED_HOST;
-    m_deviceType = eDeviceType::CPU;
 }
 
 TensorDataStridedHost::TensorDataStridedHost(const TensorShape& shape, const DataType& dtype, const Buffer& buffer)

--- a/src/core/tensor_storage.cpp
+++ b/src/core/tensor_storage.cpp
@@ -21,6 +21,8 @@
 
 #include "core/tensor_storage.hpp"
 
+#include <iostream>
+
 #include "core/detail/context.hpp"
 #include "core/hip_assert.h"
 
@@ -45,7 +47,14 @@ TensorStorage::TensorStorage(size_t bytes, eDeviceType device, const IAllocator&
 }
 
 TensorStorage::~TensorStorage() {
-    if (m_cleanup) m_cleanup(m_data);
+    if (!m_cleanup) return;
+    try {
+        m_cleanup(m_data);
+    } catch (const std::exception& e) {
+        std::cerr << "Warning: TensorStorage cleanup function threw an exception: " << e.what() << std::endl;
+    } catch (...) {
+        std::cerr << "Warning: TensorStorage cleanup function threw an unknown exception." << std::endl;
+    }
 }
 
 void* TensorStorage::data() const { return m_data; }

--- a/src/core/tensor_storage.cpp
+++ b/src/core/tensor_storage.cpp
@@ -24,7 +24,6 @@
 #include <iostream>
 
 #include "core/detail/context.hpp"
-#include "core/hip_assert.h"
 
 namespace roccv {
 TensorStorage::TensorStorage(void* data, TensorStorageCleanupFunc cleanup)

--- a/src/core/tensor_storage.cpp
+++ b/src/core/tensor_storage.cpp
@@ -25,41 +25,28 @@
 #include "core/hip_assert.h"
 
 namespace roccv {
-TensorStorage::TensorStorage(void* data, eDeviceType device, eOwnership ownership)
-    : TensorStorage(data, device, GlobalContext().getDefaultAllocator(), ownership) {}
-
-TensorStorage::TensorStorage(void* data, eDeviceType device, const IAllocator& alloc, eOwnership ownership)
-    : m_device(device), m_ownership(ownership), m_data(data), m_allocator(alloc) {}
+TensorStorage::TensorStorage(void* data, TensorStorageCleanupFunc cleanup)
+    : m_data(data), m_cleanup(std::move(cleanup)) {}
 
 TensorStorage::TensorStorage(size_t bytes, eDeviceType device)
     : TensorStorage(bytes, device, GlobalContext().getDefaultAllocator()) {}
 
-TensorStorage::TensorStorage(size_t bytes, eDeviceType device, const IAllocator& alloc)
-    : m_device(device), m_ownership(eOwnership::OWNING), m_allocator(alloc) {
-    switch (m_device) {
+TensorStorage::TensorStorage(size_t bytes, eDeviceType device, const IAllocator& alloc) {
+    switch (device) {
         case eDeviceType::GPU:
-            m_data = m_allocator.allocHipMem(bytes);
+            m_data = alloc.allocHipMem(bytes);
+            m_cleanup = [&alloc](void* data) { alloc.freeHipMem(data); };
             break;
         case eDeviceType::CPU:
-            m_data = m_allocator.allocHostMem(bytes);
+            m_data = alloc.allocHostMem(bytes);
+            m_cleanup = [&alloc](void* data) { alloc.freeHostMem(data); };
             break;
     }
 }
 
 TensorStorage::~TensorStorage() {
-    if (m_ownership != eOwnership::OWNING) return;
-
-    switch (m_device) {
-        case eDeviceType::GPU:
-            m_allocator.freeHipMem(m_data);
-            break;
-        case eDeviceType::CPU:
-            m_allocator.freeHostMem(m_data);
-            break;
-    }
+    if (m_cleanup) m_cleanup(m_data);
 }
 
 void* TensorStorage::data() const { return m_data; }
-
-eDeviceType TensorStorage::device() const { return m_device; }
 }  // namespace roccv

--- a/tests/roccv/cpp/src/tests/core/tensor/test_tensor.cpp
+++ b/tests/roccv/cpp/src/tests/core/tensor/test_tensor.cpp
@@ -127,6 +127,82 @@ void TestTensorCorrectness() {
 }
 
 /**
+ * @brief Ensures that wrapping external data via TensorWrapData does not take ownership of the underlying buffer.
+ *
+ * The buffer must remain valid and intact after the wrapping Tensor (and any views derived from it) are destroyed.
+ */
+void TestTensorWrapNonOwning() {
+    TensorShape shape({1, 2, 2, 3}, "NHWC");
+    DataType dtype(DATA_TYPE_U8);
+    size_t numElems = shape.size();
+
+    // Test owns this buffer for the entire duration of the test.
+    auto* buffer = new uint8_t[numElems];
+    for (size_t i = 0; i < numElems; i++) {
+        buffer[i] = static_cast<uint8_t>(i);
+    }
+
+    {
+        TensorDataStrided::Buffer buf;
+        buf.basePtr = buffer;
+        buf.strides = Tensor::CalcStrides(shape, dtype);
+        TensorDataStridedHost data(shape, dtype, buf);
+
+        // Wrap with no cleanup function: this must produce a non-owning view.
+        Tensor tensor = TensorWrapData(data);
+        EXPECT_TRUE(tensor.exportData<TensorDataStrided>().basePtr() == buffer);
+
+        // A reshaped view shares the same underlying storage; destroying both must still not free the buffer.
+        Tensor view = tensor.reshape(TensorShape({2, 2, 3}, "HWC"));
+        EXPECT_TRUE(view.exportData<TensorDataStrided>().basePtr() == buffer);
+    }
+
+    // The buffer must still be intact (untouched by tensor destruction).
+    bool intact = true;
+    for (size_t i = 0; i < numElems; i++) {
+        if (buffer[i] != static_cast<uint8_t>(i)) {
+            intact = false;
+            break;
+        }
+    }
+    EXPECT_TRUE(intact);
+
+    // The test still owns the buffer and is responsible for freeing it. A double-free here would indicate the tensor
+    // incorrectly took ownership.
+    delete[] buffer;
+}
+
+/**
+ * @brief Ensures that a cleanup function provided to TensorWrapData is invoked exactly once, when the last reference to
+ * the wrapped data is destroyed.
+ */
+void TestTensorWrapCleanup() {
+    TensorShape shape({1, 2, 2, 3}, "NHWC");
+    DataType dtype(DATA_TYPE_U8);
+
+    auto* buffer = new uint8_t[shape.size()];
+    int cleanupCalls = 0;
+
+    {
+        TensorDataStrided::Buffer buf;
+        buf.basePtr = buffer;
+        buf.strides = Tensor::CalcStrides(shape, dtype);
+        TensorDataStridedHost data(shape, dtype, buf);
+
+        Tensor tensor = TensorWrapData(data, [&cleanupCalls](const TensorData&) { cleanupCalls++; });
+
+        // A view shares the same storage, so the cleanup must not fire until both references are dropped.
+        Tensor view = tensor.reshape(TensorShape({2, 2, 3}, "HWC"));
+        EXPECT_EQ(cleanupCalls, 0);
+    }
+
+    // Both the tensor and its view have gone out of scope: cleanup must have run exactly once.
+    EXPECT_EQ(cleanupCalls, 1);
+
+    delete[] buffer;
+}
+
+/**
  * @brief Tests internal stride calculations on Tensor construction.
  */
 void TestTensorStrideCalculation(const TensorShape& shape, const DataType& dtype) {
@@ -155,6 +231,10 @@ int main(int argc, char** argv) {
 
     // Correctness tests
     TEST_CASE(TestTensorCorrectness());
+
+    // Wrapped-data ownership tests
+    TEST_CASE(TestTensorWrapNonOwning());
+    TEST_CASE(TestTensorWrapCleanup());
 
     // Stride calculation tests
     // clang-format off

--- a/tests/roccv/cpp/src/tests/core/tensor/test_tensor.cpp
+++ b/tests/roccv/cpp/src/tests/core/tensor/test_tensor.cpp
@@ -203,6 +203,45 @@ void TestTensorWrapCleanup() {
 }
 
 /**
+ * @brief Ensures TensorData::cast preserves the concrete device when casting to a non-leaf type.
+ *
+ * Casting to the base TensorDataStrided (as exportData<TensorDataStrided>() does throughout the codebase) must report
+ * the same device as the source tensor, not a hardcoded default.
+ */
+void TestTensorDataCastDevicePropagation() {
+    // Host tensor: exporting/casting to the base strided type must still report CPU.
+    {
+        Tensor tensor(TensorShape({1, 2, 2, 3}, "NHWC"), DataType(DATA_TYPE_U8), eDeviceType::CPU);
+        auto data = tensor.exportData<TensorDataStrided>();
+        EXPECT_TRUE(data.device() == eDeviceType::CPU);
+    }
+
+    // Device tensor: exporting/casting to the base strided type must still report GPU.
+    {
+        Tensor tensor(TensorShape({1, 2, 2, 3}, "NHWC"), DataType(DATA_TYPE_U8), eDeviceType::GPU);
+        auto data = tensor.exportData<TensorDataStrided>();
+        EXPECT_TRUE(data.device() == eDeviceType::GPU);
+    }
+
+    // Direct cast: a host strided descriptor must remain CPU when viewed as the base type, and must refuse a cast to an
+    // incompatible (device) leaf type.
+    {
+        TensorShape shape({1, 2, 2, 3}, "NHWC");
+        DataType dtype(DATA_TYPE_U8);
+        TensorDataStrided::Buffer buf;
+        buf.basePtr = nullptr;
+        buf.strides = Tensor::CalcStrides(shape, dtype);
+        TensorDataStridedHost host(shape, dtype, buf);
+
+        auto asStrided = host.cast<TensorDataStrided>();
+        EXPECT_TRUE(asStrided.has_value());
+        EXPECT_TRUE(asStrided->device() == eDeviceType::CPU);
+
+        EXPECT_FALSE(host.cast<TensorDataStridedHip>().has_value());
+    }
+}
+
+/**
  * @brief Tests internal stride calculations on Tensor construction.
  */
 void TestTensorStrideCalculation(const TensorShape& shape, const DataType& dtype) {
@@ -235,6 +274,9 @@ int main(int argc, char** argv) {
     // Wrapped-data ownership tests
     TEST_CASE(TestTensorWrapNonOwning());
     TEST_CASE(TestTensorWrapCleanup());
+
+    // TensorData cast device propagation
+    TEST_CASE(TestTensorDataCastDevicePropagation());
 
     // Stride calculation tests
     // clang-format off


### PR DESCRIPTION
## Fix TensorWrapData ownership semantics

### Problem
`TensorWrapData` constructed its backing `TensorStorage` as **owning**, so it would `hipFree`/`free` a buffer it never allocated when the wrapping `Tensor` went out of scope — freeing (or double-freeing) caller-owned memory. Separately, `TensorData::cast` to a non-leaf type (e.g. `TensorDataStrided`) lost the concrete buffer type, so `device()` silently reported `GPU` for host tensors.

### Changes
- **Non-owning by default**: `TensorWrapData(data, cleanup = {})` now produces a view. Pass an optional `TensorDataCleanupFunc` to tie external-memory cleanup to the Tensor's lifetime (fires once, when the last view is destroyed).
- **Simplified `TensorStorage`**: replaced the `device`/`ownership`/`allocator` members with a single `TensorStorageCleanupFunc` — empty means view, set means owning. Removed the now-unused `eOwnership` enum, and made `TensorStorage` an internal implementation detail (no longer in the public Tensor constructor).
- **Fixed cast device propagation**: `device()` is now derived from the buffer type instead of a separately-tracked field that could fall out of sync.
- Updated `py_tensor` (DLPack import) and the cropandresize sample to the new API; DLPack memory stays owned by the producer (no cleanup), the sample provides a `hipFree` cleanup.

### Testing
Adds C++ coverage for non-owning wrap (no double-free / buffer stays intact), cleanup-fires-exactly-once across views, and cast device propagation. Builds clean; `test_tensor` passes.
