### PR TITLE
[Optimization] Improve Composite host kernel performance

### DIFF
--- a/include/kernels/host/composite_host.hpp
+++ b/include/kernels/host/composite_host.hpp
@@ -46,7 +46,8 @@ inline void composite(SrcWrapper foreground, SrcWrapper background, MaskWrapper 
                 auto fgVal = RangeCast<work_type>(fgRow[x]);
                 auto bgVal = RangeCast<work_type>(bgRow[x]);
 
-                work_type result = fgVal * maskFactor.x + (1.0f - maskFactor.x) * bgVal;
+                // Lerp in FMA-friendly form: one multiply + one add per channel instead of two multiplies.
+                work_type result = bgVal + (fgVal - bgVal) * maskFactor.x;
 
                 // If number of channels in output is 4, ensure that the last channel (alpha in this case) is always
                 // fully on.

--- a/include/kernels/host/composite_host.hpp
+++ b/include/kernels/host/composite_host.hpp
@@ -32,24 +32,28 @@ inline void composite(SrcWrapper foreground, SrcWrapper background, MaskWrapper 
     using dst_type = typename DstWrapper::ValueType;
     using work_type = MakeType<float, NumElements<src_type>>;
 
+#pragma omp parallel for collapse(2) schedule(static)
     for (int batch = 0; batch < output.batches(); batch++) {
-#pragma omp parallel for
         for (int y = 0; y < output.height(); y++) {
+            auto* maskRow = &mask.at(batch, y, 0, 0);
+            auto* fgRow = &foreground.at(batch, y, 0, 0);
+            auto* bgRow = &background.at(batch, y, 0, 0);
+            auto* outRow = &output.at(batch, y, 0, 0);
+
             for (int x = 0; x < output.width(); x++) {
                 // Range cast all input values to float to avoid overflowing values and keep them in the same range.
-                auto maskFactor = RangeCast<float1>(mask.at(batch, y, x, 0));
-                auto fgVal = RangeCast<work_type>(foreground.at(batch, y, x, 0));
-                auto bgVal = RangeCast<work_type>(background.at(batch, y, x, 0));
+                auto maskFactor = RangeCast<float1>(maskRow[x]);
+                auto fgVal = RangeCast<work_type>(fgRow[x]);
+                auto bgVal = RangeCast<work_type>(bgRow[x]);
 
                 work_type result = fgVal * maskFactor.x + (1.0f - maskFactor.x) * bgVal;
 
                 // If number of channels in output is 4, ensure that the last channel (alpha in this case) is always
                 // fully on.
                 if constexpr (NumElements<dst_type> == 4) {
-                    output.at(batch, y, x, 0) =
-                        RangeCast<dst_type>((MakeType<float, 4>){result.x, result.y, result.z, 1.0f});
+                    outRow[x] = RangeCast<dst_type>((MakeType<float, 4>){result.x, result.y, result.z, 1.0f});
                 } else {
-                    output.at(batch, y, x, 0) = RangeCast<dst_type>(result);
+                    outRow[x] = RangeCast<dst_type>(result);
                 }
             }
         }

--- a/include/kernels/host/composite_host.hpp
+++ b/include/kernels/host/composite_host.hpp
@@ -40,7 +40,8 @@ inline void composite(SrcWrapper foreground, SrcWrapper background, MaskWrapper 
             auto* bgRow = &background.at(batch, y, 0, 0);
             auto* outRow = &output.at(batch, y, 0, 0);
 
-            for (int x = 0; x < output.width(); x++) {
+            const int width = static_cast<int>(output.width());
+            for (int x = 0; x < width; x++) {
                 // Range cast all input values to float to avoid overflowing values and keep them in the same range.
                 auto maskFactor = RangeCast<float1>(maskRow[x]);
                 auto fgVal = RangeCast<work_type>(fgRow[x]);


### PR DESCRIPTION
### Description
This PR aims to improve the performance of the host path for the Composite operator. This is acting as a small, localized test to see if broader improvements can be made across all of the host kernels for rocCV using the same ideas.

### Technical Details
- Hoists row address calculations outside of the row loop to avoid full recalculation at each pixel location.
- Row width stored in a local variable to enable SIMD optimizations on the inner row loop.
- Specified `collapse(2)` in the OMP pragma to improve work distribution across threads.