### PR TITLE
[Optimization] Normalize host kernel optimization

### DIFF
--- a/include/core/wrappers/image_wrapper.hpp
+++ b/include/core/wrappers/image_wrapper.hpp
@@ -140,7 +140,7 @@ class ImageWrapper {
      * @brief True when pixels within a row are densely packed (width stride equals the element size), so a row
      * pointer from &at(n, h, 0, 0) can be walked as a unit-stride array; otherwise fall back to at().
      */
-    __device__ __host__ inline bool isContiguous() const { return stride.w == static_cast<int64_t>(sizeof(T)); }
+    __device__ __host__ inline bool isRowContiguous() const { return stride.w == static_cast<int64_t>(sizeof(T)); }
 
     /**
      * @brief Retrives the height of the images.

--- a/include/core/wrappers/image_wrapper.hpp
+++ b/include/core/wrappers/image_wrapper.hpp
@@ -133,29 +133,12 @@ class ImageWrapper {
     }
 
     __device__ __host__ const T at(int64_t n, int64_t h, int64_t w, int64_t c) const {
-        return *(reinterpret_cast<T*>(data + (stride.n * n) + (stride.h * h) + (stride.w * w) + (stride.c * c)));
+        return const_cast<ImageWrapper*>(this)->at(n, h, w, c);
     }
 
     /**
-     * @brief Returns a typed pointer to the pixel at the given coordinates. Defaults to the start of a row, which
-     * (when isContiguous() is true) can be walked as a unit-stride T array, e.g. ptr(n, h)[x].
-     */
-    __device__ __host__ inline T* ptr(int64_t n, int64_t h, int64_t w = 0, int64_t c = 0) {
-        return reinterpret_cast<T*>(data + (stride.n * n) + (stride.h * h) + (stride.w * w) + (stride.c * c));
-    }
-
-    __device__ __host__ inline const T* ptr(int64_t n, int64_t h, int64_t w = 0, int64_t c = 0) const {
-        return reinterpret_cast<const T*>(data + (stride.n * n) + (stride.h * h) + (stride.w * w) + (stride.c * c));
-    }
-
-    /**
-     * @brief Number of bytes between consecutive pixels within a row (the width stride).
-     */
-    __device__ __host__ inline int64_t pixelStride() const { return stride.w; }
-
-    /**
-     * @brief True when pixels within a row are densely packed (width stride equals the element size), so a row can
-     * be traversed with unit-stride pointer arithmetic; otherwise respect pixelStride() / fall back to at().
+     * @brief True when pixels within a row are densely packed (width stride equals the element size), so a row
+     * pointer from &at(n, h, 0, 0) can be walked as a unit-stride array; otherwise fall back to at().
      */
     __device__ __host__ inline bool isContiguous() const { return stride.w == static_cast<int64_t>(sizeof(T)); }
 

--- a/include/core/wrappers/image_wrapper.hpp
+++ b/include/core/wrappers/image_wrapper.hpp
@@ -137,18 +137,8 @@ class ImageWrapper {
     }
 
     /**
-     * @brief Returns a typed pointer to the pixel at the given coordinates.
-     *
-     * Unlike at(), which recomputes the full byte offset on every call, this hands back a pointer that callers
-     * can advance directly. When isContiguous() is true the pixels of a row are unit-stride, so a host kernel can
-     * walk the row as a plain T array (e.g. ptr(n, h)[x]) — a form the compiler can auto-vectorize. When it is
-     * false the row is padded/strided and the pointer must instead be advanced by pixelStride() bytes per pixel.
-     *
-     * @param n Batch coordinate.
-     * @param h Height coordinate.
-     * @param w Width coordinate (defaults to the start of the row).
-     * @param c Channel coordinate.
-     * @return A pointer to the underlying data at the given coordinates.
+     * @brief Returns a typed pointer to the pixel at the given coordinates. Defaults to the start of a row, which
+     * (when isContiguous() is true) can be walked as a unit-stride T array, e.g. ptr(n, h)[x].
      */
     __device__ __host__ inline T* ptr(int64_t n, int64_t h, int64_t w = 0, int64_t c = 0) {
         return reinterpret_cast<T*>(data + (stride.n * n) + (stride.h * h) + (stride.w * w) + (stride.c * c));
@@ -160,17 +150,12 @@ class ImageWrapper {
 
     /**
      * @brief Number of bytes between consecutive pixels within a row (the width stride).
-     *
-     * @return The width stride, in bytes.
      */
     __device__ __host__ inline int64_t pixelStride() const { return stride.w; }
 
     /**
-     * @brief Reports whether pixels within a row are densely packed, i.e. the width stride equals the element
-     * size. When true a row can be traversed with unit-stride pointer arithmetic (ptr(n, h)[x]) and is a candidate
-     * for SIMD vectorization; when false callers must respect pixelStride() / fall back to at().
-     *
-     * @return True if rows are contiguous in the width dimension.
+     * @brief True when pixels within a row are densely packed (width stride equals the element size), so a row can
+     * be traversed with unit-stride pointer arithmetic; otherwise respect pixelStride() / fall back to at().
      */
     __device__ __host__ inline bool isContiguous() const { return stride.w == static_cast<int64_t>(sizeof(T)); }
 

--- a/include/core/wrappers/image_wrapper.hpp
+++ b/include/core/wrappers/image_wrapper.hpp
@@ -137,6 +137,44 @@ class ImageWrapper {
     }
 
     /**
+     * @brief Returns a typed pointer to the pixel at the given coordinates.
+     *
+     * Unlike at(), which recomputes the full byte offset on every call, this hands back a pointer that callers
+     * can advance directly. When isContiguous() is true the pixels of a row are unit-stride, so a host kernel can
+     * walk the row as a plain T array (e.g. ptr(n, h)[x]) — a form the compiler can auto-vectorize. When it is
+     * false the row is padded/strided and the pointer must instead be advanced by pixelStride() bytes per pixel.
+     *
+     * @param n Batch coordinate.
+     * @param h Height coordinate.
+     * @param w Width coordinate (defaults to the start of the row).
+     * @param c Channel coordinate.
+     * @return A pointer to the underlying data at the given coordinates.
+     */
+    __device__ __host__ inline T* ptr(int64_t n, int64_t h, int64_t w = 0, int64_t c = 0) {
+        return reinterpret_cast<T*>(data + (stride.n * n) + (stride.h * h) + (stride.w * w) + (stride.c * c));
+    }
+
+    __device__ __host__ inline const T* ptr(int64_t n, int64_t h, int64_t w = 0, int64_t c = 0) const {
+        return reinterpret_cast<const T*>(data + (stride.n * n) + (stride.h * h) + (stride.w * w) + (stride.c * c));
+    }
+
+    /**
+     * @brief Number of bytes between consecutive pixels within a row (the width stride).
+     *
+     * @return The width stride, in bytes.
+     */
+    __device__ __host__ inline int64_t pixelStride() const { return stride.w; }
+
+    /**
+     * @brief Reports whether pixels within a row are densely packed, i.e. the width stride equals the element
+     * size. When true a row can be traversed with unit-stride pointer arithmetic (ptr(n, h)[x]) and is a candidate
+     * for SIMD vectorization; when false callers must respect pixelStride() / fall back to at().
+     *
+     * @return True if rows are contiguous in the width dimension.
+     */
+    __device__ __host__ inline bool isContiguous() const { return stride.w == static_cast<int64_t>(sizeof(T)); }
+
+    /**
      * @brief Retrives the height of the images.
      *
      * @return Image height.

--- a/include/kernels/host/normalize_host.hpp
+++ b/include/kernels/host/normalize_host.hpp
@@ -80,8 +80,8 @@ void normalize(SrcWrapper input, BaseWrapper base, ScaleWrapper scale, DstWrappe
 
             // Fast path: packed rows with row-constant base/scale become a unit-stride, vectorizable loop.
             if (scaleBroadcastW && baseBroadcastW && input.isContiguous() && output.isContiguous()) {
-                const typename SrcWrapper::ValueType* __restrict__ inRow = input.ptr(b, y);
-                result_type* __restrict__ outRow = output.ptr(b, y);
+                const typename SrcWrapper::ValueType* __restrict__ inRow = &input.at(b, y, 0, 0);
+                result_type* __restrict__ outRow = &output.at(b, y, 0, 0);
                 for (int x = 0; x < width; x++) {
                     work_type result = (StaticCast<work_type>(inRow[x]) - rowBase) * rowScale * globalScale + shift;
                     outRow[x] = SaturateCast<result_type>(result);

--- a/include/kernels/host/normalize_host.hpp
+++ b/include/kernels/host/normalize_host.hpp
@@ -79,7 +79,7 @@ void normalize(SrcWrapper input, BaseWrapper base, ScaleWrapper scale, DstWrappe
             if (baseBroadcastW) rowBase = StaticCast<work_type>(base.at(baseBatchIdx, baseHeightIdx, 0, 0));
 
             // Fast path: packed rows with row-constant base/scale become a unit-stride, vectorizable loop.
-            if (scaleBroadcastW && baseBroadcastW && input.isContiguous() && output.isContiguous()) {
+            if (scaleBroadcastW && baseBroadcastW && input.isRowContiguous() && output.isRowContiguous()) {
                 const typename SrcWrapper::ValueType* __restrict__ inRow = &input.at(b, y, 0, 0);
                 result_type* __restrict__ outRow = &output.at(b, y, 0, 0);
                 for (int x = 0; x < width; x++) {

--- a/include/kernels/host/normalize_host.hpp
+++ b/include/kernels/host/normalize_host.hpp
@@ -62,15 +62,6 @@ void normalize(SrcWrapper input, BaseWrapper base, ScaleWrapper scale, DstWrappe
         }
     };
 
-    // When base/scale broadcast across all of N, H and W their value is constant for the whole tensor (the common
-    // per-channel (1,1,1,C) case), so resolve it once up front rather than once per row inside the parallel loop.
-    const bool scaleConstant = scaleBroadcastN && scaleBroadcastH && scaleBroadcastW;
-    const bool baseConstant = baseBroadcastN && baseBroadcastH && baseBroadcastW;
-    work_type tensorScale{};
-    work_type tensorBase{};
-    if (scaleConstant) tensorScale = resolveScale(StaticCast<work_type>(scale.at(0, 0, 0, 0)));
-    if (baseConstant) tensorBase = StaticCast<work_type>(base.at(0, 0, 0, 0));
-
     // Collapse batch and row so work scales even when batch == 1 (HWC); rows are uniform, so schedule statically.
 #pragma omp parallel for collapse(2) schedule(static)
     for (int b = 0; b < batches; b++) {
@@ -80,18 +71,12 @@ void normalize(SrcWrapper input, BaseWrapper base, ScaleWrapper scale, DstWrappe
             const int scaleBatchIdx = scaleBroadcastN ? 0 : b;
             const int scaleHeightIdx = scaleBroadcastH ? 0 : y;
 
-            // Resolve base/scale at the coarsest level they stay constant: reuse the whole-tensor value when fully
-            // broadcast, else resolve once per row when constant across width (hoisting the stddev sqrt).
+            // If base/scale don't vary across the row, resolve them once per row (hoists the stddev sqrt).
             work_type rowScale{};
             work_type rowBase{};
-            if (scaleConstant)
-                rowScale = tensorScale;
-            else if (scaleBroadcastW)
+            if (scaleBroadcastW)
                 rowScale = resolveScale(StaticCast<work_type>(scale.at(scaleBatchIdx, scaleHeightIdx, 0, 0)));
-            if (baseConstant)
-                rowBase = tensorBase;
-            else if (baseBroadcastW)
-                rowBase = StaticCast<work_type>(base.at(baseBatchIdx, baseHeightIdx, 0, 0));
+            if (baseBroadcastW) rowBase = StaticCast<work_type>(base.at(baseBatchIdx, baseHeightIdx, 0, 0));
 
             // Fast path: packed rows with row-constant base/scale become a unit-stride, vectorizable loop.
             if (scaleBroadcastW && baseBroadcastW && input.isContiguous() && output.isContiguous()) {

--- a/include/kernels/host/normalize_host.hpp
+++ b/include/kernels/host/normalize_host.hpp
@@ -88,19 +88,33 @@ void normalize(SrcWrapper input, BaseWrapper base, ScaleWrapper scale, DstWrappe
                 rowScale = resolveScale(StaticCast<work_type>(scale.at(scaleBatchIdx, scaleHeightIdx, 0, 0)));
             if (baseBroadcastW) rowBase = StaticCast<work_type>(base.at(baseBatchIdx, baseHeightIdx, 0, 0));
 
-            for (int x = 0; x < width; x++) {
-                const work_type scaleVal =
-                    scaleBroadcastW
-                        ? rowScale
-                        : resolveScale(StaticCast<work_type>(scale.at(scaleBatchIdx, scaleHeightIdx, x, 0)));
-                const work_type baseVal =
-                    baseBroadcastW ? rowBase : StaticCast<work_type>(base.at(baseBatchIdx, baseHeightIdx, x, 0));
+            // Fast path: when the input and output rows are densely packed and the per-pixel base/scale are
+            // constant across the row, the inner loop reduces to a unit-stride map over two T arrays. Walking raw
+            // row pointers drops the per-pixel offset arithmetic of at() and gives the compiler a contiguous loop
+            // it can auto-vectorize. Anything else (strided/padded rows, or spatially-varying base/scale) takes the
+            // general stride-correct path below.
+            if (scaleBroadcastW && baseBroadcastW && input.isContiguous() && output.isContiguous()) {
+                const typename SrcWrapper::ValueType* __restrict__ inRow = input.ptr(b, y);
+                result_type* __restrict__ outRow = output.ptr(b, y);
+                for (int x = 0; x < width; x++) {
+                    work_type result = (StaticCast<work_type>(inRow[x]) - rowBase) * rowScale * globalScale + shift;
+                    outRow[x] = SaturateCast<result_type>(result);
+                }
+            } else {
+                for (int x = 0; x < width; x++) {
+                    const work_type scaleVal =
+                        scaleBroadcastW
+                            ? rowScale
+                            : resolveScale(StaticCast<work_type>(scale.at(scaleBatchIdx, scaleHeightIdx, x, 0)));
+                    const work_type baseVal =
+                        baseBroadcastW ? rowBase : StaticCast<work_type>(base.at(baseBatchIdx, baseHeightIdx, x, 0));
 
-                work_type result =
-                    (StaticCast<work_type>(input.at(b, y, x, 0)) - baseVal) * scaleVal * globalScale + shift;
+                    work_type result =
+                        (StaticCast<work_type>(input.at(b, y, x, 0)) - baseVal) * scaleVal * globalScale + shift;
 
-                // Saturate cast value back into the output tensor's value type
-                output.at(b, y, x, 0) = SaturateCast<result_type>(result);
+                    // Saturate cast value back into the output tensor's value type
+                    output.at(b, y, x, 0) = SaturateCast<result_type>(result);
+                }
             }
         }
     }

--- a/include/kernels/host/normalize_host.hpp
+++ b/include/kernels/host/normalize_host.hpp
@@ -62,6 +62,15 @@ void normalize(SrcWrapper input, BaseWrapper base, ScaleWrapper scale, DstWrappe
         }
     };
 
+    // When base/scale broadcast across all of N, H and W their value is constant for the whole tensor (the common
+    // per-channel (1,1,1,C) case), so resolve it once up front rather than once per row inside the parallel loop.
+    const bool scaleConstant = scaleBroadcastN && scaleBroadcastH && scaleBroadcastW;
+    const bool baseConstant = baseBroadcastN && baseBroadcastH && baseBroadcastW;
+    work_type tensorScale{};
+    work_type tensorBase{};
+    if (scaleConstant) tensorScale = resolveScale(StaticCast<work_type>(scale.at(0, 0, 0, 0)));
+    if (baseConstant) tensorBase = StaticCast<work_type>(base.at(0, 0, 0, 0));
+
     // Collapse batch and row so work scales even when batch == 1 (HWC); rows are uniform, so schedule statically.
 #pragma omp parallel for collapse(2) schedule(static)
     for (int b = 0; b < batches; b++) {
@@ -71,12 +80,18 @@ void normalize(SrcWrapper input, BaseWrapper base, ScaleWrapper scale, DstWrappe
             const int scaleBatchIdx = scaleBroadcastN ? 0 : b;
             const int scaleHeightIdx = scaleBroadcastH ? 0 : y;
 
-            // If base/scale don't vary across the row, resolve them once per row (hoists the stddev sqrt).
+            // Resolve base/scale at the coarsest level they stay constant: reuse the whole-tensor value when fully
+            // broadcast, else resolve once per row when constant across width (hoisting the stddev sqrt).
             work_type rowScale{};
             work_type rowBase{};
-            if (scaleBroadcastW)
+            if (scaleConstant)
+                rowScale = tensorScale;
+            else if (scaleBroadcastW)
                 rowScale = resolveScale(StaticCast<work_type>(scale.at(scaleBatchIdx, scaleHeightIdx, 0, 0)));
-            if (baseBroadcastW) rowBase = StaticCast<work_type>(base.at(baseBatchIdx, baseHeightIdx, 0, 0));
+            if (baseConstant)
+                rowBase = tensorBase;
+            else if (baseBroadcastW)
+                rowBase = StaticCast<work_type>(base.at(baseBatchIdx, baseHeightIdx, 0, 0));
 
             // Fast path: packed rows with row-constant base/scale become a unit-stride, vectorizable loop.
             if (scaleBroadcastW && baseBroadcastW && input.isContiguous() && output.isContiguous()) {

--- a/include/kernels/host/normalize_host.hpp
+++ b/include/kernels/host/normalize_host.hpp
@@ -31,7 +31,6 @@
 #include "core/detail/casting.hpp"
 #include "core/detail/math/vectorized_type_math.hpp"
 #include "core/detail/type_traits.hpp"
-#include "core/detail/vector_utils.hpp"
 
 namespace Kernels::Host {
 template <bool ScaleStddev, typename SrcWrapper, typename DstWrapper, typename ScaleWrapper, typename BaseWrapper>
@@ -62,6 +61,11 @@ void normalize(SrcWrapper input, BaseWrapper base, ScaleWrapper scale, DstWrappe
         }
     };
 
+    // Single-sourced per-pixel formula shared by both the contiguous fast path and the strided fallback.
+    auto computePixel = [&](const work_type& in, const work_type& baseVal, const work_type& scaleVal) -> result_type {
+        return SaturateCast<result_type>((in - baseVal) * scaleVal * globalScale + shift);
+    };
+
     // Collapse batch and row so work scales even when batch == 1 (HWC); rows are uniform, so schedule statically.
 #pragma omp parallel for collapse(2) schedule(static)
     for (int b = 0; b < batches; b++) {
@@ -83,8 +87,7 @@ void normalize(SrcWrapper input, BaseWrapper base, ScaleWrapper scale, DstWrappe
                 const typename SrcWrapper::ValueType* __restrict__ inRow = &input.at(b, y, 0, 0);
                 result_type* __restrict__ outRow = &output.at(b, y, 0, 0);
                 for (int x = 0; x < width; x++) {
-                    work_type result = (StaticCast<work_type>(inRow[x]) - rowBase) * rowScale * globalScale + shift;
-                    outRow[x] = SaturateCast<result_type>(result);
+                    outRow[x] = computePixel(StaticCast<work_type>(inRow[x]), rowBase, rowScale);
                 }
             } else {
                 for (int x = 0; x < width; x++) {
@@ -95,9 +98,8 @@ void normalize(SrcWrapper input, BaseWrapper base, ScaleWrapper scale, DstWrappe
                     const work_type baseVal =
                         baseBroadcastW ? rowBase : StaticCast<work_type>(base.at(baseBatchIdx, baseHeightIdx, x, 0));
 
-                    work_type result =
-                        (StaticCast<work_type>(input.at(b, y, x, 0)) - baseVal) * scaleVal * globalScale + shift;
-                    output.at(b, y, x, 0) = SaturateCast<result_type>(result);
+                    output.at(b, y, x, 0) =
+                        computePixel(StaticCast<work_type>(input.at(b, y, x, 0)), baseVal, scaleVal);
                 }
             }
         }

--- a/include/kernels/host/normalize_host.hpp
+++ b/include/kernels/host/normalize_host.hpp
@@ -39,37 +39,65 @@ void normalize(SrcWrapper input, BaseWrapper base, ScaleWrapper scale, DstWrappe
                float shift, float epsilon) {
     using namespace roccv::detail;
     using work_type = MakeType<float, NumComponents<typename SrcWrapper::ValueType>>;
-    using result_type = DstWrapper::ValueType;
+    using result_type = typename DstWrapper::ValueType;
 
-// Split work across available threads for the batch dimension of the images. By default, OpenMP will use the maximum
-// available threads on the system unless set otherwise.
-#pragma omp parallel for
-    for (int b = 0; b < output.batches(); b++) {
-        for (int y = 0; y < output.height(); y++) {
-            for (int x = 0; x < output.width(); x++) {
-                const int baseBatchIdx = base.batches() == 1 ? 0 : b;
-                const int baseHeightIdx = base.height() == 1 ? 0 : y;
-                const int baseWidthIdx = base.width() == 1 ? 0 : x;
+    const int batches = static_cast<int>(output.batches());
+    const int height = static_cast<int>(output.height());
+    const int width = static_cast<int>(output.width());
 
-                const int scaleBatchIdx = scale.batches() == 1 ? 0 : b;
-                const int scaleHeightIdx = scale.height() == 1 ? 0 : y;
-                const int scaleWidthIdx = scale.width() == 1 ? 0 : x;
+    // The base/scale tensors are broadcastable: any of their N/H/W extents may be 1, in which case that index is
+    // shared across the entire corresponding output dimension. Whether a dimension broadcasts is a property of the
+    // tensor shapes, not of the current pixel, so resolve these flags once instead of re-testing them per pixel.
+    const bool baseBroadcastN = base.batches() == 1;
+    const bool baseBroadcastH = base.height() == 1;
+    const bool baseBroadcastW = base.width() == 1;
+    const bool scaleBroadcastN = scale.batches() == 1;
+    const bool scaleBroadcastH = scale.height() == 1;
+    const bool scaleBroadcastW = scale.width() == 1;
 
-                work_type scaleVal;
-                work_type s = StaticCast<work_type>(scale.at(scaleBatchIdx, scaleHeightIdx, scaleWidthIdx, 0));
-                if constexpr (ScaleStddev) {
-                    // Scale tensor is the standard deviation, invert back to scale with epsilon added to avoid division
-                    // by zero.
-                    scaleVal = 1.0f / (math::vsqrtf((s * s) + epsilon));
-                } else {
-                    // Scale tensor remains normal, calculate assuming the values in the scale tensor are indeed the
-                    // scale
-                    scaleVal = s;
-                }
-                work_type result = (StaticCast<work_type>(input.at(b, y, x, 0)) -
-                                    StaticCast<work_type>(base.at(baseBatchIdx, baseHeightIdx, baseWidthIdx, 0))) *
-                                       scaleVal * globalScale +
-                                   shift;
+    // Turns a raw scale-tensor sample into the multiplicative scale. When the tensor holds standard deviations we
+    // invert back to a scale, adding epsilon under the root to guard against division by zero.
+    auto resolveScale = [&](const work_type& s) -> work_type {
+        if constexpr (ScaleStddev) {
+            return 1.0f / (math::vsqrtf((s * s) + epsilon));
+        } else {
+            return s;
+        }
+    };
+
+    // Collapse the batch and row loops into one iteration space. Parallelizing over the batch alone leaves all but
+    // one thread idle for single-image (HWC, batch == 1) inputs; collapsing exposes batches * height independent
+    // rows so the work scales regardless of batch size. Each row does an identical amount of work, so static
+    // scheduling partitions the iteration space up front and avoids the bookkeeping of dynamic scheduling. Strides
+    // are honored throughout by going through the wrapper's at() accessor rather than assuming a contiguous layout.
+#pragma omp parallel for collapse(2) schedule(static)
+    for (int b = 0; b < batches; b++) {
+        for (int y = 0; y < height; y++) {
+            // Indices into the base/scale tensors only depend on b/y here, so resolve them once per row.
+            const int baseBatchIdx = baseBroadcastN ? 0 : b;
+            const int baseHeightIdx = baseBroadcastH ? 0 : y;
+            const int scaleBatchIdx = scaleBroadcastN ? 0 : b;
+            const int scaleHeightIdx = scaleBroadcastH ? 0 : y;
+
+            // When base/scale broadcast across the width, their values are constant for the whole row. Hoist them
+            // out of the x loop so the common per-channel parameter case (shape (1,1,1,C)) computes the base sample
+            // and the (potentially sqrt-heavy) scale exactly once per row instead of once per pixel.
+            work_type rowScale{};
+            work_type rowBase{};
+            if (scaleBroadcastW)
+                rowScale = resolveScale(StaticCast<work_type>(scale.at(scaleBatchIdx, scaleHeightIdx, 0, 0)));
+            if (baseBroadcastW) rowBase = StaticCast<work_type>(base.at(baseBatchIdx, baseHeightIdx, 0, 0));
+
+            for (int x = 0; x < width; x++) {
+                const work_type scaleVal =
+                    scaleBroadcastW
+                        ? rowScale
+                        : resolveScale(StaticCast<work_type>(scale.at(scaleBatchIdx, scaleHeightIdx, x, 0)));
+                const work_type baseVal =
+                    baseBroadcastW ? rowBase : StaticCast<work_type>(base.at(baseBatchIdx, baseHeightIdx, x, 0));
+
+                work_type result =
+                    (StaticCast<work_type>(input.at(b, y, x, 0)) - baseVal) * scaleVal * globalScale + shift;
 
                 // Saturate cast value back into the output tensor's value type
                 output.at(b, y, x, 0) = SaturateCast<result_type>(result);

--- a/include/kernels/host/normalize_host.hpp
+++ b/include/kernels/host/normalize_host.hpp
@@ -45,9 +45,7 @@ void normalize(SrcWrapper input, BaseWrapper base, ScaleWrapper scale, DstWrappe
     const int height = static_cast<int>(output.height());
     const int width = static_cast<int>(output.width());
 
-    // The base/scale tensors are broadcastable: any of their N/H/W extents may be 1, in which case that index is
-    // shared across the entire corresponding output dimension. Whether a dimension broadcasts is a property of the
-    // tensor shapes, not of the current pixel, so resolve these flags once instead of re-testing them per pixel.
+    // base/scale are broadcastable along any of N/H/W (extent 1 means the index collapses to 0).
     const bool baseBroadcastN = base.batches() == 1;
     const bool baseBroadcastH = base.height() == 1;
     const bool baseBroadcastW = base.width() == 1;
@@ -55,8 +53,7 @@ void normalize(SrcWrapper input, BaseWrapper base, ScaleWrapper scale, DstWrappe
     const bool scaleBroadcastH = scale.height() == 1;
     const bool scaleBroadcastW = scale.width() == 1;
 
-    // Turns a raw scale-tensor sample into the multiplicative scale. When the tensor holds standard deviations we
-    // invert back to a scale, adding epsilon under the root to guard against division by zero.
+    // Convert a scale sample to a multiplier, inverting standard deviations (epsilon guards against /0).
     auto resolveScale = [&](const work_type& s) -> work_type {
         if constexpr (ScaleStddev) {
             return 1.0f / (math::vsqrtf((s * s) + epsilon));
@@ -65,34 +62,23 @@ void normalize(SrcWrapper input, BaseWrapper base, ScaleWrapper scale, DstWrappe
         }
     };
 
-    // Collapse the batch and row loops into one iteration space. Parallelizing over the batch alone leaves all but
-    // one thread idle for single-image (HWC, batch == 1) inputs; collapsing exposes batches * height independent
-    // rows so the work scales regardless of batch size. Each row does an identical amount of work, so static
-    // scheduling partitions the iteration space up front and avoids the bookkeeping of dynamic scheduling. Strides
-    // are honored throughout by going through the wrapper's at() accessor rather than assuming a contiguous layout.
+    // Collapse batch and row so work scales even when batch == 1 (HWC); rows are uniform, so schedule statically.
 #pragma omp parallel for collapse(2) schedule(static)
     for (int b = 0; b < batches; b++) {
         for (int y = 0; y < height; y++) {
-            // Indices into the base/scale tensors only depend on b/y here, so resolve them once per row.
             const int baseBatchIdx = baseBroadcastN ? 0 : b;
             const int baseHeightIdx = baseBroadcastH ? 0 : y;
             const int scaleBatchIdx = scaleBroadcastN ? 0 : b;
             const int scaleHeightIdx = scaleBroadcastH ? 0 : y;
 
-            // When base/scale broadcast across the width, their values are constant for the whole row. Hoist them
-            // out of the x loop so the common per-channel parameter case (shape (1,1,1,C)) computes the base sample
-            // and the (potentially sqrt-heavy) scale exactly once per row instead of once per pixel.
+            // If base/scale don't vary across the row, resolve them once per row (hoists the stddev sqrt).
             work_type rowScale{};
             work_type rowBase{};
             if (scaleBroadcastW)
                 rowScale = resolveScale(StaticCast<work_type>(scale.at(scaleBatchIdx, scaleHeightIdx, 0, 0)));
             if (baseBroadcastW) rowBase = StaticCast<work_type>(base.at(baseBatchIdx, baseHeightIdx, 0, 0));
 
-            // Fast path: when the input and output rows are densely packed and the per-pixel base/scale are
-            // constant across the row, the inner loop reduces to a unit-stride map over two T arrays. Walking raw
-            // row pointers drops the per-pixel offset arithmetic of at() and gives the compiler a contiguous loop
-            // it can auto-vectorize. Anything else (strided/padded rows, or spatially-varying base/scale) takes the
-            // general stride-correct path below.
+            // Fast path: packed rows with row-constant base/scale become a unit-stride, vectorizable loop.
             if (scaleBroadcastW && baseBroadcastW && input.isContiguous() && output.isContiguous()) {
                 const typename SrcWrapper::ValueType* __restrict__ inRow = input.ptr(b, y);
                 result_type* __restrict__ outRow = output.ptr(b, y);
@@ -111,8 +97,6 @@ void normalize(SrcWrapper input, BaseWrapper base, ScaleWrapper scale, DstWrappe
 
                     work_type result =
                         (StaticCast<work_type>(input.at(b, y, x, 0)) - baseVal) * scaleVal * globalScale + shift;
-
-                    // Saturate cast value back into the output tensor's value type
                     output.at(b, y, x, 0) = SaturateCast<result_type>(result);
                 }
             }


### PR DESCRIPTION
### Technical Description
- Hoists scale/base calculations outside of inner rows when broadcasting.
- Implemented a fast-path for row-contiguous tensors to enable better row traversal rather than performing a full calculation on strides every pixel.
- Collapse OMP loop for better thread usage on single image processing + use static scheduling instead.

### Notes
- Update `const` version of ImageWrapper.at() to ensure one source of truth.
- Add `isContiguous()` method in ImageWrapper to determine when a row is packed (to choose fast paths and better row-level traversals)
