### PR TITLE
[Optimization] Templatize brightness/contrast parameter types to avoid branching on device

### DIFF
--- a/benchmarks/src/roccv/bench_brightness_contrast.cpp
+++ b/benchmarks/src/roccv/bench_brightness_contrast.cpp
@@ -32,9 +32,9 @@
 using namespace roccv;
 
 typedef enum eBCType {
-    BC_TYPE_DEFAULT = -1,   ///< Use default value. Added enum to help test defaults explicitly
-    BC_TYPE_BROADCAST = 0,  ///< Broadcast single value to all samples.
-    BC_TYPE_PER = 1         ///< Per-sample values.
+    BC_TYPE_DEFAULT = -1,   ///< Use default value.
+    BC_TYPE_BROADCAST = 1,  ///< Broadcast single value to all samples.
+    BC_TYPE_PER = 2         ///< Per-sample values.
 } eBCType;
 
 template <eDeviceType DeviceType>

--- a/benchmarks/src/roccv/bench_brightness_contrast.cpp
+++ b/benchmarks/src/roccv/bench_brightness_contrast.cpp
@@ -32,7 +32,7 @@
 using namespace roccv;
 
 typedef enum eBCType {
-    BC_TYPE_DEFAULT = -1,   ///< Use default value. Added enum to help test defaults explicilty
+    BC_TYPE_DEFAULT = -1,   ///< Use default value. Added enum to help test defaults explicitly
     BC_TYPE_BROADCAST = 0,  ///< Broadcast single value to all samples.
     BC_TYPE_PER = 1         ///< Per-sample values.
 } eBCType;

--- a/benchmarks/src/roccv/bench_brightness_contrast.cpp
+++ b/benchmarks/src/roccv/bench_brightness_contrast.cpp
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <core/hip_assert.h>
+
+#include <core/image_format.hpp>
+#include <core/tensor.hpp>
+#include <op_brightness_contrast.hpp>
+#include <roccvbench/registry.hpp>
+#include <roccvbench/utils.hpp>
+
+#include "roccv_bench_helpers.hpp"
+
+using namespace roccv;
+
+// copied over from src/op_brightness_contrast.cpp (in anon. namespace there)
+typedef enum eBCType {
+    BC_TYPE_DEFAULT = 0,    ///< Use default value.
+    BC_TYPE_BROADCAST = 1,  ///< Broadcast single value to all samples.
+    BC_TYPE_PER = 2         ///< Per-sample values.
+} eBCType;
+
+template <eDeviceType DeviceType>
+static roccvbench::BenchmarkResults RunBrightnessContrastBenchmark(roccvbench::BenchmarkParamsList params) {
+    roccvbench::BenchmarkResults results;
+
+    int samples = roccvbench::GetParamValue<int>(params, "samples");
+    int width = roccvbench::GetParamValue<int>(params, "width");
+    int height = roccvbench::GetParamValue<int>(params, "height");
+    int runs = roccvbench::GetParamValue<int>(params, "runs");
+    int warmupRuns = roccvbench::GetParamValue<int>(params, "warmupRuns");
+    ImageFormat inFormat = roccvbench::GetParamValue<ImageFormat>(params, "inFormat");
+    ImageFormat outFormat = roccvbench::GetParamValue<ImageFormat>(params, "outFormat");
+    eBCType bcType = roccvbench::GetParamValue<eBCType>(params, "bcType");
+
+    Tensor::Requirements inReqs = Tensor::CalcRequirements(samples, {width, height}, inFormat, DeviceType);
+    Tensor::Requirements outReqs = Tensor::CalcRequirements(samples, {width, height}, outFormat, DeviceType);
+    Tensor input(inReqs);
+    Tensor output(outReqs);
+
+    RegisterMemoryUsage(input, results.readMemoryBytes);
+    RegisterMemoryUsage(output, results.writtenMemoryBytes);
+
+    FillTensor(input);
+
+    BrightnessContrast op;
+    hipStream_t stream;
+    HIP_VALIDATE_NO_ERRORS(hipStreamCreate(&stream));
+
+    if (bcType == eBCType::BC_TYPE_DEFAULT) {
+        roccvbench::RecordRuns<DeviceType>(stream, runs, warmupRuns, results.executionTimes, [&]() {
+            op(stream, input, output, std::nullopt, std::nullopt, std::nullopt, std::nullopt, DeviceType);
+        });
+    } else {
+        int bcSamples = (bcType == eBCType::BC_TYPE_BROADCAST) ? 1 : samples;
+        DataType bcDType =
+            (inFormat.dtype() == eDataType::DATA_TYPE_S32 || outFormat.dtype() == eDataType::DATA_TYPE_S32)
+                ? DataType(eDataType::DATA_TYPE_F64)
+                : DataType(eDataType::DATA_TYPE_F32);
+        Tensor::Requirements bcReqs = Tensor::CalcRequirements({{bcSamples}, "N"}, bcDType, DeviceType);
+        Tensor brightness(bcReqs);
+        Tensor contrast(bcReqs);
+        Tensor brightnessShift(bcReqs);
+        Tensor contrastCenter(bcReqs);
+
+        RegisterMemoryUsage(brightness, results.readMemoryBytes);
+        RegisterMemoryUsage(contrast, results.readMemoryBytes);
+        RegisterMemoryUsage(brightnessShift, results.readMemoryBytes);
+        RegisterMemoryUsage(contrastCenter, results.readMemoryBytes);
+
+        FillTensor(brightness);
+        FillTensor(contrast);
+        FillTensor(brightnessShift);
+        FillTensor(contrastCenter);
+
+        roccvbench::RecordRuns<DeviceType>(stream, runs, warmupRuns, results.executionTimes, [&]() {
+            op(stream, input, output, brightness, contrast, brightnessShift, contrastCenter, DeviceType);
+        });
+    }
+    HIP_VALIDATE_NO_ERRORS(hipStreamDestroy(stream));
+
+    return results;
+}
+
+#define DEFINE_BRIGHTNESS_CONTRAST_BENCHMARK(name, device, inFormat, outFormat, bcType)              \
+    BENCHMARK_P(BrightnessContrast, name,                                                            \
+                BENCH_PARAMS(BENCH_PARAM("inFormat", inFormat), BENCH_PARAM("outFormat", outFormat), \
+                             BENCH_PARAM("bcType", bcType))) {                                       \
+        return RunBrightnessContrastBenchmark<device>(params);                                       \
+    }
+
+// clang-format off
+// GPU benchmarks
+DEFINE_BRIGHTNESS_CONTRAST_BENCHMARK(GPU, eDeviceType::GPU, FMT_U8, FMT_U8, eBCType::BC_TYPE_BROADCAST);
+DEFINE_BRIGHTNESS_CONTRAST_BENCHMARK(GPU, eDeviceType::GPU, FMT_U8, FMT_U8, eBCType::BC_TYPE_DEFAULT);
+DEFINE_BRIGHTNESS_CONTRAST_BENCHMARK(GPU, eDeviceType::GPU, FMT_U8, FMT_U8, eBCType::BC_TYPE_PER);
+
+DEFINE_BRIGHTNESS_CONTRAST_BENCHMARK(GPU, eDeviceType::GPU, FMT_F32, FMT_F32, eBCType::BC_TYPE_BROADCAST);
+DEFINE_BRIGHTNESS_CONTRAST_BENCHMARK(GPU, eDeviceType::GPU, FMT_F32, FMT_F32, eBCType::BC_TYPE_DEFAULT);
+DEFINE_BRIGHTNESS_CONTRAST_BENCHMARK(GPU, eDeviceType::GPU, FMT_F32, FMT_F32, eBCType::BC_TYPE_PER);
+
+DEFINE_BRIGHTNESS_CONTRAST_BENCHMARK(GPU, eDeviceType::GPU, FMT_S32, FMT_S32, eBCType::BC_TYPE_BROADCAST);
+DEFINE_BRIGHTNESS_CONTRAST_BENCHMARK(GPU, eDeviceType::GPU, FMT_S32, FMT_S32, eBCType::BC_TYPE_DEFAULT); 
+DEFINE_BRIGHTNESS_CONTRAST_BENCHMARK(GPU, eDeviceType::GPU, FMT_S32, FMT_S32, eBCType::BC_TYPE_PER); 
+
+DEFINE_BRIGHTNESS_CONTRAST_BENCHMARK(GPU, eDeviceType::GPU, FMT_RGB8, FMT_RGB8, eBCType::BC_TYPE_BROADCAST);
+DEFINE_BRIGHTNESS_CONTRAST_BENCHMARK(GPU, eDeviceType::GPU, FMT_RGB8, FMT_RGB8, eBCType::BC_TYPE_DEFAULT);
+DEFINE_BRIGHTNESS_CONTRAST_BENCHMARK(GPU, eDeviceType::GPU, FMT_RGB8, FMT_RGB8, eBCType::BC_TYPE_PER);
+
+DEFINE_BRIGHTNESS_CONTRAST_BENCHMARK(GPU, eDeviceType::GPU, FMT_RGBA8, FMT_RGBA8, eBCType::BC_TYPE_BROADCAST);
+DEFINE_BRIGHTNESS_CONTRAST_BENCHMARK(GPU, eDeviceType::GPU, FMT_RGBA8, FMT_RGBA8, eBCType::BC_TYPE_DEFAULT); 
+DEFINE_BRIGHTNESS_CONTRAST_BENCHMARK(GPU, eDeviceType::GPU, FMT_RGBA8, FMT_RGBA8, eBCType::BC_TYPE_PER); 
+
+// CPU benchmarks
+DEFINE_BRIGHTNESS_CONTRAST_BENCHMARK(CPU, eDeviceType::CPU, FMT_S32, FMT_S32, eBCType::BC_TYPE_BROADCAST);
+DEFINE_BRIGHTNESS_CONTRAST_BENCHMARK(CPU, eDeviceType::CPU, FMT_S32, FMT_S32, eBCType::BC_TYPE_DEFAULT); 
+DEFINE_BRIGHTNESS_CONTRAST_BENCHMARK(CPU, eDeviceType::CPU, FMT_S32, FMT_S32, eBCType::BC_TYPE_PER); 
+
+DEFINE_BRIGHTNESS_CONTRAST_BENCHMARK(CPU, eDeviceType::CPU, FMT_RGB8, FMT_RGB8, eBCType::BC_TYPE_BROADCAST);
+DEFINE_BRIGHTNESS_CONTRAST_BENCHMARK(CPU, eDeviceType::CPU, FMT_RGB8, FMT_RGB8, eBCType::BC_TYPE_DEFAULT);
+DEFINE_BRIGHTNESS_CONTRAST_BENCHMARK(CPU, eDeviceType::CPU, FMT_RGB8, FMT_RGB8, eBCType::BC_TYPE_PER);
+// clang-format on

--- a/benchmarks/src/roccv/bench_brightness_contrast.cpp
+++ b/benchmarks/src/roccv/bench_brightness_contrast.cpp
@@ -31,11 +31,10 @@
 
 using namespace roccv;
 
-// copied over from src/op_brightness_contrast.cpp (in anon. namespace there)
 typedef enum eBCType {
-    BC_TYPE_DEFAULT = 0,    ///< Use default value.
-    BC_TYPE_BROADCAST = 1,  ///< Broadcast single value to all samples.
-    BC_TYPE_PER = 2         ///< Per-sample values.
+    BC_TYPE_DEFAULT = -1,    ///< Use default value. **added to make benchmark design easier
+    BC_TYPE_BROADCAST = 0,  ///< Broadcast single value to all samples.
+    BC_TYPE_PER = 1        ///< Per-sample values.
 } eBCType;
 
 template <eDeviceType DeviceType>

--- a/benchmarks/src/roccv/bench_brightness_contrast.cpp
+++ b/benchmarks/src/roccv/bench_brightness_contrast.cpp
@@ -32,9 +32,9 @@
 using namespace roccv;
 
 typedef enum eBCType {
-    BC_TYPE_DEFAULT = -1,    ///< Use default value. **added to make benchmark design easier
+    BC_TYPE_DEFAULT = -1,   ///< Use default value. Added enum to help test defaults explicilty
     BC_TYPE_BROADCAST = 0,  ///< Broadcast single value to all samples.
-    BC_TYPE_PER = 1        ///< Per-sample values.
+    BC_TYPE_PER = 1         ///< Per-sample values.
 } eBCType;
 
 template <eDeviceType DeviceType>

--- a/include/op_brightness_contrast.hpp
+++ b/include/op_brightness_contrast.hpp
@@ -51,6 +51,11 @@ class BrightnessContrast final : public IOperator {
      *                        Channels: [1, 2, 3, 4]
      *       Supported DataType(s):     [U8, U16, S16, S32, F32]
      *
+     *
+     * Brightness, Contrast, BrightnessShift, ContrastCenter (can each be different):
+     *       Supported TensorLayout(s): [N]
+     *       Supported DataTypes(s)     [F32, F64]
+     *
      * Input/Output dependency:
      *
      *       Property      |  Input == Output

--- a/include/op_brightness_contrast.hpp
+++ b/include/op_brightness_contrast.hpp
@@ -54,7 +54,7 @@ class BrightnessContrast final : public IOperator {
      *
      * Brightness, Contrast, BrightnessShift, ContrastCenter:
      *       Supported TensorLayout(s): [N]
-     *       Supported DataTypes(s)     [F32, F64]
+     *       Supported DataTypes(s):    [F32, F64]
      *
      * Input/Output dependency:
      *

--- a/include/op_brightness_contrast.hpp
+++ b/include/op_brightness_contrast.hpp
@@ -52,7 +52,7 @@ class BrightnessContrast final : public IOperator {
      *       Supported DataType(s):     [U8, U16, S16, S32, F32]
      *
      *
-     * Brightness, Contrast, BrightnessShift, ContrastCenter (can each be different):
+     * Brightness, Contrast, BrightnessShift, ContrastCenter:
      *       Supported TensorLayout(s): [N]
      *       Supported DataTypes(s)     [F32, F64]
      *
@@ -66,6 +66,10 @@ class BrightnessContrast final : public IOperator {
      *       Width         | Yes
      *       Height        | Yes
      *       Batch         | Yes
+     *
+     * Parameter dependencies:
+     *      DataType: F64 when input or output is S32, otherwise F32
+     *      Batch:  1 or N (where N matches input batch size)
      *
      * @param[in] stream The HIP stream to run this operator on.
      * @param[in] input Input tensor with image data.

--- a/python/include/operators/py_op_brightness_contrast.hpp
+++ b/python/include/operators/py_op_brightness_contrast.hpp
@@ -33,8 +33,7 @@ namespace py = pybind11;
 class PyOpBrightnessContrast {
    public:
     static void Export(py::module& m);
-    static PyTensor Execute(PyTensor& input,
-                            std::optional<std::reference_wrapper<PyTensor>> brightness,
+    static PyTensor Execute(PyTensor& input, std::optional<std::reference_wrapper<PyTensor>> brightness,
                             std::optional<std::reference_wrapper<PyTensor>> contrast,
                             std::optional<std::reference_wrapper<PyTensor>> brightnessShift,
                             std::optional<std::reference_wrapper<PyTensor>> contrastCenter,

--- a/python/include/operators/py_op_brightness_contrast.hpp
+++ b/python/include/operators/py_op_brightness_contrast.hpp
@@ -33,7 +33,7 @@ namespace py = pybind11;
 class PyOpBrightnessContrast {
    public:
     static void Export(py::module& m);
-    static PyTensor Execute(PyTensor& input, eDataType dtype,
+    static PyTensor Execute(PyTensor& input,
                             std::optional<std::reference_wrapper<PyTensor>> brightness,
                             std::optional<std::reference_wrapper<PyTensor>> contrast,
                             std::optional<std::reference_wrapper<PyTensor>> brightnessShift,

--- a/python/src/operators/py_op_brightness_contrast.cpp
+++ b/python/src/operators/py_op_brightness_contrast.cpp
@@ -24,8 +24,7 @@ THE SOFTWARE.
 
 #include <op_brightness_contrast.hpp>
 
-PyTensor PyOpBrightnessContrast::Execute(PyTensor& input, eDataType dtype,
-                                         std::optional<std::reference_wrapper<PyTensor>> brightness,
+PyTensor PyOpBrightnessContrast::Execute(PyTensor& input, std::optional<std::reference_wrapper<PyTensor>> brightness,
                                          std::optional<std::reference_wrapper<PyTensor>> contrast,
                                          std::optional<std::reference_wrapper<PyTensor>> brightnessShift,
                                          std::optional<std::reference_wrapper<PyTensor>> contrastCenter,
@@ -48,7 +47,7 @@ PyTensor PyOpBrightnessContrast::Execute(PyTensor& input, eDataType dtype,
             ? std::optional<std::reference_wrapper<roccv::Tensor>>(*contrastCenter.value().get().getTensor())
             : std::nullopt;
 
-    auto outputTensor = std::make_shared<roccv::Tensor>(inputTensor->shape(), roccv::DataType(dtype), device);
+    auto outputTensor = std::make_shared<roccv::Tensor>(inputTensor->shape(), inputTensor->dtype(), device);
 
     roccv::BrightnessContrast op;
     op(hipStream, *inputTensor, *outputTensor, brightnessTensor, contrastTensor, brightnessShiftTensor,
@@ -86,7 +85,7 @@ void PyOpBrightnessContrast::ExecuteInto(PyTensor& output, PyTensor& input,
 
 void PyOpBrightnessContrast::Export(py::module& m) {
     using namespace py::literals;
-    m.def("brightness_contrast", &PyOpBrightnessContrast::Execute, "src"_a, "dtype"_a, "brightness"_a = py::none(),
+    m.def("brightness_contrast", &PyOpBrightnessContrast::Execute, "src"_a, "brightness"_a = py::none(),
           "contrast"_a = py::none(), "brightness_shift"_a = py::none(), "contrast_center"_a = py::none(), py::kw_only(),
           "stream"_a = nullptr, "device"_a = eDeviceType::GPU, R"pbdoc(
             
@@ -97,7 +96,6 @@ void PyOpBrightnessContrast::Export(py::module& m) {
             
             Args:
                 src (rocpycv.Tensor): Input tensor containing one or more images.
-                dtype (eDataType): Datatype of the output tensor.
                 brightness (rocpycv.Tensor, optional): Brightness multipliers. Can contain 1 or N values where N is the number of input images. Default: 1.0.
                 contrast (rocpycv.Tensor, optional): Contrast multipliers. Can contain 1 or N values where N is the number of input images. Default: 1.0.
                 brightness_shift (rocpycv.Tensor, optional): Brightness shifts. Can contain 1 or N values where N is the number of input images. Default: 0.0.

--- a/src/op_brightness_contrast.cpp
+++ b/src/op_brightness_contrast.cpp
@@ -80,8 +80,7 @@ T read_broadcast_value(const std::optional<std::reference_wrapper<const Tensor>>
     if (tensor_opt.has_value()) {
         const Tensor &tensor = tensor_opt->get();
         TensorDataStrided tdata = tensor.exportData<TensorDataStrided>();
-        const unsigned char *data = static_cast<const unsigned char *>(tdata.basePtr());
-        return *(reinterpret_cast<const T *>(data));
+        return *static_cast<const T *>(tdata.basePtr());
     }
     return default_val;
 }
@@ -272,6 +271,7 @@ void dispatch_brightness(hipStream_t stream, const Tensor &input, const Tensor &
             throw Exception("Not mapped to a defined function.", eStatusType::INVALID_OPERATION);
     }
 }
+
 template <typename T>
 void dispatch_bc_dtype(hipStream_t stream, const Tensor &input, const Tensor &output,
                        std::optional<std::reference_wrapper<const Tensor>> brightness,
@@ -353,7 +353,7 @@ void BrightnessContrast::operator()(hipStream_t stream, const roccv::Tensor &inp
     eBCType brightnessShiftType = determine_bc_type(brightnessShift);
     eBCType contrastCenterType = determine_bc_type(contrastCenter);
 
-    // first dispatch based on bc_dtype, already known here
+    // dispatch based on datatype of BC params
     switch (bc_dtype) {
         case eDataType::DATA_TYPE_F32:
             dispatch_bc_dtype<float>(stream, input, output, brightness, contrast, brightnessShift, contrastCenter,

--- a/src/op_brightness_contrast.cpp
+++ b/src/op_brightness_contrast.cpp
@@ -40,54 +40,43 @@ typedef enum eBCType {
     BC_TYPE_PER = 2         ///< Per-sample values.
 } eBCType;
 
-template <typename DT>
+template <typename DT, eBCType BCType>
 class BCWrapper {
    public:
     BCWrapper(std::optional<std::reference_wrapper<const Tensor>> tensor_opt, DT default_val)
-        : default_value(default_val) {
-        if (!tensor_opt.has_value()) {
-            arg_type = eBCType::BC_TYPE_DEFAULT;
-            data = nullptr;
-            batch_stride = -1;
-        } else {
+        : default_value(default_val), batch_stride(-1), data(nullptr) {
+        if constexpr (BCType == eBCType::BC_TYPE_BROADCAST || BCType == eBCType::BC_TYPE_PER) {
             const Tensor &tensor = tensor_opt->get();
-            if (tensor.layout() != eTensorLayout::TENSOR_LAYOUT_N) {
-                throw Exception("The given tensor layout is not supported for BCWrapper", eStatusType::NOT_IMPLEMENTED);
-            }
-            arg_type =
-                (tensor.shape(tensor.layout().batch_index()) == 1) ? eBCType::BC_TYPE_BROADCAST : eBCType::BC_TYPE_PER;
             TensorDataStrided tdata = tensor.exportData<TensorDataStrided>();
             batch_stride = tdata.stride(tensor.layout().batch_index());
-            data = static_cast<unsigned char *>(tdata.basePtr());
+            data = static_cast<const unsigned char *>(tdata.basePtr());
         }
     }
 
     __device__ __host__ const DT at(int64_t n) const {
-        switch (arg_type) {
-            case eBCType::BC_TYPE_BROADCAST:
-                return *(reinterpret_cast<DT *>(data));
-            case eBCType::BC_TYPE_PER:
-                return *(reinterpret_cast<DT *>(data + (batch_stride * n)));
-            default:
-                return default_value;
+        if constexpr (BCType == eBCType::BC_TYPE_BROADCAST) {
+            return *(reinterpret_cast<const DT *>(data));
         }
+        if constexpr (BCType == eBCType::BC_TYPE_PER) {
+            return *(reinterpret_cast<const DT *>(data + (batch_stride * n)));
+        }
+        return default_value;
     }
 
    private:
     DT default_value;
-    eBCType arg_type;
     int64_t batch_stride;
-    unsigned char *data;
+    const unsigned char *data;
 };
 
-template <typename DT>
+template <typename DT, eBCType B_T, eBCType C_T, eBCType BS_T, eBCType CC_T>
 struct GroupBCWrappers {
     using ValueType = DT;
 
-    BCWrapper<DT> brightnessWrapper;
-    BCWrapper<DT> contrastWrapper;
-    BCWrapper<DT> brightnessShiftWrapper;
-    BCWrapper<DT> contrastCenterWrapper;
+    BCWrapper<DT, B_T> brightnessWrapper;
+    BCWrapper<DT, C_T> contrastWrapper;
+    BCWrapper<DT, BS_T> brightnessShiftWrapper;
+    BCWrapper<DT, CC_T> contrastCenterWrapper;
 };
 }  // namespace
 
@@ -155,8 +144,8 @@ void dispatch_brightness_contrast_input_dtype(hipStream_t stream, const Tensor &
 }
 
 template <typename BCWrappers>
-void dispatch_brightness_contrast_bc_dtype(hipStream_t stream, const Tensor &input, const Tensor &output,
-                                           const BCWrappers &bc_wrappers, eDeviceType device) {
+void dispatch_bc_dtype(hipStream_t stream, const Tensor &input, const Tensor &output, const BCWrappers &bc_wrappers,
+                       eDeviceType device) {
     eDataType input_dtype = input.dtype().etype();
 
     // Select kernel dispatcher based on a base input datatype.
@@ -173,6 +162,129 @@ void dispatch_brightness_contrast_bc_dtype(hipStream_t stream, const Tensor &inp
     auto func = funcs.at(input_dtype);
     if (func == 0) throw Exception("Not mapped to a defined function.", eStatusType::INVALID_OPERATION);
     func(stream, input, output, bc_wrappers, device);
+}
+
+template <eBCType B_T, eBCType C_T, eBCType BS_T, eBCType CC_T>
+void dispatch_contrast_center(hipStream_t stream, const Tensor &input, const Tensor &output,
+                              std::optional<std::reference_wrapper<const Tensor>> brightness,
+                              std::optional<std::reference_wrapper<const Tensor>> contrast,
+                              std::optional<std::reference_wrapper<const Tensor>> brightnessShift,
+                              std::optional<std::reference_wrapper<const Tensor>> contrastCenter, eDataType bc_dtype,
+                              eDeviceType device) {
+    auto compute_cc_default = [&]() -> double {
+        switch (input.dtype().etype()) {
+            case eDataType::DATA_TYPE_U8:
+                return 1u << (8 - 1);
+            case eDataType::DATA_TYPE_U16:
+                return 1u << (16 - 1);
+            case eDataType::DATA_TYPE_S16:
+                return 1u << (16 - 2);
+            case eDataType::DATA_TYPE_S32:
+                return 1u << (32 - 2);
+            case eDataType::DATA_TYPE_F32:
+                return 0.5;
+            default:
+                return 0.5;
+        }
+    };
+
+    if (bc_dtype == eDataType::DATA_TYPE_F32) {
+        GroupBCWrappers<float, B_T, C_T, BS_T, CC_T> wrappers{
+            BCWrapper<float, B_T>(brightness, 1.0f), BCWrapper<float, C_T>(contrast, 1.0f),
+            BCWrapper<float, BS_T>(brightnessShift, 0.0f),
+            BCWrapper<float, CC_T>(contrastCenter, static_cast<float>(compute_cc_default()))};
+        dispatch_bc_dtype<GroupBCWrappers<float, B_T, C_T, BS_T, CC_T>>(stream, input, output, wrappers, device);
+    } else if (bc_dtype == eDataType::DATA_TYPE_F64) {
+        GroupBCWrappers<double, B_T, C_T, BS_T, CC_T> wrappers{
+            BCWrapper<double, B_T>(brightness, 1.0), BCWrapper<double, C_T>(contrast, 1.0),
+            BCWrapper<double, BS_T>(brightnessShift, 0.0),
+            BCWrapper<double, CC_T>(contrastCenter, compute_cc_default())};
+        dispatch_bc_dtype<GroupBCWrappers<double, B_T, C_T, BS_T, CC_T>>(stream, input, output, wrappers, device);
+    } else {
+        throw Exception("Not mapped to a defined function.", eStatusType::INVALID_OPERATION);
+    }
+}
+
+template <eBCType B_T, eBCType C_T, eBCType BS_T>
+void dispatch_brightness_shift(hipStream_t stream, const Tensor &input, const Tensor &output,
+                               std::optional<std::reference_wrapper<const Tensor>> brightness,
+                               std::optional<std::reference_wrapper<const Tensor>> contrast,
+                               std::optional<std::reference_wrapper<const Tensor>> brightnessShift,
+                               std::optional<std::reference_wrapper<const Tensor>> contrastCenter,
+                               eBCType contrastCenterType, eDataType bc_dtype, eDeviceType device) {
+    switch (contrastCenterType) {
+        case BC_TYPE_DEFAULT:
+            dispatch_contrast_center<B_T, C_T, BS_T, BC_TYPE_DEFAULT>(
+                stream, input, output, brightness, contrast, brightnessShift, contrastCenter, bc_dtype, device);
+            break;
+        case BC_TYPE_BROADCAST:
+            dispatch_contrast_center<B_T, C_T, BS_T, BC_TYPE_BROADCAST>(
+                stream, input, output, brightness, contrast, brightnessShift, contrastCenter, bc_dtype, device);
+            break;
+        case BC_TYPE_PER:
+            dispatch_contrast_center<B_T, C_T, BS_T, BC_TYPE_PER>(stream, input, output, brightness, contrast,
+                                                                  brightnessShift, contrastCenter, bc_dtype, device);
+            break;
+        default:
+            throw Exception("Not mapped to a defined function.", eStatusType::INVALID_OPERATION);
+    }
+}
+
+template <eBCType B_T, eBCType C_T>
+void dispatch_contrast(hipStream_t stream, const Tensor &input, const Tensor &output,
+                       std::optional<std::reference_wrapper<const Tensor>> brightness,
+                       std::optional<std::reference_wrapper<const Tensor>> contrast,
+                       std::optional<std::reference_wrapper<const Tensor>> brightnessShift,
+                       std::optional<std::reference_wrapper<const Tensor>> contrastCenter, eBCType brightnessShiftType,
+                       eBCType contrastCenterType, eDataType bc_dtype, eDeviceType device) {
+    switch (brightnessShiftType) {
+        case BC_TYPE_DEFAULT:
+            dispatch_brightness_shift<B_T, C_T, BC_TYPE_DEFAULT>(stream, input, output, brightness, contrast,
+                                                                 brightnessShift, contrastCenter, contrastCenterType,
+                                                                 bc_dtype, device);
+            break;
+        case BC_TYPE_BROADCAST:
+            dispatch_brightness_shift<B_T, C_T, BC_TYPE_BROADCAST>(stream, input, output, brightness, contrast,
+                                                                   brightnessShift, contrastCenter, contrastCenterType,
+                                                                   bc_dtype, device);
+            break;
+        case BC_TYPE_PER:
+            dispatch_brightness_shift<B_T, C_T, BC_TYPE_PER>(stream, input, output, brightness, contrast,
+                                                             brightnessShift, contrastCenter, contrastCenterType,
+                                                             bc_dtype, device);
+            break;
+        default:
+            throw Exception("Not mapped to a defined function.", eStatusType::INVALID_OPERATION);
+    }
+}
+
+template <eBCType B_T>
+void dispatch_brightness(hipStream_t stream, const Tensor &input, const Tensor &output,
+                         std::optional<std::reference_wrapper<const Tensor>> brightness,
+                         std::optional<std::reference_wrapper<const Tensor>> contrast,
+                         std::optional<std::reference_wrapper<const Tensor>> brightnessShift,
+                         std::optional<std::reference_wrapper<const Tensor>> contrastCenter, eBCType contrastType,
+                         eBCType brightnessShiftType, eBCType contrastCenterType, eDataType bc_dtype,
+                         eDeviceType device) {
+    switch (contrastType) {
+        case BC_TYPE_DEFAULT:
+            dispatch_contrast<B_T, BC_TYPE_DEFAULT>(stream, input, output, brightness, contrast, brightnessShift,
+                                                    contrastCenter, brightnessShiftType, contrastCenterType, bc_dtype,
+                                                    device);
+            break;
+        case BC_TYPE_BROADCAST:
+            dispatch_contrast<B_T, BC_TYPE_BROADCAST>(stream, input, output, brightness, contrast, brightnessShift,
+                                                      contrastCenter, brightnessShiftType, contrastCenterType, bc_dtype,
+                                                      device);
+            break;
+        case BC_TYPE_PER:
+            dispatch_contrast<B_T, BC_TYPE_PER>(stream, input, output, brightness, contrast, brightnessShift,
+                                                contrastCenter, brightnessShiftType, contrastCenterType, bc_dtype,
+                                                device);
+            break;
+        default:
+            throw Exception("Not mapped to a defined function.", eStatusType::INVALID_OPERATION);
+    }
 }
 
 void BrightnessContrast::operator()(hipStream_t stream, const roccv::Tensor &input, const roccv::Tensor &output,
@@ -216,36 +328,41 @@ void BrightnessContrast::operator()(hipStream_t stream, const roccv::Tensor &inp
     validate_bc_param(brightnessShift);
     validate_bc_param(contrastCenter);
 
-    auto compute_cc_default = [&]() -> double {
-        switch (input_dtype) {
-            case eDataType::DATA_TYPE_U8:
-                return 1u << (8 - 1);
-            case eDataType::DATA_TYPE_U16:
-                return 1u << (16 - 1);
-            case eDataType::DATA_TYPE_S16:
-                return 1u << (16 - 2);
-            case eDataType::DATA_TYPE_S32:
-                return 1u << (32 - 2);
-            case eDataType::DATA_TYPE_F32:
-                return 0.5;
-            default:
-                return 0.5;
+    // Determine brightness/contrast etc. types
+    auto determine_bc_type = [](const std::optional<std::reference_wrapper<const Tensor>> &tensor_opt) -> eBCType {
+        if (!tensor_opt.has_value()) {
+            return eBCType::BC_TYPE_DEFAULT;
+        } else {
+            const Tensor &tensor = tensor_opt->get();
+            return (tensor.shape(tensor.layout().batch_index()) == 1) ? eBCType::BC_TYPE_BROADCAST
+                                                                      : eBCType::BC_TYPE_PER;
         }
     };
 
-    // Select kernel dispatcher based on BC datatype
-    if (bc_dtype == eDataType::DATA_TYPE_F32) {
-        GroupBCWrappers<float> wrappers{BCWrapper<float>(brightness, 1.0f), BCWrapper<float>(contrast, 1.0f),
-                                        BCWrapper<float>(brightnessShift, 0.0f),
-                                        BCWrapper<float>(contrastCenter, static_cast<float>(compute_cc_default()))};
-        dispatch_brightness_contrast_bc_dtype<GroupBCWrappers<float>>(stream, input, output, wrappers, device);
-    } else if (bc_dtype == eDataType::DATA_TYPE_F64) {
-        GroupBCWrappers<double> wrappers{BCWrapper<double>(brightness, 1.0), BCWrapper<double>(contrast, 1.0),
-                                         BCWrapper<double>(brightnessShift, 0.0),
-                                         BCWrapper<double>(contrastCenter, compute_cc_default())};
-        dispatch_brightness_contrast_bc_dtype<GroupBCWrappers<double>>(stream, input, output, wrappers, device);
-    } else {
-        throw Exception("Not mapped to a defined function.", eStatusType::INVALID_OPERATION);
+    eBCType brightnessType = determine_bc_type(brightness);
+    eBCType contrastType = determine_bc_type(contrast);
+    eBCType brightnessShiftType = determine_bc_type(brightnessShift);
+    eBCType contrastCenterType = determine_bc_type(contrastCenter);
+
+    // dispatch based on brightness type
+    switch (brightnessType) {
+        case BC_TYPE_DEFAULT:
+            dispatch_brightness<BC_TYPE_DEFAULT>(stream, input, output, brightness, contrast, brightnessShift,
+                                                 contrastCenter, contrastType, brightnessShiftType, contrastCenterType,
+                                                 bc_dtype, device);
+            break;
+        case BC_TYPE_BROADCAST:
+            dispatch_brightness<BC_TYPE_BROADCAST>(stream, input, output, brightness, contrast, brightnessShift,
+                                                   contrastCenter, contrastType, brightnessShiftType,
+                                                   contrastCenterType, bc_dtype, device);
+            break;
+        case BC_TYPE_PER:
+            dispatch_brightness<BC_TYPE_PER>(stream, input, output, brightness, contrast, brightnessShift,
+                                             contrastCenter, contrastType, brightnessShiftType, contrastCenterType,
+                                             bc_dtype, device);
+            break;
+        default:
+            throw Exception("Not mapped to a defined function.", eStatusType::INVALID_OPERATION);
     }
 }
 }  // namespace roccv

--- a/src/op_brightness_contrast.cpp
+++ b/src/op_brightness_contrast.cpp
@@ -35,9 +35,8 @@ THE SOFTWARE.
 namespace {
 using namespace roccv;
 typedef enum eBCType {
-    BC_TYPE_DEFAULT = 0,    ///< Use default value.
-    BC_TYPE_BROADCAST = 1,  ///< Broadcast single value to all samples.
-    BC_TYPE_PER = 2         ///< Per-sample values.
+    BC_TYPE_BROADCAST = 0,  ///< Broadcast single value to all samples.
+    BC_TYPE_PER = 1         ///< Per-sample values.
 } eBCType;
 
 template <typename DT, eBCType BCType>
@@ -45,7 +44,7 @@ class BCWrapper {
    public:
     BCWrapper(std::optional<std::reference_wrapper<const Tensor>> tensor_opt, DT default_val)
         : default_value(default_val), batch_stride(-1), data(nullptr) {
-        if constexpr (BCType == eBCType::BC_TYPE_BROADCAST || BCType == eBCType::BC_TYPE_PER) {
+        if constexpr (BCType == eBCType::BC_TYPE_PER) {
             const Tensor &tensor = tensor_opt->get();
             TensorDataStrided tdata = tensor.exportData<TensorDataStrided>();
             batch_stride = tdata.stride(tensor.layout().batch_index());
@@ -54,9 +53,6 @@ class BCWrapper {
     }
 
     __device__ __host__ const DT at(int64_t n) const {
-        if constexpr (BCType == eBCType::BC_TYPE_BROADCAST) {
-            return *(reinterpret_cast<const DT *>(data));
-        }
         if constexpr (BCType == eBCType::BC_TYPE_PER) {
             return *(reinterpret_cast<const DT *>(data + (batch_stride * n)));
         }
@@ -78,6 +74,17 @@ struct GroupBCWrappers {
     BCWrapper<DT, BS_T> brightnessShiftWrapper;
     BCWrapper<DT, CC_T> contrastCenterWrapper;
 };
+
+template <typename T>
+T read_broadcast_value(const std::optional<std::reference_wrapper<const Tensor>> &tensor_opt, T default_val) {
+    if (tensor_opt.has_value()) {
+        const Tensor &tensor = tensor_opt->get();
+        TensorDataStrided tdata = tensor.exportData<TensorDataStrided>();
+        const unsigned char *data = static_cast<const unsigned char *>(tdata.basePtr());
+        return *(reinterpret_cast<const T *>(data));
+    }
+    return default_val;
+}
 }  // namespace
 
 namespace roccv {
@@ -144,8 +151,8 @@ void dispatch_brightness_contrast_input_dtype(hipStream_t stream, const Tensor &
 }
 
 template <typename BCWrappers>
-void dispatch_bc_dtype(hipStream_t stream, const Tensor &input, const Tensor &output, const BCWrappers &bc_wrappers,
-                       eDeviceType device) {
+void dispatch_contrast_center(hipStream_t stream, const Tensor &input, const Tensor &output,
+                              const BCWrappers &bc_wrappers, eDeviceType device) {
     eDataType input_dtype = input.dtype().etype();
 
     // Select kernel dispatcher based on a base input datatype.
@@ -164,13 +171,12 @@ void dispatch_bc_dtype(hipStream_t stream, const Tensor &input, const Tensor &ou
     func(stream, input, output, bc_wrappers, device);
 }
 
-template <eBCType B_T, eBCType C_T, eBCType BS_T, eBCType CC_T>
-void dispatch_contrast_center(hipStream_t stream, const Tensor &input, const Tensor &output,
-                              std::optional<std::reference_wrapper<const Tensor>> brightness,
-                              std::optional<std::reference_wrapper<const Tensor>> contrast,
-                              std::optional<std::reference_wrapper<const Tensor>> brightnessShift,
-                              std::optional<std::reference_wrapper<const Tensor>> contrastCenter, eDataType bc_dtype,
-                              eDeviceType device) {
+template <typename T, eBCType B_T, eBCType C_T, eBCType BS_T>
+void dispatch_brightness_shift(hipStream_t stream, const Tensor &input, const Tensor &output,
+                               BCWrapper<T, B_T> brightnessWrapper, BCWrapper<T, C_T> contrastWrapper,
+                               BCWrapper<T, BS_T> brightnessShiftWrapper,
+                               std::optional<std::reference_wrapper<const Tensor>> contrastCenter,
+                               eBCType contrastCenterType, eDeviceType device) {
     auto compute_cc_default = [&]() -> double {
         switch (input.dtype().etype()) {
             case eDataType::DATA_TYPE_U8:
@@ -187,100 +193,105 @@ void dispatch_contrast_center(hipStream_t stream, const Tensor &input, const Ten
                 return 0.5;
         }
     };
-
-    if (bc_dtype == eDataType::DATA_TYPE_F32) {
-        GroupBCWrappers<float, B_T, C_T, BS_T, CC_T> wrappers{
-            BCWrapper<float, B_T>(brightness, 1.0f), BCWrapper<float, C_T>(contrast, 1.0f),
-            BCWrapper<float, BS_T>(brightnessShift, 0.0f),
-            BCWrapper<float, CC_T>(contrastCenter, static_cast<float>(compute_cc_default()))};
-        dispatch_bc_dtype<GroupBCWrappers<float, B_T, C_T, BS_T, CC_T>>(stream, input, output, wrappers, device);
-    } else if (bc_dtype == eDataType::DATA_TYPE_F64) {
-        GroupBCWrappers<double, B_T, C_T, BS_T, CC_T> wrappers{
-            BCWrapper<double, B_T>(brightness, 1.0), BCWrapper<double, C_T>(contrast, 1.0),
-            BCWrapper<double, BS_T>(brightnessShift, 0.0),
-            BCWrapper<double, CC_T>(contrastCenter, compute_cc_default())};
-        dispatch_bc_dtype<GroupBCWrappers<double, B_T, C_T, BS_T, CC_T>>(stream, input, output, wrappers, device);
-    } else {
-        throw Exception("Not mapped to a defined function.", eStatusType::INVALID_OPERATION);
-    }
-}
-
-template <eBCType B_T, eBCType C_T, eBCType BS_T>
-void dispatch_brightness_shift(hipStream_t stream, const Tensor &input, const Tensor &output,
-                               std::optional<std::reference_wrapper<const Tensor>> brightness,
-                               std::optional<std::reference_wrapper<const Tensor>> contrast,
-                               std::optional<std::reference_wrapper<const Tensor>> brightnessShift,
-                               std::optional<std::reference_wrapper<const Tensor>> contrastCenter,
-                               eBCType contrastCenterType, eDataType bc_dtype, eDeviceType device) {
+    T defaultValue = static_cast<T>(compute_cc_default());
     switch (contrastCenterType) {
-        case BC_TYPE_DEFAULT:
-            dispatch_contrast_center<B_T, C_T, BS_T, BC_TYPE_DEFAULT>(
-                stream, input, output, brightness, contrast, brightnessShift, contrastCenter, bc_dtype, device);
-            break;
         case BC_TYPE_BROADCAST:
-            dispatch_contrast_center<B_T, C_T, BS_T, BC_TYPE_BROADCAST>(
-                stream, input, output, brightness, contrast, brightnessShift, contrastCenter, bc_dtype, device);
+            defaultValue = read_broadcast_value<T>(contrastCenter, defaultValue);
+            dispatch_contrast_center<GroupBCWrappers<T, B_T, C_T, BS_T, BC_TYPE_BROADCAST>>(
+                stream, input, output,
+                GroupBCWrappers<T, B_T, C_T, BS_T, BC_TYPE_BROADCAST>{
+                    brightnessWrapper,
+                    contrastWrapper,
+                    brightnessShiftWrapper,
+                    BCWrapper<T, BC_TYPE_BROADCAST>(contrastCenter, defaultValue),
+                },
+                device);
             break;
         case BC_TYPE_PER:
-            dispatch_contrast_center<B_T, C_T, BS_T, BC_TYPE_PER>(stream, input, output, brightness, contrast,
-                                                                  brightnessShift, contrastCenter, bc_dtype, device);
+            dispatch_contrast_center<GroupBCWrappers<T, B_T, C_T, BS_T, BC_TYPE_PER>>(
+                stream, input, output,
+                GroupBCWrappers<T, B_T, C_T, BS_T, BC_TYPE_PER>{
+                    brightnessWrapper,
+                    contrastWrapper,
+                    brightnessShiftWrapper,
+                    BCWrapper<T, BC_TYPE_PER>(contrastCenter, defaultValue),
+                },
+                device);
             break;
         default:
             throw Exception("Not mapped to a defined function.", eStatusType::INVALID_OPERATION);
     }
 }
 
-template <eBCType B_T, eBCType C_T>
+template <typename T, eBCType B_T, eBCType C_T>
 void dispatch_contrast(hipStream_t stream, const Tensor &input, const Tensor &output,
-                       std::optional<std::reference_wrapper<const Tensor>> brightness,
-                       std::optional<std::reference_wrapper<const Tensor>> contrast,
+                       BCWrapper<T, B_T> brightnessWrapper, BCWrapper<T, C_T> contrastWrapper,
                        std::optional<std::reference_wrapper<const Tensor>> brightnessShift,
                        std::optional<std::reference_wrapper<const Tensor>> contrastCenter, eBCType brightnessShiftType,
-                       eBCType contrastCenterType, eDataType bc_dtype, eDeviceType device) {
+                       eBCType contrastCenterType, eDeviceType device) {
+    T defaultValue = static_cast<T>(0.0);
     switch (brightnessShiftType) {
-        case BC_TYPE_DEFAULT:
-            dispatch_brightness_shift<B_T, C_T, BC_TYPE_DEFAULT>(stream, input, output, brightness, contrast,
-                                                                 brightnessShift, contrastCenter, contrastCenterType,
-                                                                 bc_dtype, device);
-            break;
         case BC_TYPE_BROADCAST:
-            dispatch_brightness_shift<B_T, C_T, BC_TYPE_BROADCAST>(stream, input, output, brightness, contrast,
-                                                                   brightnessShift, contrastCenter, contrastCenterType,
-                                                                   bc_dtype, device);
+            defaultValue = read_broadcast_value<T>(brightnessShift, defaultValue);
+            dispatch_brightness_shift<T, B_T, C_T, BC_TYPE_BROADCAST>(
+                stream, input, output, brightnessWrapper, contrastWrapper,
+                BCWrapper<T, BC_TYPE_BROADCAST>(brightnessShift, defaultValue), contrastCenter, contrastCenterType,
+                device);
             break;
         case BC_TYPE_PER:
-            dispatch_brightness_shift<B_T, C_T, BC_TYPE_PER>(stream, input, output, brightness, contrast,
-                                                             brightnessShift, contrastCenter, contrastCenterType,
-                                                             bc_dtype, device);
+            dispatch_brightness_shift<T, B_T, C_T, BC_TYPE_PER>(
+                stream, input, output, brightnessWrapper, contrastWrapper,
+                BCWrapper<T, BC_TYPE_PER>(brightnessShift, defaultValue), contrastCenter, contrastCenterType, device);
             break;
         default:
             throw Exception("Not mapped to a defined function.", eStatusType::INVALID_OPERATION);
     }
 }
 
-template <eBCType B_T>
+template <typename T, eBCType B_T>
 void dispatch_brightness(hipStream_t stream, const Tensor &input, const Tensor &output,
-                         std::optional<std::reference_wrapper<const Tensor>> brightness,
+                         BCWrapper<T, B_T> brightnessWrapper,
                          std::optional<std::reference_wrapper<const Tensor>> contrast,
                          std::optional<std::reference_wrapper<const Tensor>> brightnessShift,
                          std::optional<std::reference_wrapper<const Tensor>> contrastCenter, eBCType contrastType,
-                         eBCType brightnessShiftType, eBCType contrastCenterType, eDataType bc_dtype,
-                         eDeviceType device) {
+                         eBCType brightnessShiftType, eBCType contrastCenterType, eDeviceType device) {
+    T defaultValue = static_cast<T>(1.0);
     switch (contrastType) {
-        case BC_TYPE_DEFAULT:
-            dispatch_contrast<B_T, BC_TYPE_DEFAULT>(stream, input, output, brightness, contrast, brightnessShift,
-                                                    contrastCenter, brightnessShiftType, contrastCenterType, bc_dtype,
-                                                    device);
-            break;
         case BC_TYPE_BROADCAST:
-            dispatch_contrast<B_T, BC_TYPE_BROADCAST>(stream, input, output, brightness, contrast, brightnessShift,
-                                                      contrastCenter, brightnessShiftType, contrastCenterType, bc_dtype,
-                                                      device);
+            defaultValue = read_broadcast_value<T>(contrast, defaultValue);
+            dispatch_contrast<T, B_T, BC_TYPE_BROADCAST>(
+                stream, input, output, brightnessWrapper, BCWrapper<T, BC_TYPE_BROADCAST>(contrast, defaultValue),
+                brightnessShift, contrastCenter, brightnessShiftType, contrastCenterType, device);
             break;
         case BC_TYPE_PER:
-            dispatch_contrast<B_T, BC_TYPE_PER>(stream, input, output, brightness, contrast, brightnessShift,
-                                                contrastCenter, brightnessShiftType, contrastCenterType, bc_dtype,
-                                                device);
+            dispatch_contrast<T, B_T, BC_TYPE_PER>(stream, input, output, brightnessWrapper,
+                                                   BCWrapper<T, BC_TYPE_PER>(contrast, defaultValue), brightnessShift,
+                                                   contrastCenter, brightnessShiftType, contrastCenterType, device);
+            break;
+        default:
+            throw Exception("Not mapped to a defined function.", eStatusType::INVALID_OPERATION);
+    }
+}
+template <typename T>
+void dispatch_bc_dtype(hipStream_t stream, const Tensor &input, const Tensor &output,
+                       std::optional<std::reference_wrapper<const Tensor>> brightness,
+                       std::optional<std::reference_wrapper<const Tensor>> contrast,
+                       std::optional<std::reference_wrapper<const Tensor>> brightnessShift,
+                       std::optional<std::reference_wrapper<const Tensor>> contrastCenter, eBCType brightnessType,
+                       eBCType contrastType, eBCType brightnessShiftType, eBCType contrastCenterType,
+                       eDeviceType device) {
+    T defaultValue = static_cast<T>(1.0);
+    switch (brightnessType) {
+        case BC_TYPE_BROADCAST:
+            defaultValue = read_broadcast_value<T>(brightness, defaultValue);
+            dispatch_brightness<T, BC_TYPE_BROADCAST>(
+                stream, input, output, BCWrapper<T, BC_TYPE_BROADCAST>(brightness, defaultValue), contrast,
+                brightnessShift, contrastCenter, contrastType, brightnessShiftType, contrastCenterType, device);
+            break;
+        case BC_TYPE_PER:
+            dispatch_brightness<T, BC_TYPE_PER>(
+                stream, input, output, BCWrapper<T, BC_TYPE_PER>(brightness, defaultValue), contrast, brightnessShift,
+                contrastCenter, contrastType, brightnessShiftType, contrastCenterType, device);
             break;
         default:
             throw Exception("Not mapped to a defined function.", eStatusType::INVALID_OPERATION);
@@ -330,13 +341,11 @@ void BrightnessContrast::operator()(hipStream_t stream, const roccv::Tensor &inp
 
     // Determine brightness/contrast etc. types
     auto determine_bc_type = [](const std::optional<std::reference_wrapper<const Tensor>> &tensor_opt) -> eBCType {
-        if (!tensor_opt.has_value()) {
-            return eBCType::BC_TYPE_DEFAULT;
-        } else {
+        if (tensor_opt.has_value()) {
             const Tensor &tensor = tensor_opt->get();
-            return (tensor.shape(tensor.layout().batch_index()) == 1) ? eBCType::BC_TYPE_BROADCAST
-                                                                      : eBCType::BC_TYPE_PER;
+            if (tensor.shape(tensor.layout().batch_index()) != 1) return eBCType::BC_TYPE_PER;
         }
+        return eBCType::BC_TYPE_BROADCAST;
     };
 
     eBCType brightnessType = determine_bc_type(brightness);
@@ -344,22 +353,15 @@ void BrightnessContrast::operator()(hipStream_t stream, const roccv::Tensor &inp
     eBCType brightnessShiftType = determine_bc_type(brightnessShift);
     eBCType contrastCenterType = determine_bc_type(contrastCenter);
 
-    // dispatch based on brightness type
-    switch (brightnessType) {
-        case BC_TYPE_DEFAULT:
-            dispatch_brightness<BC_TYPE_DEFAULT>(stream, input, output, brightness, contrast, brightnessShift,
-                                                 contrastCenter, contrastType, brightnessShiftType, contrastCenterType,
-                                                 bc_dtype, device);
+    // first dispatch based on bc_dtype, already known here
+    switch (bc_dtype) {
+        case eDataType::DATA_TYPE_F32:
+            dispatch_bc_dtype<float>(stream, input, output, brightness, contrast, brightnessShift, contrastCenter,
+                                     brightnessType, contrastType, brightnessShiftType, contrastCenterType, device);
             break;
-        case BC_TYPE_BROADCAST:
-            dispatch_brightness<BC_TYPE_BROADCAST>(stream, input, output, brightness, contrast, brightnessShift,
-                                                   contrastCenter, contrastType, brightnessShiftType,
-                                                   contrastCenterType, bc_dtype, device);
-            break;
-        case BC_TYPE_PER:
-            dispatch_brightness<BC_TYPE_PER>(stream, input, output, brightness, contrast, brightnessShift,
-                                             contrastCenter, contrastType, brightnessShiftType, contrastCenterType,
-                                             bc_dtype, device);
+        case eDataType::DATA_TYPE_F64:
+            dispatch_bc_dtype<double>(stream, input, output, brightness, contrast, brightnessShift, contrastCenter,
+                                      brightnessType, contrastType, brightnessShiftType, contrastCenterType, device);
             break;
         default:
             throw Exception("Not mapped to a defined function.", eStatusType::INVALID_OPERATION);

--- a/src/op_brightness_contrast.cpp
+++ b/src/op_brightness_contrast.cpp
@@ -35,34 +35,38 @@ THE SOFTWARE.
 namespace {
 using namespace roccv;
 typedef enum eBCType {
-    BC_TYPE_BROADCAST = 0,  ///< Broadcast single value to all samples.
-    BC_TYPE_PER = 1         ///< Per-sample values.
+    BC_TYPE_DEFAULT = -1,       ///< Use default value.
+    BC_TYPE_BROADCAST_PER = 0,  ///< Use passed in broadcast or per-sample value/s
+    BC_TYPE_BROADCAST = 1,      ///< Broadcast single value to all samples.
+    BC_TYPE_PER = 2             ///< Per-sample values.
 } eBCType;
 
 template <typename DT, eBCType BCType>
 class BCWrapper {
    public:
-    BCWrapper(std::optional<std::reference_wrapper<const Tensor>> tensor_opt, DT default_val)
-        : default_value(default_val), batch_stride(-1), data(nullptr) {
-        if constexpr (BCType == eBCType::BC_TYPE_PER) {
+    BCWrapper(std::optional<std::reference_wrapper<const Tensor>> tensor_opt, DT default_value, bool per)
+        : m_default_value(default_value), m_data(nullptr) {
+        if constexpr (BCType != eBCType::BC_TYPE_DEFAULT) {
             const Tensor &tensor = tensor_opt->get();
             TensorDataStrided tdata = tensor.exportData<TensorDataStrided>();
-            batch_stride = tdata.stride(tensor.layout().batch_index());
-            data = static_cast<const unsigned char *>(tdata.basePtr());
+            if (per) {
+                m_batch_stride = tdata.stride(tensor.layout().batch_index());
+            }
+            m_data = static_cast<const unsigned char *>(tdata.basePtr());
         }
     }
 
     __device__ __host__ const DT at(int64_t n) const {
-        if constexpr (BCType == eBCType::BC_TYPE_PER) {
-            return *(reinterpret_cast<const DT *>(data + (batch_stride * n)));
+        if constexpr (BCType == eBCType::BC_TYPE_BROADCAST_PER) {
+            return *(reinterpret_cast<const DT *>(m_data + (m_batch_stride * n)));
         }
-        return default_value;
+        return m_default_value;
     }
 
    private:
-    DT default_value;
-    int64_t batch_stride;
-    const unsigned char *data;
+    DT m_default_value;
+    int64_t m_batch_stride = 0;
+    const unsigned char *m_data;
 };
 
 template <typename DT, eBCType B_T, eBCType C_T, eBCType BS_T, eBCType CC_T>
@@ -74,16 +78,6 @@ struct GroupBCWrappers {
     BCWrapper<DT, BS_T> brightnessShiftWrapper;
     BCWrapper<DT, CC_T> contrastCenterWrapper;
 };
-
-template <typename T>
-T read_broadcast_value(const std::optional<std::reference_wrapper<const Tensor>> &tensor_opt, T default_val) {
-    if (tensor_opt.has_value()) {
-        const Tensor &tensor = tensor_opt->get();
-        TensorDataStrided tdata = tensor.exportData<TensorDataStrided>();
-        return *static_cast<const T *>(tdata.basePtr());
-    }
-    return default_val;
-}
 }  // namespace
 
 namespace roccv {
@@ -195,25 +189,35 @@ void dispatch_brightness_shift(hipStream_t stream, const Tensor &input, const Te
     T defaultValue = static_cast<T>(compute_cc_default());
     switch (contrastCenterType) {
         case BC_TYPE_BROADCAST:
-            defaultValue = read_broadcast_value<T>(contrastCenter, defaultValue);
-            dispatch_contrast_center<GroupBCWrappers<T, B_T, C_T, BS_T, BC_TYPE_BROADCAST>>(
+            dispatch_contrast_center<GroupBCWrappers<T, B_T, C_T, BS_T, BC_TYPE_BROADCAST_PER>>(
                 stream, input, output,
-                GroupBCWrappers<T, B_T, C_T, BS_T, BC_TYPE_BROADCAST>{
+                GroupBCWrappers<T, B_T, C_T, BS_T, BC_TYPE_BROADCAST_PER>{
                     brightnessWrapper,
                     contrastWrapper,
                     brightnessShiftWrapper,
-                    BCWrapper<T, BC_TYPE_BROADCAST>(contrastCenter, defaultValue),
+                    BCWrapper<T, BC_TYPE_BROADCAST_PER>(contrastCenter, defaultValue, false),
                 },
                 device);
             break;
         case BC_TYPE_PER:
-            dispatch_contrast_center<GroupBCWrappers<T, B_T, C_T, BS_T, BC_TYPE_PER>>(
+            dispatch_contrast_center<GroupBCWrappers<T, B_T, C_T, BS_T, BC_TYPE_BROADCAST_PER>>(
                 stream, input, output,
-                GroupBCWrappers<T, B_T, C_T, BS_T, BC_TYPE_PER>{
+                GroupBCWrappers<T, B_T, C_T, BS_T, BC_TYPE_BROADCAST_PER>{
                     brightnessWrapper,
                     contrastWrapper,
                     brightnessShiftWrapper,
-                    BCWrapper<T, BC_TYPE_PER>(contrastCenter, defaultValue),
+                    BCWrapper<T, BC_TYPE_BROADCAST_PER>(contrastCenter, defaultValue, true),
+                },
+                device);
+            break;
+        case BC_TYPE_DEFAULT:
+            dispatch_contrast_center<GroupBCWrappers<T, B_T, C_T, BS_T, BC_TYPE_DEFAULT>>(
+                stream, input, output,
+                GroupBCWrappers<T, B_T, C_T, BS_T, BC_TYPE_DEFAULT>{
+                    brightnessWrapper,
+                    contrastWrapper,
+                    brightnessShiftWrapper,
+                    BCWrapper<T, BC_TYPE_DEFAULT>(contrastCenter, defaultValue, false),
                 },
                 device);
             break;
@@ -231,16 +235,22 @@ void dispatch_contrast(hipStream_t stream, const Tensor &input, const Tensor &ou
     T defaultValue = static_cast<T>(0.0);
     switch (brightnessShiftType) {
         case BC_TYPE_BROADCAST:
-            defaultValue = read_broadcast_value<T>(brightnessShift, defaultValue);
-            dispatch_brightness_shift<T, B_T, C_T, BC_TYPE_BROADCAST>(
+            dispatch_brightness_shift<T, B_T, C_T, BC_TYPE_BROADCAST_PER>(
                 stream, input, output, brightnessWrapper, contrastWrapper,
-                BCWrapper<T, BC_TYPE_BROADCAST>(brightnessShift, defaultValue), contrastCenter, contrastCenterType,
-                device);
+                BCWrapper<T, BC_TYPE_BROADCAST_PER>(brightnessShift, defaultValue, false), contrastCenter,
+                contrastCenterType, device);
             break;
         case BC_TYPE_PER:
-            dispatch_brightness_shift<T, B_T, C_T, BC_TYPE_PER>(
+            dispatch_brightness_shift<T, B_T, C_T, BC_TYPE_BROADCAST_PER>(
                 stream, input, output, brightnessWrapper, contrastWrapper,
-                BCWrapper<T, BC_TYPE_PER>(brightnessShift, defaultValue), contrastCenter, contrastCenterType, device);
+                BCWrapper<T, BC_TYPE_BROADCAST_PER>(brightnessShift, defaultValue, true), contrastCenter,
+                contrastCenterType, device);
+            break;
+        case BC_TYPE_DEFAULT:
+            dispatch_brightness_shift<T, B_T, C_T, BC_TYPE_DEFAULT>(
+                stream, input, output, brightnessWrapper, contrastWrapper,
+                BCWrapper<T, BC_TYPE_DEFAULT>(brightnessShift, defaultValue, false), contrastCenter, contrastCenterType,
+                device);
             break;
         default:
             throw Exception("Not mapped to a defined function.", eStatusType::INVALID_OPERATION);
@@ -257,15 +267,21 @@ void dispatch_brightness(hipStream_t stream, const Tensor &input, const Tensor &
     T defaultValue = static_cast<T>(1.0);
     switch (contrastType) {
         case BC_TYPE_BROADCAST:
-            defaultValue = read_broadcast_value<T>(contrast, defaultValue);
-            dispatch_contrast<T, B_T, BC_TYPE_BROADCAST>(
-                stream, input, output, brightnessWrapper, BCWrapper<T, BC_TYPE_BROADCAST>(contrast, defaultValue),
-                brightnessShift, contrastCenter, brightnessShiftType, contrastCenterType, device);
+            dispatch_contrast<T, B_T, BC_TYPE_BROADCAST_PER>(
+                stream, input, output, brightnessWrapper,
+                BCWrapper<T, BC_TYPE_BROADCAST_PER>(contrast, defaultValue, false), brightnessShift, contrastCenter,
+                brightnessShiftType, contrastCenterType, device);
             break;
         case BC_TYPE_PER:
-            dispatch_contrast<T, B_T, BC_TYPE_PER>(stream, input, output, brightnessWrapper,
-                                                   BCWrapper<T, BC_TYPE_PER>(contrast, defaultValue), brightnessShift,
-                                                   contrastCenter, brightnessShiftType, contrastCenterType, device);
+            dispatch_contrast<T, B_T, BC_TYPE_BROADCAST_PER>(
+                stream, input, output, brightnessWrapper,
+                BCWrapper<T, BC_TYPE_BROADCAST_PER>(contrast, defaultValue, true), brightnessShift, contrastCenter,
+                brightnessShiftType, contrastCenterType, device);
+            break;
+        case BC_TYPE_DEFAULT:
+            dispatch_contrast<T, B_T, BC_TYPE_DEFAULT>(
+                stream, input, output, brightnessWrapper, BCWrapper<T, BC_TYPE_DEFAULT>(contrast, defaultValue, false),
+                brightnessShift, contrastCenter, brightnessShiftType, contrastCenterType, device);
             break;
         default:
             throw Exception("Not mapped to a defined function.", eStatusType::INVALID_OPERATION);
@@ -283,15 +299,19 @@ void dispatch_bc_dtype(hipStream_t stream, const Tensor &input, const Tensor &ou
     T defaultValue = static_cast<T>(1.0);
     switch (brightnessType) {
         case BC_TYPE_BROADCAST:
-            defaultValue = read_broadcast_value<T>(brightness, defaultValue);
-            dispatch_brightness<T, BC_TYPE_BROADCAST>(
-                stream, input, output, BCWrapper<T, BC_TYPE_BROADCAST>(brightness, defaultValue), contrast,
+            dispatch_brightness<T, BC_TYPE_BROADCAST_PER>(
+                stream, input, output, BCWrapper<T, BC_TYPE_BROADCAST_PER>(brightness, defaultValue, false), contrast,
                 brightnessShift, contrastCenter, contrastType, brightnessShiftType, contrastCenterType, device);
             break;
         case BC_TYPE_PER:
-            dispatch_brightness<T, BC_TYPE_PER>(
-                stream, input, output, BCWrapper<T, BC_TYPE_PER>(brightness, defaultValue), contrast, brightnessShift,
-                contrastCenter, contrastType, brightnessShiftType, contrastCenterType, device);
+            dispatch_brightness<T, BC_TYPE_BROADCAST_PER>(
+                stream, input, output, BCWrapper<T, BC_TYPE_BROADCAST_PER>(brightness, defaultValue, true), contrast,
+                brightnessShift, contrastCenter, contrastType, brightnessShiftType, contrastCenterType, device);
+            break;
+        case BC_TYPE_DEFAULT:
+            dispatch_brightness<T, BC_TYPE_DEFAULT>(
+                stream, input, output, BCWrapper<T, BC_TYPE_DEFAULT>(brightness, defaultValue, false), contrast,
+                brightnessShift, contrastCenter, contrastType, brightnessShiftType, contrastCenterType, device);
             break;
         default:
             throw Exception("Not mapped to a defined function.", eStatusType::INVALID_OPERATION);
@@ -341,11 +361,13 @@ void BrightnessContrast::operator()(hipStream_t stream, const roccv::Tensor &inp
 
     // Determine brightness/contrast etc. types
     auto determine_bc_type = [](const std::optional<std::reference_wrapper<const Tensor>> &tensor_opt) -> eBCType {
-        if (tensor_opt.has_value()) {
+        if (!tensor_opt.has_value()) {
+            return eBCType::BC_TYPE_DEFAULT;
+        } else {
             const Tensor &tensor = tensor_opt->get();
-            if (tensor.shape(tensor.layout().batch_index()) != 1) return eBCType::BC_TYPE_PER;
+            return (tensor.shape(tensor.layout().batch_index()) == 1) ? eBCType::BC_TYPE_BROADCAST
+                                                                      : eBCType::BC_TYPE_PER;
         }
-        return eBCType::BC_TYPE_BROADCAST;
     };
 
     eBCType brightnessType = determine_bc_type(brightness);

--- a/tests/roccv/cpp/src/tests/operators/test_op_brightness_contrast.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_brightness_contrast.cpp
@@ -85,9 +85,9 @@ std::vector<BT_DEST> GoldenBrightnessContrast(std::vector<BT_SRC>& input, int32_
 
 template <typename SRC_DT, typename DEST_DT, typename BC_DT, typename BT_SRC = detail::BaseType<SRC_DT>,
           typename BT_DEST = detail::BaseType<DEST_DT>>
-void TestCorrectness(int batchSize, int width, int height, ImageFormat inFormat, ImageFormat outFormat,
-                     BC_DT brightness, BC_DT contrast, BC_DT brightnessShift, BC_DT contrastCenter, eDataType bc_edt,
-                     eDeviceType device) {
+void TestCorrectnessBroadcast(int batchSize, int width, int height, ImageFormat inFormat, ImageFormat outFormat,
+                              BC_DT brightness, BC_DT contrast, BC_DT brightnessShift, BC_DT contrastCenter,
+                              eDataType bc_edt, eDeviceType device) {
     // Create input and output tensor based on test parameters
     Tensor input(batchSize, {width, height}, inFormat, device);
     Tensor output(batchSize, {width, height}, outFormat, device);
@@ -100,22 +100,28 @@ void TestCorrectness(int batchSize, int width, int height, ImageFormat inFormat,
     CopyVectorIntoTensor(input, inputData);
 
     // Create brightness/contrast tensors
-    TensorShape shape(TensorLayout(eTensorLayout::TENSOR_LAYOUT_N), {batchSize});
+    TensorShape shape(TensorLayout(eTensorLayout::TENSOR_LAYOUT_N), {1});
     Tensor brightnessTensor(shape, DataType(bc_edt), device);
     Tensor contrastTensor(shape, DataType(bc_edt), device);
     Tensor brightnessShiftTensor(shape, DataType(bc_edt), device);
     Tensor contrastCenterTensor(shape, DataType(bc_edt), device);
 
-    // Create BC vectors filled with passed in values, use to fill in tensors
+    // Create single-element vectors to fill broadcast tensors
+    std::vector<BC_DT> broadcastBrightness = {brightness};
+    std::vector<BC_DT> broadcastContrast = {contrast};
+    std::vector<BC_DT> broadcastBrightnessShift = {brightnessShift};
+    std::vector<BC_DT> broadcastContrastCenter = {contrastCenter};
+
+    CopyVectorIntoTensor(brightnessTensor, broadcastBrightness);
+    CopyVectorIntoTensor(contrastTensor, broadcastContrast);
+    CopyVectorIntoTensor(brightnessShiftTensor, broadcastBrightnessShift);
+    CopyVectorIntoTensor(contrastCenterTensor, broadcastContrastCenter);
+
+    // Create BC vectors filled with passed in values for golden solution
     std::vector<BC_DT> brightnessData(batchSize, brightness);
     std::vector<BC_DT> contrastData(batchSize, contrast);
     std::vector<BC_DT> brightnessShiftData(batchSize, brightnessShift);
     std::vector<BC_DT> contrastCenterData(batchSize, contrastCenter);
-
-    CopyVectorIntoTensor(brightnessTensor, brightnessData);
-    CopyVectorIntoTensor(contrastTensor, contrastData);
-    CopyVectorIntoTensor(brightnessShiftTensor, brightnessShiftData);
-    CopyVectorIntoTensor(contrastCenterTensor, contrastCenterData);
 
     // Calculate golden output reference
     std::vector<BT_DEST> ref = GoldenBrightnessContrast<SRC_DT, DEST_DT, BC_DT>(
@@ -356,69 +362,69 @@ int main(int argc, char** argv) {
 
     // CPU correctness tests
     // 1 Channel
-    TEST_CASE((TestCorrectness<uchar1, uchar1, float>(1, 360, 480, FMT_U8, FMT_U8, 1.5f, 1.2f, 0.1f, 100.0f,
-                                                      eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<ushort1, ushort1, float>(1, 360, 480, FMT_U16, FMT_U16, 1.5f, 1.2f, 0.1f, 30000.0f,
-                                                        eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<short1, short1, float>(1, 360, 480, FMT_S16, FMT_S16, 1.5f, 1.2f, 0.1f, 10000.0f,
-                                                      eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<int1, int1, double>(1, 360, 480, FMT_S32, FMT_S32, 1.5, 1.2, 0.1, 1000000000.0,
-                                                   eDataType::DATA_TYPE_F64, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<float1, float1, float>(1, 360, 480, FMT_F32, FMT_F32, 1.5f, 1.2f, 0.1f, 0.6f,
-                                                      eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectnessBroadcast<uchar1, uchar1, float>(3, 360, 480, FMT_U8, FMT_U8, 1.5f, 1.2f, 0.1f, 100.0f,
+                                                               eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectnessBroadcast<ushort1, ushort1, float>(
+        3, 360, 480, FMT_U16, FMT_U16, 1.5f, 1.2f, 0.1f, 30000.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectnessBroadcast<short1, short1, float>(3, 360, 480, FMT_S16, FMT_S16, 1.5f, 1.2f, 0.1f,
+                                                               10000.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectnessBroadcast<int1, int1, double>(3, 360, 480, FMT_S32, FMT_S32, 1.5, 1.2, 0.1, 1000000000.0,
+                                                            eDataType::DATA_TYPE_F64, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectnessBroadcast<float1, float1, float>(3, 360, 480, FMT_F32, FMT_F32, 1.5f, 1.2f, 0.1f, 0.6f,
+                                                               eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
 
-    TEST_CASE((TestCorrectness<uchar1, ushort1, float>(1, 480, 360, FMT_U8, FMT_U16, 1.5f, 1.2f, 0.1f, 100.0f,
-                                                       eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<ushort1, uchar1, float>(1, 480, 360, FMT_U16, FMT_U8, 1.5f, 1.2f, 0.1f, 30000.0f,
-                                                       eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<short1, uchar1, float>(1, 480, 360, FMT_S16, FMT_U8, 1.5f, 1.2f, 0.1f, 10000.0f,
-                                                      eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<ushort1, short1, float>(1, 480, 360, FMT_U16, FMT_S16, 1.5f, 1.2f, 0.1f, 30000.0f,
-                                                       eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<short1, ushort1, float>(1, 480, 360, FMT_S16, FMT_U16, 1.5f, 1.2f, 0.1f, 10000.0f,
-                                                       eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<uchar1, int1, double>(1, 480, 360, FMT_U8, FMT_S32, 1.5, 1.2, 0.1, 100.0,
-                                                     eDataType::DATA_TYPE_F64, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<int1, uchar1, double>(1, 480, 360, FMT_S32, FMT_U8, 1.5, 1.2, 0.1, 1000000000.0,
-                                                     eDataType::DATA_TYPE_F64, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<uchar1, float1, float>(1, 480, 360, FMT_U8, FMT_F32, 1.5f, 1.2f, 0.1f, 100.0f,
-                                                      eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<float1, uchar1, float>(1, 480, 360, FMT_F32, FMT_U8, 1.5f, 1.2f, 0.1f, 0.6f,
-                                                      eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectnessBroadcast<uchar1, ushort1, float>(1, 480, 360, FMT_U8, FMT_U16, 1.5f, 1.2f, 0.1f, 100.0f,
+                                                                eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectnessBroadcast<ushort1, uchar1, float>(1, 480, 360, FMT_U16, FMT_U8, 1.5f, 1.2f, 0.1f,
+                                                                30000.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectnessBroadcast<short1, uchar1, float>(1, 480, 360, FMT_S16, FMT_U8, 1.5f, 1.2f, 0.1f, 10000.0f,
+                                                               eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectnessBroadcast<ushort1, short1, float>(1, 480, 360, FMT_U16, FMT_S16, 1.5f, 1.2f, 0.1f,
+                                                                30000.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectnessBroadcast<short1, ushort1, float>(1, 480, 360, FMT_S16, FMT_U16, 1.5f, 1.2f, 0.1f,
+                                                                10000.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectnessBroadcast<uchar1, int1, double>(1, 480, 360, FMT_U8, FMT_S32, 1.5, 1.2, 0.1, 100.0,
+                                                              eDataType::DATA_TYPE_F64, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectnessBroadcast<int1, uchar1, double>(1, 480, 360, FMT_S32, FMT_U8, 1.5, 1.2, 0.1, 1000000000.0,
+                                                              eDataType::DATA_TYPE_F64, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectnessBroadcast<uchar1, float1, float>(1, 480, 360, FMT_U8, FMT_F32, 1.5f, 1.2f, 0.1f, 100.0f,
+                                                               eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectnessBroadcast<float1, uchar1, float>(1, 480, 360, FMT_F32, FMT_U8, 1.5f, 1.2f, 0.1f, 0.6f,
+                                                               eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
 
     TEST_CASE((TestCorrectnessDefaultsAndPer<float1, float1, float>(3, 480, 360, FMT_F32, FMT_F32, eDeviceType::CPU)));
     TEST_CASE((TestCorrectnessDefaultsAndPer<uchar1, int1, double>(3, 480, 360, FMT_U8, FMT_S32, eDeviceType::CPU)));
 
     // 3 Channels
-    TEST_CASE((TestCorrectness<uchar3, uchar3, float>(1, 640, 480, FMT_RGB8, FMT_RGB8, 1.5f, 1.2f, 0.1f, 100.0f,
-                                                      eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<ushort3, ushort3, float>(1, 640, 480, FMT_RGB16, FMT_RGB16, 1.5f, 1.2f, 0.1f, 30000.0f,
-                                                        eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<short3, short3, float>(1, 640, 480, FMT_RGBs16, FMT_RGBs16, 1.5f, 1.2f, 0.1f, 10000.0f,
-                                                      eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<int3, int3, double>(1, 640, 480, FMT_RGBs32, FMT_RGBs32, 1.5, 1.2, 0.1, 1000000000.0,
-                                                   eDataType::DATA_TYPE_F64, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<float3, float3, float>(1, 640, 480, FMT_RGBf32, FMT_RGBf32, 1.5f, 1.2f, 0.1f, 0.6f,
-                                                      eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectnessBroadcast<uchar3, uchar3, float>(1, 640, 480, FMT_RGB8, FMT_RGB8, 1.5f, 1.2f, 0.1f,
+                                                               100.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectnessBroadcast<ushort3, ushort3, float>(
+        1, 640, 480, FMT_RGB16, FMT_RGB16, 1.5f, 1.2f, 0.1f, 30000.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectnessBroadcast<short3, short3, float>(1, 640, 480, FMT_RGBs16, FMT_RGBs16, 1.5f, 1.2f, 0.1f,
+                                                               10000.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectnessBroadcast<int3, int3, double>(1, 640, 480, FMT_RGBs32, FMT_RGBs32, 1.5, 1.2, 0.1,
+                                                            1000000000.0, eDataType::DATA_TYPE_F64, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectnessBroadcast<float3, float3, float>(1, 640, 480, FMT_RGBf32, FMT_RGBf32, 1.5f, 1.2f, 0.1f,
+                                                               0.6f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
 
-    TEST_CASE((TestCorrectness<uchar3, ushort3, float>(1, 480, 640, FMT_RGB8, FMT_RGB16, 1.5f, 1.2f, 0.1f, 100.0f,
-                                                       eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<ushort3, uchar3, float>(1, 480, 640, FMT_RGB16, FMT_RGB8, 1.5f, 1.2f, 0.1f, 30000.0f,
-                                                       eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<short3, uchar3, float>(1, 480, 640, FMT_RGBs16, FMT_RGB8, 1.5f, 1.2f, 0.1f, 10000.0f,
-                                                      eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<ushort3, short3, float>(1, 480, 640, FMT_RGB16, FMT_RGBs16, 1.5f, 1.2f, 0.1f, 30000.0f,
-                                                       eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<short3, ushort3, float>(1, 480, 640, FMT_RGBs16, FMT_RGB16, 1.5f, 1.2f, 0.1f, 10000.0f,
-                                                       eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<uchar3, int3, double>(1, 480, 640, FMT_RGB8, FMT_RGBs32, 1.5, 1.2, 0.1, 100.0,
-                                                     eDataType::DATA_TYPE_F64, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<int3, uchar3, double>(1, 480, 640, FMT_RGBs32, FMT_RGB8, 1.5, 1.2, 0.1, 1000000000.0,
-                                                     eDataType::DATA_TYPE_F64, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<uchar3, float3, float>(1, 480, 640, FMT_RGB8, FMT_RGBf32, 1.5f, 1.2f, 0.1f, 100.0f,
-                                                      eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<float3, uchar3, float>(1, 480, 640, FMT_RGBf32, FMT_RGB8, 1.5f, 1.2f, 0.1f, 0.6f,
-                                                      eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectnessBroadcast<uchar3, ushort3, float>(3, 480, 640, FMT_RGB8, FMT_RGB16, 1.5f, 1.2f, 0.1f,
+                                                                100.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectnessBroadcast<ushort3, uchar3, float>(3, 480, 640, FMT_RGB16, FMT_RGB8, 1.5f, 1.2f, 0.1f,
+                                                                30000.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectnessBroadcast<short3, uchar3, float>(3, 480, 640, FMT_RGBs16, FMT_RGB8, 1.5f, 1.2f, 0.1f,
+                                                               10000.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectnessBroadcast<ushort3, short3, float>(3, 480, 640, FMT_RGB16, FMT_RGBs16, 1.5f, 1.2f, 0.1f,
+                                                                30000.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectnessBroadcast<short3, ushort3, float>(3, 480, 640, FMT_RGBs16, FMT_RGB16, 1.5f, 1.2f, 0.1f,
+                                                                10000.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectnessBroadcast<uchar3, int3, double>(3, 480, 640, FMT_RGB8, FMT_RGBs32, 1.5, 1.2, 0.1, 100.0,
+                                                              eDataType::DATA_TYPE_F64, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectnessBroadcast<int3, uchar3, double>(
+        3, 480, 640, FMT_RGBs32, FMT_RGB8, 1.5, 1.2, 0.1, 1000000000.0, eDataType::DATA_TYPE_F64, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectnessBroadcast<uchar3, float3, float>(3, 480, 640, FMT_RGB8, FMT_RGBf32, 1.5f, 1.2f, 0.1f,
+                                                               100.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectnessBroadcast<float3, uchar3, float>(3, 480, 640, FMT_RGBf32, FMT_RGB8, 1.5f, 1.2f, 0.1f,
+                                                               0.6f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
 
     TEST_CASE(
         (TestCorrectnessDefaultsAndPer<float3, float3, float>(3, 480, 640, FMT_RGBf32, FMT_RGBf32, eDeviceType::CPU)));
@@ -426,35 +432,35 @@ int main(int argc, char** argv) {
         (TestCorrectnessDefaultsAndPer<uchar3, int3, double>(3, 480, 640, FMT_RGB8, FMT_RGBs32, eDeviceType::CPU)));
 
     // 4 Channels
-    TEST_CASE((TestCorrectness<uchar4, uchar4, float>(1, 360, 480, FMT_RGBA8, FMT_RGBA8, 1.5f, 1.2f, 0.1f, 100.0f,
-                                                      eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<ushort4, ushort4, float>(1, 360, 480, FMT_RGBA16, FMT_RGBA16, 1.5f, 1.2f, 0.1f, 30000.0f,
-                                                        eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<short4, short4, float>(1, 360, 480, FMT_RGBAs16, FMT_RGBAs16, 1.5f, 1.2f, 0.1f, 10000.0f,
-                                                      eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<int4, int4, double>(1, 360, 480, FMT_RGBAs32, FMT_RGBAs32, 1.5, 1.2, 0.1, 1000000000.0,
-                                                   eDataType::DATA_TYPE_F64, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<float4, float4, float>(1, 360, 480, FMT_RGBAf32, FMT_RGBAf32, 1.5f, 1.2f, 0.1f, 0.6f,
-                                                      eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectnessBroadcast<uchar4, uchar4, float>(1, 360, 480, FMT_RGBA8, FMT_RGBA8, 1.5f, 1.2f, 0.1f,
+                                                               100.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectnessBroadcast<ushort4, ushort4, float>(
+        1, 360, 480, FMT_RGBA16, FMT_RGBA16, 1.5f, 1.2f, 0.1f, 30000.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectnessBroadcast<short4, short4, float>(1, 360, 480, FMT_RGBAs16, FMT_RGBAs16, 1.5f, 1.2f, 0.1f,
+                                                               10000.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectnessBroadcast<int4, int4, double>(1, 360, 480, FMT_RGBAs32, FMT_RGBAs32, 1.5, 1.2, 0.1,
+                                                            1000000000.0, eDataType::DATA_TYPE_F64, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectnessBroadcast<float4, float4, float>(1, 360, 480, FMT_RGBAf32, FMT_RGBAf32, 1.5f, 1.2f, 0.1f,
+                                                               0.6f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
 
-    TEST_CASE((TestCorrectness<uchar4, ushort4, float>(1, 480, 360, FMT_RGBA8, FMT_RGBA16, 1.5f, 1.2f, 0.1f, 100.0f,
-                                                       eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<ushort4, uchar4, float>(1, 480, 360, FMT_RGBA16, FMT_RGBA8, 1.5f, 1.2f, 0.1f, 30000.0f,
-                                                       eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<short4, uchar4, float>(1, 480, 360, FMT_RGBAs16, FMT_RGBA8, 1.5f, 1.2f, 0.1f, 10000.0f,
-                                                      eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<ushort4, short4, float>(1, 480, 360, FMT_RGBA16, FMT_RGBAs16, 1.5f, 1.2f, 0.1f, 30000.0f,
-                                                       eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<short4, ushort4, float>(1, 480, 360, FMT_RGBAs16, FMT_RGBA16, 1.5f, 1.2f, 0.1f, 10000.0f,
-                                                       eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<uchar4, int4, double>(1, 480, 360, FMT_RGBA8, FMT_RGBAs32, 1.5, 1.2, 0.1, 100.0,
-                                                     eDataType::DATA_TYPE_F64, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<int4, uchar4, double>(1, 480, 360, FMT_RGBAs32, FMT_RGBA8, 1.5, 1.2, 0.1, 1000000000.0,
-                                                     eDataType::DATA_TYPE_F64, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<uchar4, float4, float>(1, 480, 360, FMT_RGBA8, FMT_RGBAf32, 1.5f, 1.2f, 0.1f, 100.0f,
-                                                      eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
-    TEST_CASE((TestCorrectness<float4, uchar4, float>(1, 480, 360, FMT_RGBAf32, FMT_RGBA8, 1.5f, 1.2f, 0.1f, 0.6f,
-                                                      eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectnessBroadcast<uchar4, ushort4, float>(1, 480, 360, FMT_RGBA8, FMT_RGBA16, 1.5f, 1.2f, 0.1f,
+                                                                100.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectnessBroadcast<ushort4, uchar4, float>(1, 480, 360, FMT_RGBA16, FMT_RGBA8, 1.5f, 1.2f, 0.1f,
+                                                                30000.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectnessBroadcast<short4, uchar4, float>(1, 480, 360, FMT_RGBAs16, FMT_RGBA8, 1.5f, 1.2f, 0.1f,
+                                                               10000.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectnessBroadcast<ushort4, short4, float>(1, 480, 360, FMT_RGBA16, FMT_RGBAs16, 1.5f, 1.2f, 0.1f,
+                                                                30000.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectnessBroadcast<short4, ushort4, float>(1, 480, 360, FMT_RGBAs16, FMT_RGBA16, 1.5f, 1.2f, 0.1f,
+                                                                10000.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectnessBroadcast<uchar4, int4, double>(1, 480, 360, FMT_RGBA8, FMT_RGBAs32, 1.5, 1.2, 0.1, 100.0,
+                                                              eDataType::DATA_TYPE_F64, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectnessBroadcast<int4, uchar4, double>(
+        1, 480, 360, FMT_RGBAs32, FMT_RGBA8, 1.5, 1.2, 0.1, 1000000000.0, eDataType::DATA_TYPE_F64, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectnessBroadcast<uchar4, float4, float>(1, 480, 360, FMT_RGBA8, FMT_RGBAf32, 1.5f, 1.2f, 0.1f,
+                                                               100.0f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
+    TEST_CASE((TestCorrectnessBroadcast<float4, uchar4, float>(1, 480, 360, FMT_RGBAf32, FMT_RGBA8, 1.5f, 1.2f, 0.1f,
+                                                               0.6f, eDataType::DATA_TYPE_F32, eDeviceType::CPU)));
 
     TEST_CASE((
         TestCorrectnessDefaultsAndPer<float4, float4, float>(3, 480, 360, FMT_RGBAf32, FMT_RGBAf32, eDeviceType::CPU)));
@@ -463,69 +469,69 @@ int main(int argc, char** argv) {
 
     // GPU Correctness Tests
     // 1 Channel
-    TEST_CASE((TestCorrectness<uchar1, uchar1, float>(1, 360, 480, FMT_U8, FMT_U8, 1.5f, 1.2f, 0.1f, 100.0f,
-                                                      eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<ushort1, ushort1, float>(1, 360, 480, FMT_U16, FMT_U16, 1.5f, 1.2f, 0.1f, 30000.0f,
-                                                        eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<short1, short1, float>(1, 360, 480, FMT_S16, FMT_S16, 1.5f, 1.2f, 0.1f, 10000.0f,
-                                                      eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<int1, int1, double>(1, 360, 480, FMT_S32, FMT_S32, 1.5, 1.2, 0.1, 1000000000.0,
-                                                   eDataType::DATA_TYPE_F64, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<float1, float1, float>(1, 360, 480, FMT_F32, FMT_F32, 1.5f, 1.2f, 0.1f, 0.6f,
-                                                      eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectnessBroadcast<uchar1, uchar1, float>(3, 360, 480, FMT_U8, FMT_U8, 1.5f, 1.2f, 0.1f, 100.0f,
+                                                               eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectnessBroadcast<ushort1, ushort1, float>(
+        3, 360, 480, FMT_U16, FMT_U16, 1.5f, 1.2f, 0.1f, 30000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectnessBroadcast<short1, short1, float>(3, 360, 480, FMT_S16, FMT_S16, 1.5f, 1.2f, 0.1f,
+                                                               10000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectnessBroadcast<int1, int1, double>(3, 360, 480, FMT_S32, FMT_S32, 1.5, 1.2, 0.1, 1000000000.0,
+                                                            eDataType::DATA_TYPE_F64, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectnessBroadcast<float1, float1, float>(3, 360, 480, FMT_F32, FMT_F32, 1.5f, 1.2f, 0.1f, 0.6f,
+                                                               eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
 
-    TEST_CASE((TestCorrectness<uchar1, ushort1, float>(1, 480, 360, FMT_U8, FMT_U16, 1.5f, 1.2f, 0.1f, 100.0f,
-                                                       eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<ushort1, uchar1, float>(1, 480, 360, FMT_U16, FMT_U8, 1.5f, 1.2f, 0.1f, 30000.0f,
-                                                       eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<short1, uchar1, float>(1, 480, 360, FMT_S16, FMT_U8, 1.5f, 1.2f, 0.1f, 10000.0f,
-                                                      eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<ushort1, short1, float>(1, 480, 360, FMT_U16, FMT_S16, 1.5f, 1.2f, 0.1f, 30000.0f,
-                                                       eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<short1, ushort1, float>(1, 480, 360, FMT_S16, FMT_U16, 1.5f, 1.2f, 0.1f, 10000.0f,
-                                                       eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<uchar1, int1, double>(1, 480, 360, FMT_U8, FMT_S32, 1.5, 1.2, 0.1, 100.0,
-                                                     eDataType::DATA_TYPE_F64, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<int1, uchar1, double>(1, 480, 360, FMT_S32, FMT_U8, 1.5, 1.2, 0.1, 1000000000.0,
-                                                     eDataType::DATA_TYPE_F64, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<uchar1, float1, float>(1, 480, 360, FMT_U8, FMT_F32, 1.5f, 1.2f, 0.1f, 100.0f,
-                                                      eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<float1, uchar1, float>(1, 480, 360, FMT_F32, FMT_U8, 1.5f, 1.2f, 0.1f, 0.6f,
-                                                      eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectnessBroadcast<uchar1, ushort1, float>(1, 480, 360, FMT_U8, FMT_U16, 1.5f, 1.2f, 0.1f, 100.0f,
+                                                                eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectnessBroadcast<ushort1, uchar1, float>(1, 480, 360, FMT_U16, FMT_U8, 1.5f, 1.2f, 0.1f,
+                                                                30000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectnessBroadcast<short1, uchar1, float>(1, 480, 360, FMT_S16, FMT_U8, 1.5f, 1.2f, 0.1f, 10000.0f,
+                                                               eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectnessBroadcast<ushort1, short1, float>(1, 480, 360, FMT_U16, FMT_S16, 1.5f, 1.2f, 0.1f,
+                                                                30000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectnessBroadcast<short1, ushort1, float>(1, 480, 360, FMT_S16, FMT_U16, 1.5f, 1.2f, 0.1f,
+                                                                10000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectnessBroadcast<uchar1, int1, double>(1, 480, 360, FMT_U8, FMT_S32, 1.5, 1.2, 0.1, 100.0,
+                                                              eDataType::DATA_TYPE_F64, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectnessBroadcast<int1, uchar1, double>(1, 480, 360, FMT_S32, FMT_U8, 1.5, 1.2, 0.1, 1000000000.0,
+                                                              eDataType::DATA_TYPE_F64, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectnessBroadcast<uchar1, float1, float>(1, 480, 360, FMT_U8, FMT_F32, 1.5f, 1.2f, 0.1f, 100.0f,
+                                                               eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectnessBroadcast<float1, uchar1, float>(1, 480, 360, FMT_F32, FMT_U8, 1.5f, 1.2f, 0.1f, 0.6f,
+                                                               eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
 
     TEST_CASE((TestCorrectnessDefaultsAndPer<float1, float1, float>(3, 480, 360, FMT_F32, FMT_F32, eDeviceType::GPU)));
     TEST_CASE((TestCorrectnessDefaultsAndPer<uchar1, int1, double>(3, 480, 360, FMT_U8, FMT_S32, eDeviceType::GPU)));
 
     // 3 Channels
-    TEST_CASE((TestCorrectness<uchar3, uchar3, float>(1, 360, 480, FMT_RGB8, FMT_RGB8, 1.5f, 1.2f, 0.1f, 100.0f,
-                                                      eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<ushort3, ushort3, float>(1, 360, 480, FMT_RGB16, FMT_RGB16, 1.5f, 1.2f, 0.1f, 30000.0f,
-                                                        eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<short3, short3, float>(1, 360, 480, FMT_RGBs16, FMT_RGBs16, 1.5f, 1.2f, 0.1f, 10000.0f,
-                                                      eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<int3, int3, double>(1, 360, 480, FMT_RGBs32, FMT_RGBs32, 1.5, 1.2, 0.1, 1000000000.0,
-                                                   eDataType::DATA_TYPE_F64, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<float3, float3, float>(1, 360, 480, FMT_RGBf32, FMT_RGBf32, 1.5f, 1.2f, 0.1f, 0.6f,
-                                                      eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectnessBroadcast<uchar3, uchar3, float>(1, 360, 480, FMT_RGB8, FMT_RGB8, 1.5f, 1.2f, 0.1f,
+                                                               100.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectnessBroadcast<ushort3, ushort3, float>(
+        1, 360, 480, FMT_RGB16, FMT_RGB16, 1.5f, 1.2f, 0.1f, 30000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectnessBroadcast<short3, short3, float>(1, 360, 480, FMT_RGBs16, FMT_RGBs16, 1.5f, 1.2f, 0.1f,
+                                                               10000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectnessBroadcast<int3, int3, double>(1, 360, 480, FMT_RGBs32, FMT_RGBs32, 1.5, 1.2, 0.1,
+                                                            1000000000.0, eDataType::DATA_TYPE_F64, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectnessBroadcast<float3, float3, float>(1, 360, 480, FMT_RGBf32, FMT_RGBf32, 1.5f, 1.2f, 0.1f,
+                                                               0.6f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
 
-    TEST_CASE((TestCorrectness<uchar3, ushort3, float>(1, 480, 360, FMT_RGB8, FMT_RGB16, 1.5f, 1.2f, 0.1f, 100.0f,
-                                                       eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<ushort3, uchar3, float>(1, 480, 360, FMT_RGB16, FMT_RGB8, 1.5f, 1.2f, 0.1f, 30000.0f,
-                                                       eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<short3, uchar3, float>(1, 480, 360, FMT_RGBs16, FMT_RGB8, 1.5f, 1.2f, 0.1f, 10000.0f,
-                                                      eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<ushort3, short3, float>(1, 480, 360, FMT_RGB16, FMT_RGBs16, 1.5f, 1.2f, 0.1f, 30000.0f,
-                                                       eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<short3, ushort3, float>(1, 480, 360, FMT_RGBs16, FMT_RGB16, 1.5f, 1.2f, 0.1f, 10000.0f,
-                                                       eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<uchar3, int3, double>(1, 480, 360, FMT_RGB8, FMT_RGBs32, 1.5, 1.2, 0.1, 100.0,
-                                                     eDataType::DATA_TYPE_F64, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<int3, uchar3, double>(1, 480, 360, FMT_RGBs32, FMT_RGB8, 1.5, 1.2, 0.1, 1000000000.0,
-                                                     eDataType::DATA_TYPE_F64, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<uchar3, float3, float>(1, 480, 360, FMT_RGB8, FMT_RGBf32, 1.5f, 1.2f, 0.1f, 100.0f,
-                                                      eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<float3, uchar3, float>(1, 480, 360, FMT_RGBf32, FMT_RGB8, 1.5f, 1.2f, 0.1f, 0.6f,
-                                                      eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectnessBroadcast<uchar3, ushort3, float>(3, 480, 360, FMT_RGB8, FMT_RGB16, 1.5f, 1.2f, 0.1f,
+                                                                100.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectnessBroadcast<ushort3, uchar3, float>(3, 480, 360, FMT_RGB16, FMT_RGB8, 1.5f, 1.2f, 0.1f,
+                                                                30000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectnessBroadcast<short3, uchar3, float>(3, 480, 360, FMT_RGBs16, FMT_RGB8, 1.5f, 1.2f, 0.1f,
+                                                               10000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectnessBroadcast<ushort3, short3, float>(3, 480, 360, FMT_RGB16, FMT_RGBs16, 1.5f, 1.2f, 0.1f,
+                                                                30000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectnessBroadcast<short3, ushort3, float>(3, 480, 360, FMT_RGBs16, FMT_RGB16, 1.5f, 1.2f, 0.1f,
+                                                                10000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectnessBroadcast<uchar3, int3, double>(3, 480, 360, FMT_RGB8, FMT_RGBs32, 1.5, 1.2, 0.1, 100.0,
+                                                              eDataType::DATA_TYPE_F64, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectnessBroadcast<int3, uchar3, double>(
+        3, 480, 360, FMT_RGBs32, FMT_RGB8, 1.5, 1.2, 0.1, 1000000000.0, eDataType::DATA_TYPE_F64, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectnessBroadcast<uchar3, float3, float>(3, 480, 360, FMT_RGB8, FMT_RGBf32, 1.5f, 1.2f, 0.1f,
+                                                               100.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectnessBroadcast<float3, uchar3, float>(3, 480, 360, FMT_RGBf32, FMT_RGB8, 1.5f, 1.2f, 0.1f,
+                                                               0.6f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
 
     TEST_CASE(
         (TestCorrectnessDefaultsAndPer<float3, float3, float>(3, 480, 360, FMT_RGBf32, FMT_RGBf32, eDeviceType::GPU)));
@@ -533,35 +539,40 @@ int main(int argc, char** argv) {
         (TestCorrectnessDefaultsAndPer<uchar3, int3, double>(3, 480, 360, FMT_RGB8, FMT_RGBs32, eDeviceType::GPU)));
 
     // 4 Channels
-    TEST_CASE((TestCorrectness<uchar4, uchar4, float>(1, 1920, 1080, FMT_RGBA8, FMT_RGBA8, 1.5f, 1.2f, 0.1f, 100.0f,
-                                                      eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<ushort4, ushort4, float>(1, 1920, 1080, FMT_RGBA16, FMT_RGBA16, 1.5f, 1.2f, 0.1f,
-                                                        30000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<short4, short4, float>(1, 1920, 1080, FMT_RGBAs16, FMT_RGBAs16, 1.5f, 1.2f, 0.1f,
-                                                      10000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<int4, int4, double>(1, 1920, 1080, FMT_RGBAs32, FMT_RGBAs32, 1.5, 1.2, 0.1, 1000000000.0,
-                                                   eDataType::DATA_TYPE_F64, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<float4, float4, float>(1, 1920, 1080, FMT_RGBAf32, FMT_RGBAf32, 1.5f, 1.2f, 0.1f, 0.6f,
-                                                      eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectnessBroadcast<uchar4, uchar4, float>(1, 1920, 1080, FMT_RGBA8, FMT_RGBA8, 1.5f, 1.2f, 0.1f,
+                                                               100.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE(
+        (TestCorrectnessBroadcast<ushort4, ushort4, float>(1, 1920, 1080, FMT_RGBA16, FMT_RGBA16, 1.5f, 1.2f, 0.1f,
+                                                           30000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE(
+        (TestCorrectnessBroadcast<short4, short4, float>(1, 1920, 1080, FMT_RGBAs16, FMT_RGBAs16, 1.5f, 1.2f, 0.1f,
+                                                         10000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectnessBroadcast<int4, int4, double>(1, 1920, 1080, FMT_RGBAs32, FMT_RGBAs32, 1.5, 1.2, 0.1,
+                                                            1000000000.0, eDataType::DATA_TYPE_F64, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectnessBroadcast<float4, float4, float>(
+        1, 1920, 1080, FMT_RGBAf32, FMT_RGBAf32, 1.5f, 1.2f, 0.1f, 0.6f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
 
-    TEST_CASE((TestCorrectness<uchar4, ushort4, float>(1, 1080, 1920, FMT_RGBA8, FMT_RGBA16, 1.5f, 1.2f, 0.1f, 100.0f,
-                                                       eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<ushort4, uchar4, float>(1, 1080, 1920, FMT_RGBA16, FMT_RGBA8, 1.5f, 1.2f, 0.1f, 30000.0f,
-                                                       eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<short4, uchar4, float>(1, 1080, 1920, FMT_RGBAs16, FMT_RGBA8, 1.5f, 1.2f, 0.1f, 10000.0f,
-                                                      eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<ushort4, short4, float>(1, 1080, 1920, FMT_RGBA16, FMT_RGBAs16, 1.5f, 1.2f, 0.1f,
-                                                       30000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<short4, ushort4, float>(1, 1080, 1920, FMT_RGBAs16, FMT_RGBA16, 1.5f, 1.2f, 0.1f,
-                                                       10000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<uchar4, int4, double>(1, 1080, 1920, FMT_RGBA8, FMT_RGBAs32, 1.5, 1.2, 0.1, 100.0,
-                                                     eDataType::DATA_TYPE_F64, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<int4, uchar4, double>(1, 1080, 1920, FMT_RGBAs32, FMT_RGBA8, 1.5, 1.2, 0.1, 1000000000.0,
-                                                     eDataType::DATA_TYPE_F64, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<uchar4, float4, float>(1, 1080, 1920, FMT_RGBA8, FMT_RGBAf32, 1.5f, 1.2f, 0.1f, 100.0f,
-                                                      eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
-    TEST_CASE((TestCorrectness<float4, uchar4, float>(1, 1080, 1920, FMT_RGBAf32, FMT_RGBA8, 1.5f, 1.2f, 0.1f, 0.6f,
-                                                      eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectnessBroadcast<uchar4, ushort4, float>(1, 1080, 1920, FMT_RGBA8, FMT_RGBA16, 1.5f, 1.2f, 0.1f,
+                                                                100.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectnessBroadcast<ushort4, uchar4, float>(1, 1080, 1920, FMT_RGBA16, FMT_RGBA8, 1.5f, 1.2f, 0.1f,
+                                                                30000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectnessBroadcast<short4, uchar4, float>(1, 1080, 1920, FMT_RGBAs16, FMT_RGBA8, 1.5f, 1.2f, 0.1f,
+                                                               10000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE(
+        (TestCorrectnessBroadcast<ushort4, short4, float>(1, 1080, 1920, FMT_RGBA16, FMT_RGBAs16, 1.5f, 1.2f, 0.1f,
+                                                          30000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE(
+        (TestCorrectnessBroadcast<short4, ushort4, float>(1, 1080, 1920, FMT_RGBAs16, FMT_RGBA16, 1.5f, 1.2f, 0.1f,
+                                                          10000.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectnessBroadcast<uchar4, int4, double>(1, 1080, 1920, FMT_RGBA8, FMT_RGBAs32, 1.5, 1.2, 0.1,
+                                                              100.0, eDataType::DATA_TYPE_F64, eDeviceType::GPU)));
+    TEST_CASE(
+        (TestCorrectnessBroadcast<int4, uchar4, double>(1, 1080, 1920, FMT_RGBAs32, FMT_RGBA8, 1.5, 1.2, 0.1,
+                                                        1000000000.0, eDataType::DATA_TYPE_F64, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectnessBroadcast<uchar4, float4, float>(1, 1080, 1920, FMT_RGBA8, FMT_RGBAf32, 1.5f, 1.2f, 0.1f,
+                                                               100.0f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
+    TEST_CASE((TestCorrectnessBroadcast<float4, uchar4, float>(1, 1080, 1920, FMT_RGBAf32, FMT_RGBA8, 1.5f, 1.2f, 0.1f,
+                                                               0.6f, eDataType::DATA_TYPE_F32, eDeviceType::GPU)));
 
     TEST_CASE((TestCorrectnessDefaultsAndPer<float4, float4, float>(3, 3840, 2160, FMT_RGBAf32, FMT_RGBAf32,
                                                                     eDeviceType::GPU)));

--- a/tests/roccv/python/test_op_brightness_contrast.py
+++ b/tests/roccv/python/test_op_brightness_contrast.py
@@ -28,34 +28,33 @@ from test_helpers import generate_tensor, generate_tensor_generic, compare_tenso
 
 @pytest.mark.parametrize("device", [rocpycv.eDeviceType.GPU, rocpycv.eDeviceType.CPU])
 @pytest.mark.parametrize("dtype", [rocpycv.eDataType.U8, rocpycv.eDataType.U16, rocpycv.eDataType.S16, rocpycv.eDataType.S32, rocpycv.eDataType.F32])
-@pytest.mark.parametrize("out_dtype", [rocpycv.eDataType.U8, rocpycv.eDataType.U16, rocpycv.eDataType.S16, rocpycv.eDataType.S32, rocpycv.eDataType.F32])
 @pytest.mark.parametrize("channels", [1, 3, 4])
 @pytest.mark.parametrize("samples,height,width", [
     (1, 45, 23),
     (3, 67, 85),
     (7, 25, 95)
 ])
-def test_op_brightness_contrast(samples, height, width, channels, device, dtype, out_dtype):
+def test_op_brightness_contrast(samples, height, width, channels, device, dtype):
     input = generate_tensor(samples, width, height, channels, dtype, device)
     stream = rocpycv.Stream()
 
     # test with random brightness contrast params
-    bc_dtype = rocpycv.eDataType.F64 if (dtype == rocpycv.eDataType.S32 or out_dtype == rocpycv.eDataType.S32) else rocpycv.eDataType.F32
+    bc_dtype = rocpycv.eDataType.F64 if (dtype == rocpycv.eDataType.S32) else rocpycv.eDataType.F32
     brightness = generate_tensor_generic([1], rocpycv.eTensorLayout.N, bc_dtype, device)
     contrast = generate_tensor_generic([1], rocpycv.eTensorLayout.N, bc_dtype, device)
     brightness_shift = generate_tensor_generic([1], rocpycv.eTensorLayout.N, bc_dtype, device)
     contrast_center = generate_tensor_generic([1], rocpycv.eTensorLayout.N, bc_dtype, device)
 
-    output_golden = rocpycv.Tensor([samples, height, width, channels], rocpycv.eTensorLayout.NHWC, out_dtype, device)
+    output_golden = rocpycv.Tensor([samples, height, width, channels], rocpycv.eTensorLayout.NHWC, dtype, device)
     rocpycv.brightness_contrast_into(output_golden, input, brightness, contrast, brightness_shift, contrast_center, stream=stream, device=device)
-    output = rocpycv.brightness_contrast(input, out_dtype, brightness, contrast, brightness_shift, contrast_center, stream=stream, device=device)
+    output = rocpycv.brightness_contrast(input, brightness, contrast, brightness_shift, contrast_center, stream=stream, device=device)
     stream.synchronize()
     compare_tensors(output, output_golden)
 
     # test defaults(no passed in bc params)
-    output_golden_default = rocpycv.Tensor([samples, height, width, channels], rocpycv.eTensorLayout.NHWC, out_dtype, device)
+    output_golden_default = rocpycv.Tensor([samples, height, width, channels], rocpycv.eTensorLayout.NHWC, dtype, device)
     rocpycv.brightness_contrast_into(output_golden_default, input, stream=stream, device=device)
-    output_default = rocpycv.brightness_contrast(input, out_dtype, stream=stream, device=device)
+    output_default = rocpycv.brightness_contrast(input, stream=stream, device=device)
     stream.synchronize()
     
     compare_tensors(output_default, output_golden_default)


### PR DESCRIPTION
## Motivation
 In the previous implementation of the BrightnessContrast operator, the at() function used to read brightness/contrast parameters contained runtime branching to handle different parameter types (default, broadcast, or per-sample). Avoiding this branching can increase performance on GPU.

## Technical Details
Refactored op_brightness_contrast.cpp to use template-based dispatch for brightness/contrast parameter types.
Also added the benchmarking file and minor documentation clarification in op_brightness_contrast.hpp on parameter types.

## Test Plan
Using previous  C++ and Python tests.
Added benchmark for BrightnessContrast. 

## Test Result
C++ and Python tests all pass.
Benchmarking showed a 1.06x average speedup in device-side execution time for batch sizes of 32, 64, and 128 compared to the previous implementation. For batch size of 1, there was a slight regression (approximately 0.95x) compared to the previous implementation. Edit: after refactoring again, there is now a 1.09x speedup for batch size 1 compared to the previous implementation.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
