### PR TITLE
[Optimization] GPU vector-pack writes across elementwise and geometric operators

### DIFF
--- a/include/core/detail/casting.hpp
+++ b/include/core/detail/casting.hpp
@@ -130,6 +130,40 @@ __device__ __host__ T ScalarSaturateCast(U v) {
     }
 }
 
+#ifdef __HIP_DEVICE_COMPILE__
+/**
+ * @brief Device-only fused saturating cast from a float type to a 1-4 element unsigned char type.
+ *
+ * Each `__builtin_amdgcn_cvt_pk_u8_f32` invocation lowers to a single `v_cvt_pk_u8_f32` instruction that performs
+ * round-to-nearest-even, saturation to [0, 255], the f32->u8 conversion, and a write into a selected byte of the
+ * destination word. This fuses what the generic scalar path does with a separate clamp (`v_med3_f32`), round
+ * (`v_rndne_f32`), convert (`v_cvt_i32_f32`), and byte-assembly sequence -- a float4 -> uchar4 cast collapses from
+ * ~12 ALU ops plus packing down to four instructions that build the packed 32-bit word directly.
+ *
+ * @tparam T Destination type: `unsigned char` or `uchar1`..`uchar4`.
+ * @tparam U Source type: `float` or `float1`..`float4`, with at least `NumElements<T>` elements.
+ */
+template <typename T, typename U>
+__device__ __forceinline__ T CvtPackedSaturateU8(U v) {
+    constexpr int N = NumElements<T>;
+    unsigned packed = 0;
+    packed = __builtin_amdgcn_cvt_pk_u8_f32(GetElement(v, 0), 0, packed);
+    if constexpr (N >= 2) packed = __builtin_amdgcn_cvt_pk_u8_f32(GetElement(v, 1), 1, packed);
+    if constexpr (N >= 3) packed = __builtin_amdgcn_cvt_pk_u8_f32(GetElement(v, 2), 2, packed);
+    if constexpr (N >= 4) packed = __builtin_amdgcn_cvt_pk_u8_f32(GetElement(v, 3), 3, packed);
+
+    if constexpr (N == 4) {
+        // uchar4 shares the layout of the packed 32-bit word, so the store needs no byte assembly.
+        return __builtin_bit_cast(T, packed);
+    } else {
+        T out{};
+        const unsigned char* bytes = reinterpret_cast<const unsigned char*>(&packed);
+        for (int i = 0; i < N; i++) GetElement(out, i) = bytes[i];
+        return out;
+    }
+}
+#endif
+
 /**
  * @brief Performs a saturation cast from one type to another. Each type must have type traits supported. A
  * saturation cast converts one type to another, clamping values down to the minimum/maximum of the desired cast if the
@@ -145,6 +179,13 @@ template <typename T, typename U,
           class = std::enable_if_t<(HasTypeTraits<T> && HasTypeTraits<U>) && (NumElements<T> <= NumElements<U>)>>
 __device__ __host__ T SaturateCast(U v) {
     using B = BaseType<T>;
+#ifdef __HIP_DEVICE_COMPILE__
+    // Fast path: float -> uint8 saturating casts map directly onto the hardware v_cvt_pk_u8_f32 instruction, which
+    // matches the generic clamp-then-IEEE-round semantics below. Guarded to float sources (the builtin is f32-only).
+    if constexpr (std::is_same_v<B, unsigned char> && std::is_same_v<BaseType<U>, float>) {
+        return CvtPackedSaturateU8<T, U>(v);
+    }
+#endif
     if constexpr (std::is_same_v<T, U>) {
         return v;
     } else if constexpr (NumElements<T> == 1) {

--- a/include/core/detail/casting.hpp
+++ b/include/core/detail/casting.hpp
@@ -23,10 +23,29 @@
 
 #include <algorithm>
 #include <cmath>
+#include <limits>
 
 #include "core/detail/type_traits.hpp"
 
 namespace roccv::detail {
+
+/**
+ * @brief The value of a "fully saturated" channel for type @p T in its native storage scale, as a float.
+ *
+ * For floating-point base types this is 1.0 (rocCV's normalized-float convention); for integral base types it is the
+ * type's maximum representable value (e.g. 255 for unsigned char). This mirrors RangeCast's range convention and is
+ * useful when blend math is done in native (un-normalized) scale but a channel -- such as an opaque alpha -- still
+ * needs to be set fully on before a SaturateCast back to the output type.
+ */
+template <typename T>
+__device__ __host__ constexpr float RangeMax() {
+    using B = BaseType<T>;
+    if constexpr (std::is_floating_point_v<B>) {
+        return 1.0f;
+    } else {
+        return static_cast<float>(std::numeric_limits<B>::max());
+    }
+}
 
 /**
  * @brief Rounds a floating-point value to the nearest integer using IEEE

--- a/include/core/wrappers/image_wrapper.hpp
+++ b/include/core/wrappers/image_wrapper.hpp
@@ -137,6 +137,14 @@ class ImageWrapper {
     }
 
     /**
+     * @brief Whether consecutive pixels along x are contiguous in memory (i.e. the width stride equals one whole
+     * pixel). True for interleaved layouts; lets callers safely issue a wide store across a run of pixels.
+     *
+     * @return True if pixels along the width axis are tightly packed.
+     */
+    __device__ __host__ inline bool isContiguousX() const { return stride.w == static_cast<int64_t>(sizeof(T)); }
+
+    /**
      * @brief Retrives the height of the images.
      *
      * @return Image height.

--- a/include/kernels/device/brightness_contrast_device.hpp
+++ b/include/kernels/device/brightness_contrast_device.hpp
@@ -34,6 +34,7 @@ namespace Device {
 template <typename SrcWrapper, typename DstWrapper, typename BCWrappers>
 __global__ void brightness_contrast(SrcWrapper input, DstWrapper output, BCWrappers bc_wrappers) {
     using namespace roccv::detail;
+    using src_type = typename SrcWrapper::ValueType;
     using dst_type = typename DstWrapper::ValueType;
     using bc_type = typename BCWrappers::ValueType;
     using work_type = MakeType<bc_type, NumElements<dst_type>>;
@@ -48,11 +49,12 @@ __global__ void brightness_contrast(SrcWrapper input, DstWrapper output, BCWrapp
     const bc_type brightnessShift = bc_wrappers.brightnessShiftWrapper.at(batch);
     const bc_type contrastCenter = bc_wrappers.contrastCenterWrapper.at(batch);
 
-    ApplyPackedRow(output, batch, y, [=] __device__(int n, int yy, int x) -> dst_type {
-        work_type src_val = StaticCast<work_type>(input.at(n, yy, x, 0));
-        work_type result = brightnessShift + brightness * (contrastCenter + contrast * (src_val - contrastCenter));
-        return SaturateCast<dst_type>(result);
-    });
+    ApplyPackedTransform(
+        input, output, batch, y, [=] __device__(src_type srcPixel, int /*n*/, int /*yy*/, int /*x*/) -> dst_type {
+            work_type src_val = StaticCast<work_type>(srcPixel);
+            work_type result = brightnessShift + brightness * (contrastCenter + contrast * (src_val - contrastCenter));
+            return SaturateCast<dst_type>(result);
+        });
 }
 }  // namespace Device
 }  // namespace Kernels

--- a/include/kernels/device/brightness_contrast_device.hpp
+++ b/include/kernels/device/brightness_contrast_device.hpp
@@ -50,11 +50,13 @@ __global__ void brightness_contrast(SrcWrapper input, DstWrapper output, BCWrapp
     const bc_type contrastCenter = bc_wrappers.contrastCenterWrapper.at(batch);
 
     ApplyPackedTransform(
-        input, output, batch, y, [=] __device__(src_type srcPixel, int /*n*/, int /*yy*/, int /*x*/) -> dst_type {
+        output, batch, y,
+        [=] __device__(int /*n*/, int /*yy*/, int /*x*/, src_type srcPixel) -> dst_type {
             work_type src_val = StaticCast<work_type>(srcPixel);
             work_type result = brightnessShift + brightness * (contrastCenter + contrast * (src_val - contrastCenter));
             return SaturateCast<dst_type>(result);
-        });
+        },
+        input);
 }
 }  // namespace Device
 }  // namespace Kernels

--- a/include/kernels/device/brightness_contrast_device.hpp
+++ b/include/kernels/device/brightness_contrast_device.hpp
@@ -27,6 +27,7 @@ THE SOFTWARE.
 #include "core/detail/casting.hpp"
 #include "core/detail/type_traits.hpp"
 #include "core/wrappers/image_wrapper.hpp"
+#include "kernels/device/packed_apply.hpp"
 
 namespace Kernels {
 namespace Device {
@@ -37,22 +38,21 @@ __global__ void brightness_contrast(SrcWrapper input, DstWrapper output, BCWrapp
     using bc_type = typename BCWrappers::ValueType;
     using work_type = MakeType<bc_type, NumElements<dst_type>>;
 
-    // get the pixel coords (=thread)
-    const int x = threadIdx.x + blockIdx.x * blockDim.x;
     const int y = threadIdx.y + blockIdx.y * blockDim.y;
     const int batch = blockIdx.z;
+    if (y >= output.height() || batch >= output.batches()) return;
 
-    if (x >= output.width() || y >= output.height()) return;
-
-    // get the brightness/contrast scalars to apply
+    // The brightness/contrast scalars depend only on the batch, so fetch them once per thread (outside the x-run).
     const bc_type brightness = bc_wrappers.brightnessWrapper.at(batch);
     const bc_type contrast = bc_wrappers.contrastWrapper.at(batch);
     const bc_type brightnessShift = bc_wrappers.brightnessShiftWrapper.at(batch);
     const bc_type contrastCenter = bc_wrappers.contrastCenterWrapper.at(batch);
 
-    work_type src_val = StaticCast<work_type>(input.at(batch, y, x, 0));
-    work_type result = brightnessShift + brightness * (contrastCenter + contrast * (src_val - contrastCenter));
-    output.at(batch, y, x, 0) = SaturateCast<dst_type>(result);
+    ApplyPackedRow(output, batch, y, [=] __device__(int n, int yy, int x) -> dst_type {
+        work_type src_val = StaticCast<work_type>(input.at(n, yy, x, 0));
+        work_type result = brightnessShift + brightness * (contrastCenter + contrast * (src_val - contrastCenter));
+        return SaturateCast<dst_type>(result);
+    });
 }
 }  // namespace Device
 }  // namespace Kernels

--- a/include/kernels/device/brightness_contrast_device.hpp
+++ b/include/kernels/device/brightness_contrast_device.hpp
@@ -50,13 +50,11 @@ __global__ void brightness_contrast(SrcWrapper input, DstWrapper output, BCWrapp
     const bc_type contrastCenter = bc_wrappers.contrastCenterWrapper.at(batch);
 
     ApplyPackedTransform(
-        output, batch, y,
-        [=] __device__(int /*n*/, int /*yy*/, int /*x*/, src_type srcPixel) -> dst_type {
+        input, output, batch, y, [=] __device__(src_type srcPixel, int /*n*/, int /*yy*/, int /*x*/) -> dst_type {
             work_type src_val = StaticCast<work_type>(srcPixel);
             work_type result = brightnessShift + brightness * (contrastCenter + contrast * (src_val - contrastCenter));
             return SaturateCast<dst_type>(result);
-        },
-        input);
+        });
 }
 }  // namespace Device
 }  // namespace Kernels

--- a/include/kernels/device/composite_device.hpp
+++ b/include/kernels/device/composite_device.hpp
@@ -40,18 +40,18 @@ __global__ void composite(SrcWrapper foreground, SrcWrapper background, MaskWrap
     if (y >= foreground.height() || batch >= output.batches()) return;
 
     ApplyPackedGather(output, batch, y, [=] __device__(int n, int yy, int x) -> dst_type {
-        // Range cast all input values to float to avoid overflowing values and keep them in the same range.
+        // The blend is linear, so only the mask needs normalizing; fg/bg stay at native scale (no scaling multiply).
         auto maskFactor = RangeCast<float1>(mask.at(n, yy, x, 0));
-        auto fgVal = RangeCast<work_type>(foreground.at(n, yy, x, 0));
-        auto bgVal = RangeCast<work_type>(background.at(n, yy, x, 0));
+        auto fgVal = StaticCast<work_type>(foreground.at(n, yy, x, 0));
+        auto bgVal = StaticCast<work_type>(background.at(n, yy, x, 0));
 
         work_type result = bgVal + maskFactor.x * (fgVal - bgVal);
 
-        // If output has 4 channels, ensure the last channel (alpha) is always fully on.
+        // For 4-channel output, force the alpha channel fully on.
         if constexpr (NumElements<dst_type> == 4) {
-            return RangeCast<dst_type>((MakeType<float, 4>){result.x, result.y, result.z, 1.0f});
+            return SaturateCast<dst_type>((MakeType<float, 4>){result.x, result.y, result.z, RangeMax<dst_type>()});
         } else {
-            return RangeCast<dst_type>(result);
+            return SaturateCast<dst_type>(result);
         }
     });
 }

--- a/include/kernels/device/composite_device.hpp
+++ b/include/kernels/device/composite_device.hpp
@@ -24,6 +24,7 @@
 #include <hip/hip_runtime.h>
 
 #include "core/detail/casting.hpp"
+#include "kernels/device/packed_apply.hpp"
 
 namespace Kernels {
 namespace Device {
@@ -34,25 +35,25 @@ __global__ void composite(SrcWrapper foreground, SrcWrapper background, MaskWrap
     using dst_type = typename DstWrapper::ValueType;
     using work_type = MakeType<float, NumElements<src_type>>;
 
-    const int x = blockIdx.x * blockDim.x + threadIdx.x;
     const int y = blockIdx.y * blockDim.y + threadIdx.y;
     const int batch = blockIdx.z;
+    if (y >= foreground.height() || batch >= output.batches()) return;
 
-    if (x >= foreground.width() || y >= foreground.height()) return;
+    ApplyPackedRow(output, batch, y, [=] __device__(int n, int yy, int x) -> dst_type {
+        // Range cast all input values to float to avoid overflowing values and keep them in the same range.
+        auto maskFactor = RangeCast<float1>(mask.at(n, yy, x, 0));
+        auto fgVal = RangeCast<work_type>(foreground.at(n, yy, x, 0));
+        auto bgVal = RangeCast<work_type>(background.at(n, yy, x, 0));
 
-    // Range cast all input values to float to avoid overflowing values and keep them in the same range.
-    auto maskFactor = RangeCast<float1>(mask.at(batch, y, x, 0));
-    auto fgVal = RangeCast<work_type>(foreground.at(batch, y, x, 0));
-    auto bgVal = RangeCast<work_type>(background.at(batch, y, x, 0));
+        work_type result = bgVal + maskFactor.x * (fgVal - bgVal);
 
-    work_type result = bgVal + maskFactor.x * (fgVal - bgVal);
-
-    // If number of channels in output is 4, ensure that the last channel (alpha in this case) is always fully on.
-    if constexpr (NumElements<dst_type> == 4) {
-        output.at(batch, y, x, 0) = RangeCast<dst_type>((MakeType<float, 4>){result.x, result.y, result.z, 1.0f});
-    } else {
-        output.at(batch, y, x, 0) = RangeCast<dst_type>(result);
-    }
+        // If output has 4 channels, ensure the last channel (alpha) is always fully on.
+        if constexpr (NumElements<dst_type> == 4) {
+            return RangeCast<dst_type>((MakeType<float, 4>){result.x, result.y, result.z, 1.0f});
+        } else {
+            return RangeCast<dst_type>(result);
+        }
+    });
 }
 }  // namespace Device
 }  // namespace Kernels

--- a/include/kernels/device/composite_device.hpp
+++ b/include/kernels/device/composite_device.hpp
@@ -32,7 +32,6 @@ template <typename SrcWrapper, typename MaskWrapper, typename DstWrapper>
 __global__ void composite(SrcWrapper foreground, SrcWrapper background, MaskWrapper mask, DstWrapper output) {
     using namespace roccv::detail;  // For RangeCast, NumElements, etc.
     using src_type = typename SrcWrapper::ValueType;
-    using mask_type = typename MaskWrapper::ValueType;
     using dst_type = typename DstWrapper::ValueType;
     using work_type = MakeType<float, NumElements<src_type>>;
 
@@ -40,25 +39,21 @@ __global__ void composite(SrcWrapper foreground, SrcWrapper background, MaskWrap
     const int batch = blockIdx.z;
     if (y >= foreground.height() || batch >= output.batches()) return;
 
-    ApplyPackedTransform(
-        output, batch, y,
-        [=] __device__(int /*n*/, int /*yy*/, int /*x*/, src_type fgPixel, src_type bgPixel,
-                       mask_type maskPixel) -> dst_type {
-            // Range cast all input values to float to avoid overflowing values and keep them in the same range.
-            auto maskFactor = RangeCast<float1>(maskPixel);
-            auto fgVal = RangeCast<work_type>(fgPixel);
-            auto bgVal = RangeCast<work_type>(bgPixel);
+    ApplyPackedGather(output, batch, y, [=] __device__(int n, int yy, int x) -> dst_type {
+        // Range cast all input values to float to avoid overflowing values and keep them in the same range.
+        auto maskFactor = RangeCast<float1>(mask.at(n, yy, x, 0));
+        auto fgVal = RangeCast<work_type>(foreground.at(n, yy, x, 0));
+        auto bgVal = RangeCast<work_type>(background.at(n, yy, x, 0));
 
-            work_type result = bgVal + maskFactor.x * (fgVal - bgVal);
+        work_type result = bgVal + maskFactor.x * (fgVal - bgVal);
 
-            // If output has 4 channels, ensure the last channel (alpha) is always fully on.
-            if constexpr (NumElements<dst_type> == 4) {
-                return RangeCast<dst_type>((MakeType<float, 4>){result.x, result.y, result.z, 1.0f});
-            } else {
-                return RangeCast<dst_type>(result);
-            }
-        },
-        foreground, background, mask);
+        // If output has 4 channels, ensure the last channel (alpha) is always fully on.
+        if constexpr (NumElements<dst_type> == 4) {
+            return RangeCast<dst_type>((MakeType<float, 4>){result.x, result.y, result.z, 1.0f});
+        } else {
+            return RangeCast<dst_type>(result);
+        }
+    });
 }
 }  // namespace Device
 }  // namespace Kernels

--- a/include/kernels/device/composite_device.hpp
+++ b/include/kernels/device/composite_device.hpp
@@ -32,6 +32,7 @@ template <typename SrcWrapper, typename MaskWrapper, typename DstWrapper>
 __global__ void composite(SrcWrapper foreground, SrcWrapper background, MaskWrapper mask, DstWrapper output) {
     using namespace roccv::detail;  // For RangeCast, NumElements, etc.
     using src_type = typename SrcWrapper::ValueType;
+    using mask_type = typename MaskWrapper::ValueType;
     using dst_type = typename DstWrapper::ValueType;
     using work_type = MakeType<float, NumElements<src_type>>;
 
@@ -39,21 +40,25 @@ __global__ void composite(SrcWrapper foreground, SrcWrapper background, MaskWrap
     const int batch = blockIdx.z;
     if (y >= foreground.height() || batch >= output.batches()) return;
 
-    ApplyPackedGather(output, batch, y, [=] __device__(int n, int yy, int x) -> dst_type {
-        // Range cast all input values to float to avoid overflowing values and keep them in the same range.
-        auto maskFactor = RangeCast<float1>(mask.at(n, yy, x, 0));
-        auto fgVal = RangeCast<work_type>(foreground.at(n, yy, x, 0));
-        auto bgVal = RangeCast<work_type>(background.at(n, yy, x, 0));
+    ApplyPackedTransform(
+        output, batch, y,
+        [=] __device__(int /*n*/, int /*yy*/, int /*x*/, src_type fgPixel, src_type bgPixel,
+                       mask_type maskPixel) -> dst_type {
+            // Range cast all input values to float to avoid overflowing values and keep them in the same range.
+            auto maskFactor = RangeCast<float1>(maskPixel);
+            auto fgVal = RangeCast<work_type>(fgPixel);
+            auto bgVal = RangeCast<work_type>(bgPixel);
 
-        work_type result = bgVal + maskFactor.x * (fgVal - bgVal);
+            work_type result = bgVal + maskFactor.x * (fgVal - bgVal);
 
-        // If output has 4 channels, ensure the last channel (alpha) is always fully on.
-        if constexpr (NumElements<dst_type> == 4) {
-            return RangeCast<dst_type>((MakeType<float, 4>){result.x, result.y, result.z, 1.0f});
-        } else {
-            return RangeCast<dst_type>(result);
-        }
-    });
+            // If output has 4 channels, ensure the last channel (alpha) is always fully on.
+            if constexpr (NumElements<dst_type> == 4) {
+                return RangeCast<dst_type>((MakeType<float, 4>){result.x, result.y, result.z, 1.0f});
+            } else {
+                return RangeCast<dst_type>(result);
+            }
+        },
+        foreground, background, mask);
 }
 }  // namespace Device
 }  // namespace Kernels

--- a/include/kernels/device/composite_device.hpp
+++ b/include/kernels/device/composite_device.hpp
@@ -39,7 +39,7 @@ __global__ void composite(SrcWrapper foreground, SrcWrapper background, MaskWrap
     const int batch = blockIdx.z;
     if (y >= foreground.height() || batch >= output.batches()) return;
 
-    ApplyPackedRow(output, batch, y, [=] __device__(int n, int yy, int x) -> dst_type {
+    ApplyPackedGather(output, batch, y, [=] __device__(int n, int yy, int x) -> dst_type {
         // Range cast all input values to float to avoid overflowing values and keep them in the same range.
         auto maskFactor = RangeCast<float1>(mask.at(n, yy, x, 0));
         auto fgVal = RangeCast<work_type>(foreground.at(n, yy, x, 0));

--- a/include/kernels/device/convert_to_device.hpp
+++ b/include/kernels/device/convert_to_device.hpp
@@ -27,6 +27,7 @@ THE SOFTWARE.
 #include "core/detail/casting.hpp"
 #include "core/detail/type_traits.hpp"
 #include "core/wrappers/image_wrapper.hpp"
+#include "kernels/device/packed_apply.hpp"
 
 namespace Kernels {
 namespace Device {
@@ -36,15 +37,15 @@ __global__ void convert_to(SrcWrapper input, DstWrapper output, DT_AB alpha, DT_
     using dst_type = typename DstWrapper::ValueType;
     using work_type = MakeType<DT_AB, NumElements<dst_type>>;
 
-    const int x = threadIdx.x + blockIdx.x * blockDim.x;
     const int y = threadIdx.y + blockIdx.y * blockDim.y;
     const int batch = blockIdx.z;
+    if (y >= output.height() || batch >= output.batches()) return;
 
-    if (x >= output.width() || y >= output.height() || batch >= output.batches()) return;
-
-    work_type src_val = StaticCast<work_type>(input.at(batch, y, x, 0));
-    work_type result = alpha * src_val + beta;
-    output.at(batch, y, x, 0) = SaturateCast<dst_type>(result);
+    ApplyPackedRow(output, batch, y, [=] __device__(int n, int yy, int x) -> dst_type {
+        work_type src_val = StaticCast<work_type>(input.at(n, yy, x, 0));
+        work_type result = alpha * src_val + beta;
+        return SaturateCast<dst_type>(result);
+    });
 }
 }  // namespace Device
 }  // namespace Kernels

--- a/include/kernels/device/convert_to_device.hpp
+++ b/include/kernels/device/convert_to_device.hpp
@@ -41,7 +41,7 @@ __global__ void convert_to(SrcWrapper input, DstWrapper output, DT_AB alpha, DT_
     const int batch = blockIdx.z;
     if (y >= output.height() || batch >= output.batches()) return;
 
-    ApplyPackedRow(output, batch, y, [=] __device__(int n, int yy, int x) -> dst_type {
+    ApplyPackedGather(output, batch, y, [=] __device__(int n, int yy, int x) -> dst_type {
         work_type src_val = StaticCast<work_type>(input.at(n, yy, x, 0));
         work_type result = alpha * src_val + beta;
         return SaturateCast<dst_type>(result);

--- a/include/kernels/device/copy_make_border_device.hpp
+++ b/include/kernels/device/copy_make_border_device.hpp
@@ -23,6 +23,8 @@
 
 #include <hip/hip_runtime.h>
 
+#include "kernels/device/packed_apply.hpp"
+
 namespace Kernels {
 namespace Device {
 /**
@@ -38,13 +40,14 @@ namespace Device {
  */
 template <typename SrcDesc, typename DstDesc>
 __global__ void copy_make_border(SrcDesc src, DstDesc dst, int32_t top, int32_t left) {
-    int x = blockIdx.x * blockDim.x + threadIdx.x;
-    int y = blockIdx.y * blockDim.y + threadIdx.y;
-    int b = blockIdx.z;
+    using dst_type = typename DstDesc::ValueType;
 
-    if (x >= dst.width() || y >= dst.height() || b >= dst.batches()) return;
+    const int y = blockIdx.y * blockDim.y + threadIdx.y;
+    const int b = blockIdx.z;
+    if (y >= dst.height() || b >= dst.batches()) return;
 
-    dst.at(b, y, x, 0) = src.at(b, y - top, x - left, 0);
+    ApplyPackedRow(dst, b, y,
+                   [=] __device__(int n, int yy, int x) -> dst_type { return src.at(n, yy - top, x - left, 0); });
 }
 }  // namespace Device
 }  // namespace Kernels

--- a/include/kernels/device/copy_make_border_device.hpp
+++ b/include/kernels/device/copy_make_border_device.hpp
@@ -46,7 +46,7 @@ __global__ void copy_make_border(SrcDesc src, DstDesc dst, int32_t top, int32_t 
     const int b = blockIdx.z;
     if (y >= dst.height() || b >= dst.batches()) return;
 
-    ApplyPackedRow(dst, b, y,
+    ApplyPackedGather(dst, b, y,
                    [=] __device__(int n, int yy, int x) -> dst_type { return src.at(n, yy - top, x - left, 0); });
 }
 }  // namespace Device

--- a/include/kernels/device/custom_crop_device.hpp
+++ b/include/kernels/device/custom_crop_device.hpp
@@ -24,24 +24,22 @@ THE SOFTWARE.
 
 #include <hip/hip_runtime.h>
 
+#include "kernels/device/packed_apply.hpp"
 #include "operator_types.h"
 
 namespace Kernels {
 namespace Device {
 template <typename SrcWrapper, typename DstWrapper>
 __global__ void custom_crop(SrcWrapper input, DstWrapper output, roccv::Box_t cropRect) {
-    const int x = blockIdx.x * blockDim.x + threadIdx.x;
+    using dst_type = typename DstWrapper::ValueType;
+
     const int y = blockIdx.y * blockDim.y + threadIdx.y;
     const int b = blockIdx.z;
+    if (y >= cropRect.height || b >= output.batches()) return;
 
-    if (x >= cropRect.width || y >= cropRect.height || b >= output.batches()) return;
-
-    const int srcX = x + cropRect.x;
-    const int srcY = y + cropRect.y;
-    const int dstX = x;
-    const int dstY = y;
-
-    output.at(b, dstY, dstX, 0) = input.at(b, srcY, srcX, 0);
+    ApplyPackedRow(output, b, y, [=] __device__(int n, int yy, int x) -> dst_type {
+        return input.at(n, yy + cropRect.y, x + cropRect.x, 0);
+    });
 }
 }  // namespace Device
 }  // namespace Kernels

--- a/include/kernels/device/custom_crop_device.hpp
+++ b/include/kernels/device/custom_crop_device.hpp
@@ -37,7 +37,7 @@ __global__ void custom_crop(SrcWrapper input, DstWrapper output, roccv::Box_t cr
     const int b = blockIdx.z;
     if (y >= cropRect.height || b >= output.batches()) return;
 
-    ApplyPackedRow(output, b, y, [=] __device__(int n, int yy, int x) -> dst_type {
+    ApplyPackedGather(output, b, y, [=] __device__(int n, int yy, int x) -> dst_type {
         return input.at(n, yy + cropRect.y, x + cropRect.x, 0);
     });
 }

--- a/include/kernels/device/cvt_color_device.hpp
+++ b/include/kernels/device/cvt_color_device.hpp
@@ -28,6 +28,7 @@ THE SOFTWARE.
 #include <core/detail/swizzling.hpp>
 #include <core/detail/type_traits.hpp>
 
+#include "kernels/device/packed_apply.hpp"
 #include "operator_types.h"
 
 namespace Kernels::Device {
@@ -39,22 +40,21 @@ __global__ void rgb_or_bgr_to_yuv(SrcWrapper input, DstWrapper output, float del
 
     using work_type_t = MakeType<float, NumElements<T>>;
 
-    const auto x_idx = threadIdx.x + blockIdx.x * blockDim.x;
     const auto y_idx = threadIdx.y + blockIdx.y * blockDim.y;
     const auto z_idx = blockIdx.z;
+    if (y_idx >= output.height() || z_idx >= output.batches()) return;
 
-    if (x_idx >= output.width() || y_idx >= output.height()) return;
+    ApplyPackedRow(output, z_idx, y_idx, [=] __device__(int n, int yy, int x) -> T {
+        T val = Swizzle<S>(input.at(n, yy, x, 0));
+        work_type_t valF = StaticCast<work_type_t>(val);
 
-    T val = Swizzle<S>(input.at(z_idx, y_idx, x_idx, 0));
-    work_type_t valF = StaticCast<work_type_t>(val);
+        float y = valF.x * 0.299f + valF.y * 0.587f + valF.z * 0.114f;
+        float cr = (valF.x - y) * 0.877f + delta;
+        float cb = (valF.z - y) * 0.492f + delta;
 
-    float y = valF.x * 0.299f + valF.y * 0.587f + valF.z * 0.114f;
-    float cr = (valF.x - y) * 0.877f + delta;
-    float cb = (valF.z - y) * 0.492f + delta;
-
-    work_type_t out = make_float3(y, cb, cr);
-
-    output.at(z_idx, y_idx, x_idx, 0) = SaturateCast<T>(out);
+        work_type_t out = make_float3(y, cb, cr);
+        return SaturateCast<T>(out);
+    });
 }
 
 template <typename T, roccv::eSwizzle S, typename SrcWrapper, typename DstWrapper>
@@ -63,35 +63,34 @@ __global__ void yuv_to_rgb_or_bgr(SrcWrapper input, DstWrapper output, float del
     using namespace roccv::detail;
     using work_type_t = MakeType<float, NumElements<T>>;
 
-    const int x_idx = threadIdx.x + blockDim.x * blockIdx.x;
     const int y_idx = threadIdx.y + blockDim.y * blockIdx.y;
     const int z_idx = blockIdx.z;
+    if (y_idx >= output.height() || z_idx >= output.batches()) return;
 
-    if (x_idx >= output.width() || y_idx >= output.height()) return;
+    ApplyPackedRow(output, z_idx, y_idx, [=] __device__(int n, int yy, int x) -> T {
+        T val = input.at(n, yy, x, 0);
+        work_type_t valF = StaticCast<work_type_t>(val);
 
-    T val = input.at(z_idx, y_idx, x_idx, 0);
-    work_type_t valF = StaticCast<work_type_t>(val);
+        // Convert from YUV to RGB
+        work_type_t rgb = make_float3(valF.x + (valF.z - delta) * 1.140f,                                // R
+                                      valF.x + (valF.y - delta) * -0.395f + (valF.z - delta) * -0.581f,  // G
+                                      valF.x + (valF.y - delta) * 2.032f);                               // B
 
-    // Convert from YUV to RGB
-    work_type_t rgb = make_float3(valF.x + (valF.z - delta) * 1.140f,                                // R
-                                  valF.x + (valF.y - delta) * -0.395f + (valF.z - delta) * -0.581f,  // G
-                                  valF.x + (valF.y - delta) * 2.032f);                               // B
-
-    // Saturate cast to type T (this clamps to proper ranges)
-    output.at(z_idx, y_idx, x_idx, 0) = Swizzle<S>(SaturateCast<T>(rgb));
+        // Saturate cast to type T (this clamps to proper ranges)
+        return Swizzle<S>(SaturateCast<T>(rgb));
+    });
 }
 
 template <typename T, roccv::eSwizzle S, typename SrcWrapper, typename DstWrapper>
 __global__ void reorder(SrcWrapper input, DstWrapper output) {
     using namespace roccv::detail;
 
-    const int x_idx = threadIdx.x + blockDim.x * blockIdx.x;
     const int y_idx = threadIdx.y + blockDim.y * blockIdx.y;
     const int z_idx = blockIdx.z;
+    if (y_idx >= output.height() || z_idx >= output.batches()) return;
 
-    if (x_idx >= output.width() || y_idx >= output.height()) return;
-
-    output.at(z_idx, y_idx, x_idx, 0) = Swizzle<S>(input.at(z_idx, y_idx, x_idx, 0));
+    ApplyPackedRow(output, z_idx, y_idx,
+                   [=] __device__(int n, int yy, int x) -> T { return Swizzle<S>(input.at(n, yy, x, 0)); });
 }
 
 template <typename T, roccv::eSwizzle S, typename SrcWrapper, typename DstWrapper>
@@ -100,18 +99,17 @@ __global__ void rgb_or_bgr_to_grayscale(SrcWrapper input, DstWrapper output) {
     using work_type_t = MakeType<float, NumElements<T>>;
     using out_type_t = MakeType<BaseType<T>, 1>;  // Output must be single channel grayscale
 
-    const int x_idx = threadIdx.x + blockDim.x * blockIdx.x;
     const int y_idx = threadIdx.y + blockDim.y * blockIdx.y;
     const int z_idx = blockIdx.z;
+    if (y_idx >= output.height() || z_idx >= output.batches()) return;
 
-    if (x_idx >= output.width() || y_idx >= output.height()) return;
+    ApplyPackedRow(output, z_idx, y_idx, [=] __device__(int n, int yy, int x) -> out_type_t {
+        T inVal = Swizzle<S>(input.at(n, yy, x, 0));
+        work_type_t inValF = StaticCast<work_type_t>(inVal);
 
-    T inVal = Swizzle<S>(input.at(z_idx, y_idx, x_idx, 0));
-    work_type_t inValF = StaticCast<work_type_t>(inVal);
-
-    // Calculate luminance
-    float y = inValF.x * 0.299f + inValF.y * 0.587f + inValF.z * 0.114f;
-
-    output.at(z_idx, y_idx, x_idx, 0) = SaturateCast<out_type_t>(y);
+        // Calculate luminance
+        float y = inValF.x * 0.299f + inValF.y * 0.587f + inValF.z * 0.114f;
+        return SaturateCast<out_type_t>(y);
+    });
 }
 }  // namespace Kernels::Device

--- a/include/kernels/device/cvt_color_device.hpp
+++ b/include/kernels/device/cvt_color_device.hpp
@@ -44,7 +44,7 @@ __global__ void rgb_or_bgr_to_yuv(SrcWrapper input, DstWrapper output, float del
     const auto z_idx = blockIdx.z;
     if (y_idx >= output.height() || z_idx >= output.batches()) return;
 
-    ApplyPackedRow(output, z_idx, y_idx, [=] __device__(int n, int yy, int x) -> T {
+    ApplyPackedGather(output, z_idx, y_idx, [=] __device__(int n, int yy, int x) -> T {
         T val = Swizzle<S>(input.at(n, yy, x, 0));
         work_type_t valF = StaticCast<work_type_t>(val);
 
@@ -67,7 +67,7 @@ __global__ void yuv_to_rgb_or_bgr(SrcWrapper input, DstWrapper output, float del
     const int z_idx = blockIdx.z;
     if (y_idx >= output.height() || z_idx >= output.batches()) return;
 
-    ApplyPackedRow(output, z_idx, y_idx, [=] __device__(int n, int yy, int x) -> T {
+    ApplyPackedGather(output, z_idx, y_idx, [=] __device__(int n, int yy, int x) -> T {
         T val = input.at(n, yy, x, 0);
         work_type_t valF = StaticCast<work_type_t>(val);
 
@@ -89,7 +89,7 @@ __global__ void reorder(SrcWrapper input, DstWrapper output) {
     const int z_idx = blockIdx.z;
     if (y_idx >= output.height() || z_idx >= output.batches()) return;
 
-    ApplyPackedRow(output, z_idx, y_idx,
+    ApplyPackedGather(output, z_idx, y_idx,
                    [=] __device__(int n, int yy, int x) -> T { return Swizzle<S>(input.at(n, yy, x, 0)); });
 }
 
@@ -103,7 +103,7 @@ __global__ void rgb_or_bgr_to_grayscale(SrcWrapper input, DstWrapper output) {
     const int z_idx = blockIdx.z;
     if (y_idx >= output.height() || z_idx >= output.batches()) return;
 
-    ApplyPackedRow(output, z_idx, y_idx, [=] __device__(int n, int yy, int x) -> out_type_t {
+    ApplyPackedGather(output, z_idx, y_idx, [=] __device__(int n, int yy, int x) -> out_type_t {
         T inVal = Swizzle<S>(input.at(n, yy, x, 0));
         work_type_t inValF = StaticCast<work_type_t>(inVal);
 

--- a/include/kernels/device/flip_device.hpp
+++ b/include/kernels/device/flip_device.hpp
@@ -35,7 +35,7 @@ __global__ void flip(SrcWrapper input, DstWrapper output) {
     const int b = blockIdx.z;
     if (y >= output.height() || b >= output.batches()) return;
 
-    ApplyPackedRow(output, b, y, [=] __device__(int n, int yy, int x) -> dst_type {
+    ApplyPackedGather(output, b, y, [=] __device__(int n, int yy, int x) -> dst_type {
         int srcX = x;
         int srcY = yy;
         if constexpr (FlipType == eAxis::Y || FlipType == eAxis::BOTH) {

--- a/include/kernels/device/flip_device.hpp
+++ b/include/kernels/device/flip_device.hpp
@@ -23,29 +23,30 @@
 
 #include <hip/hip_runtime.h>
 
+#include "kernels/device/packed_apply.hpp"
 #include "operator_types.h"
 
 namespace Kernels::Device {
 template <eAxis FlipType, typename SrcWrapper, typename DstWrapper>
 __global__ void flip(SrcWrapper input, DstWrapper output) {
-    const int x = blockDim.x * blockIdx.x + threadIdx.x;
+    using dst_type = typename DstWrapper::ValueType;
+
     const int y = blockDim.y * blockIdx.y + threadIdx.y;
     const int b = blockIdx.z;
+    if (y >= output.height() || b >= output.batches()) return;
 
-    if (x >= output.width() || y >= output.height()) return;
-
-    int srcX = x;
-    int srcY = y;
-    if constexpr (FlipType == eAxis::Y || FlipType == eAxis::BOTH) {
-        // Flip along y-axis (horizontally)
-        srcX = output.width() - x - 1;
-    }
-
-    if constexpr (FlipType == eAxis::X || FlipType == eAxis::BOTH) {
-        // Flip along x-axis (vertically)
-        srcY = output.height() - y - 1;
-    }
-
-    output.at(b, y, x, 0) = input.at(b, srcY, srcX, 0);
+    ApplyPackedRow(output, b, y, [=] __device__(int n, int yy, int x) -> dst_type {
+        int srcX = x;
+        int srcY = yy;
+        if constexpr (FlipType == eAxis::Y || FlipType == eAxis::BOTH) {
+            // Flip along y-axis (horizontally)
+            srcX = output.width() - x - 1;
+        }
+        if constexpr (FlipType == eAxis::X || FlipType == eAxis::BOTH) {
+            // Flip along x-axis (vertically)
+            srcY = output.height() - yy - 1;
+        }
+        return input.at(n, srcY, srcX, 0);
+    });
 }
 }  // namespace Kernels::Device

--- a/include/kernels/device/gamma_contrast_device.hpp
+++ b/include/kernels/device/gamma_contrast_device.hpp
@@ -43,8 +43,7 @@ __global__ void gamma_contrast(SrcWrapper input, DstWrapper output, float gamma)
     if (y >= output.height() || batch >= output.batches()) return;
 
     ApplyPackedTransform(
-        output, batch, y,
-        [=] __device__(int /*n*/, int /*yy*/, int /*x*/, src_type srcPixel) -> dst_type {
+        input, output, batch, y, [=] __device__(src_type srcPixel, int /*n*/, int /*yy*/, int /*x*/) -> dst_type {
             auto inVal = (RangeCast<work_type>(srcPixel));
             work_type result = math::vpowf(inVal, gamma);
             if constexpr (NumElements<dst_type> == 4) {
@@ -52,8 +51,7 @@ __global__ void gamma_contrast(SrcWrapper input, DstWrapper output, float gamma)
             } else {
                 return RangeCast<dst_type>(result);
             }
-        },
-        input);
+        });
 }
 }  // namespace Device
 }  // namespace Kernels

--- a/include/kernels/device/gamma_contrast_device.hpp
+++ b/include/kernels/device/gamma_contrast_device.hpp
@@ -42,15 +42,16 @@ __global__ void gamma_contrast(SrcWrapper input, DstWrapper output, float gamma)
     const int batch = blockIdx.z;
     if (y >= output.height() || batch >= output.batches()) return;
 
-    ApplyPackedRow(output, batch, y, [=] __device__(int n, int yy, int x) -> dst_type {
-        auto inVal = (RangeCast<work_type>(input.at(n, yy, x, 0)));
-        work_type result = math::vpowf(inVal, gamma);
-        if constexpr (NumElements<dst_type> == 4) {
-            return RangeCast<dst_type>((MakeType<float, 4>){result.x, result.y, result.z, inVal.w});
-        } else {
-            return RangeCast<dst_type>(result);
-        }
-    });
+    ApplyPackedTransform(
+        input, output, batch, y, [=] __device__(src_type srcPixel, int /*n*/, int /*yy*/, int /*x*/) -> dst_type {
+            auto inVal = (RangeCast<work_type>(srcPixel));
+            work_type result = math::vpowf(inVal, gamma);
+            if constexpr (NumElements<dst_type> == 4) {
+                return RangeCast<dst_type>((MakeType<float, 4>){result.x, result.y, result.z, inVal.w});
+            } else {
+                return RangeCast<dst_type>(result);
+            }
+        });
 }
 }  // namespace Device
 }  // namespace Kernels

--- a/include/kernels/device/gamma_contrast_device.hpp
+++ b/include/kernels/device/gamma_contrast_device.hpp
@@ -23,9 +23,10 @@ THE SOFTWARE.
 #pragma once
 
 #include <hip/hip_runtime.h>
-#include "core/detail/math/vectorized_type_math.hpp"
-#include "core/detail/casting.hpp"
 
+#include "core/detail/casting.hpp"
+#include "core/detail/math/vectorized_type_math.hpp"
+#include "kernels/device/packed_apply.hpp"
 #include "operator_types.h"
 
 namespace Kernels {
@@ -36,21 +37,20 @@ __global__ void gamma_contrast(SrcWrapper input, DstWrapper output, float gamma)
     using src_type = typename SrcWrapper::ValueType;
     using dst_type = typename DstWrapper::ValueType;
     using work_type = MakeType<float, NumElements<src_type>>;
-    
-    const int x = threadIdx.x + blockIdx.x * blockDim.x;
+
     const int y = threadIdx.y + blockIdx.y * blockDim.y;
     const int batch = blockIdx.z;
+    if (y >= output.height() || batch >= output.batches()) return;
 
-    if (x >= output.width() || y >= output.height() || batch >= output.batches()) return;
-    
-    auto inVal = (RangeCast<work_type>(input.at(batch, y, x, 0)));
-    work_type result = math::vpowf(inVal, gamma);
-    if constexpr (NumElements<dst_type> == 4) {
-        output.at(batch, y, x, 0) = RangeCast<dst_type>((MakeType<float, 4>){result.x, result.y, result.z, inVal.w});
-    } else {
-        output.at(batch, y, x, 0) = RangeCast<dst_type>(result);
-    }
-    
+    ApplyPackedRow(output, batch, y, [=] __device__(int n, int yy, int x) -> dst_type {
+        auto inVal = (RangeCast<work_type>(input.at(n, yy, x, 0)));
+        work_type result = math::vpowf(inVal, gamma);
+        if constexpr (NumElements<dst_type> == 4) {
+            return RangeCast<dst_type>((MakeType<float, 4>){result.x, result.y, result.z, inVal.w});
+        } else {
+            return RangeCast<dst_type>(result);
+        }
+    });
 }
 }  // namespace Device
 }  // namespace Kernels

--- a/include/kernels/device/gamma_contrast_device.hpp
+++ b/include/kernels/device/gamma_contrast_device.hpp
@@ -43,7 +43,8 @@ __global__ void gamma_contrast(SrcWrapper input, DstWrapper output, float gamma)
     if (y >= output.height() || batch >= output.batches()) return;
 
     ApplyPackedTransform(
-        input, output, batch, y, [=] __device__(src_type srcPixel, int /*n*/, int /*yy*/, int /*x*/) -> dst_type {
+        output, batch, y,
+        [=] __device__(int /*n*/, int /*yy*/, int /*x*/, src_type srcPixel) -> dst_type {
             auto inVal = (RangeCast<work_type>(srcPixel));
             work_type result = math::vpowf(inVal, gamma);
             if constexpr (NumElements<dst_type> == 4) {
@@ -51,7 +52,8 @@ __global__ void gamma_contrast(SrcWrapper input, DstWrapper output, float gamma)
             } else {
                 return RangeCast<dst_type>(result);
             }
-        });
+        },
+        input);
 }
 }  // namespace Device
 }  // namespace Kernels

--- a/include/kernels/device/normalize_device.hpp
+++ b/include/kernels/device/normalize_device.hpp
@@ -50,7 +50,7 @@ __global__ void normalize(SrcWrapper input, BaseWrapper base, ScaleWrapper scale
     const int baseBatchIdx = base.batches() == 1 ? 0 : b;
     const int scaleBatchIdx = scale.batches() == 1 ? 0 : b;
 
-    ApplyPackedRow(output, b, y, [=] __device__(int n, int yy, int x) -> result_type {
+    ApplyPackedGather(output, b, y, [=] __device__(int n, int yy, int x) -> result_type {
         const int baseHeightIdx = base.height() == 1 ? 0 : yy;
         const int baseWidthIdx = base.width() == 1 ? 0 : x;
         const int scaleHeightIdx = scale.height() == 1 ? 0 : yy;

--- a/include/kernels/device/normalize_device.hpp
+++ b/include/kernels/device/normalize_device.hpp
@@ -32,6 +32,7 @@
 #include "core/detail/math/vectorized_type_math.hpp"
 #include "core/detail/type_traits.hpp"
 #include "core/detail/vector_utils.hpp"
+#include "kernels/device/packed_apply.hpp"
 
 namespace Kernels::Device {
 template <bool ScaleStddev, typename SrcWrapper, typename DstWrapper, typename ScaleWrapper, typename BaseWrapper>
@@ -41,35 +42,36 @@ __global__ void normalize(SrcWrapper input, BaseWrapper base, ScaleWrapper scale
     using work_type = MakeType<float, NumComponents<typename SrcWrapper::ValueType>>;
     using result_type = DstWrapper::ValueType;
 
-    const int x = blockDim.x * blockIdx.x + threadIdx.x;
     const int y = blockDim.y * blockIdx.y + threadIdx.y;
     const int b = blockIdx.z;
+    if (y >= output.height() || b >= output.batches()) return;
 
-    if (x >= output.width() || y >= output.height()) return;
-
+    // Batch-level broadcast indices are constant across the row; resolve them once per thread.
     const int baseBatchIdx = base.batches() == 1 ? 0 : b;
-    const int baseHeightIdx = base.height() == 1 ? 0 : y;
-    const int baseWidthIdx = base.width() == 1 ? 0 : x;
-
     const int scaleBatchIdx = scale.batches() == 1 ? 0 : b;
-    const int scaleHeightIdx = scale.height() == 1 ? 0 : y;
-    const int scaleWidthIdx = scale.width() == 1 ? 0 : x;
 
-    work_type scaleVal;
-    work_type s = StaticCast<work_type>(scale.at(scaleBatchIdx, scaleHeightIdx, scaleWidthIdx, 0));
-    if constexpr (ScaleStddev) {
-        // Scale tensor is the standard deviation, invert back to scale with epsilon added to avoid division by zero.
-        scaleVal = math::vrsqrtf((s * s) + epsilon);
-    } else {
-        // Scale tensor remains normal, calculate assuming the values in the scale tensor are indeed the scale
-        scaleVal = s;
-    }
-    work_type result = (StaticCast<work_type>(input.at(b, y, x, 0)) -
-                        StaticCast<work_type>(base.at(baseBatchIdx, baseHeightIdx, baseWidthIdx, 0))) *
-                           scaleVal * globalScale +
-                       shift;
+    ApplyPackedRow(output, b, y, [=] __device__(int n, int yy, int x) -> result_type {
+        const int baseHeightIdx = base.height() == 1 ? 0 : yy;
+        const int baseWidthIdx = base.width() == 1 ? 0 : x;
+        const int scaleHeightIdx = scale.height() == 1 ? 0 : yy;
+        const int scaleWidthIdx = scale.width() == 1 ? 0 : x;
 
-    // Saturate cast value back into the output tensor's value type
-    output.at(b, y, x, 0) = SaturateCast<result_type>(result);
+        work_type scaleVal;
+        work_type s = StaticCast<work_type>(scale.at(scaleBatchIdx, scaleHeightIdx, scaleWidthIdx, 0));
+        if constexpr (ScaleStddev) {
+            // Scale tensor is the standard deviation; invert to a scale with epsilon added to avoid division by zero.
+            scaleVal = math::vrsqrtf((s * s) + epsilon);
+        } else {
+            // Scale tensor remains normal, calculate assuming the values in the scale tensor are indeed the scale
+            scaleVal = s;
+        }
+        work_type result = (StaticCast<work_type>(input.at(n, yy, x, 0)) -
+                            StaticCast<work_type>(base.at(baseBatchIdx, baseHeightIdx, baseWidthIdx, 0))) *
+                               scaleVal * globalScale +
+                           shift;
+
+        // Saturate cast value back into the output tensor's value type
+        return SaturateCast<result_type>(result);
+    });
 }
 }  // namespace Kernels::Device

--- a/include/kernels/device/normalize_device.hpp
+++ b/include/kernels/device/normalize_device.hpp
@@ -39,7 +39,6 @@ template <bool ScaleStddev, typename SrcWrapper, typename DstWrapper, typename S
 __global__ void normalize(SrcWrapper input, BaseWrapper base, ScaleWrapper scale, DstWrapper output, float globalScale,
                           float shift, float epsilon) {
     using namespace roccv::detail;
-    using src_type = typename SrcWrapper::ValueType;
     using work_type = MakeType<float, NumComponents<typename SrcWrapper::ValueType>>;
     using result_type = DstWrapper::ValueType;
 
@@ -51,32 +50,28 @@ __global__ void normalize(SrcWrapper input, BaseWrapper base, ScaleWrapper scale
     const int baseBatchIdx = base.batches() == 1 ? 0 : b;
     const int scaleBatchIdx = scale.batches() == 1 ? 0 : b;
 
-    ApplyPackedTransform(
-        output, b, y,
-        [=] __device__(int /*n*/, int yy, int x, src_type srcPixel) -> result_type {
-            const int baseHeightIdx = base.height() == 1 ? 0 : yy;
-            const int baseWidthIdx = base.width() == 1 ? 0 : x;
-            const int scaleHeightIdx = scale.height() == 1 ? 0 : yy;
-            const int scaleWidthIdx = scale.width() == 1 ? 0 : x;
+    ApplyPackedGather(output, b, y, [=] __device__(int n, int yy, int x) -> result_type {
+        const int baseHeightIdx = base.height() == 1 ? 0 : yy;
+        const int baseWidthIdx = base.width() == 1 ? 0 : x;
+        const int scaleHeightIdx = scale.height() == 1 ? 0 : yy;
+        const int scaleWidthIdx = scale.width() == 1 ? 0 : x;
 
-            work_type scaleVal;
-            work_type s = StaticCast<work_type>(scale.at(scaleBatchIdx, scaleHeightIdx, scaleWidthIdx, 0));
-            if constexpr (ScaleStddev) {
-                // Scale tensor is the standard deviation; invert to a scale with epsilon added to avoid division by
-                // zero.
-                scaleVal = math::vrsqrtf((s * s) + epsilon);
-            } else {
-                // Scale tensor remains normal, calculate assuming the values in the scale tensor are indeed the scale
-                scaleVal = s;
-            }
-            work_type result = (StaticCast<work_type>(srcPixel) -
-                                StaticCast<work_type>(base.at(baseBatchIdx, baseHeightIdx, baseWidthIdx, 0))) *
-                                   scaleVal * globalScale +
-                               shift;
+        work_type scaleVal;
+        work_type s = StaticCast<work_type>(scale.at(scaleBatchIdx, scaleHeightIdx, scaleWidthIdx, 0));
+        if constexpr (ScaleStddev) {
+            // Scale tensor is the standard deviation; invert to a scale with epsilon added to avoid division by zero.
+            scaleVal = math::vrsqrtf((s * s) + epsilon);
+        } else {
+            // Scale tensor remains normal, calculate assuming the values in the scale tensor are indeed the scale
+            scaleVal = s;
+        }
+        work_type result = (StaticCast<work_type>(input.at(n, yy, x, 0)) -
+                            StaticCast<work_type>(base.at(baseBatchIdx, baseHeightIdx, baseWidthIdx, 0))) *
+                               scaleVal * globalScale +
+                           shift;
 
-            // Saturate cast value back into the output tensor's value type
-            return SaturateCast<result_type>(result);
-        },
-        input);
+        // Saturate cast value back into the output tensor's value type
+        return SaturateCast<result_type>(result);
+    });
 }
 }  // namespace Kernels::Device

--- a/include/kernels/device/normalize_device.hpp
+++ b/include/kernels/device/normalize_device.hpp
@@ -39,6 +39,7 @@ template <bool ScaleStddev, typename SrcWrapper, typename DstWrapper, typename S
 __global__ void normalize(SrcWrapper input, BaseWrapper base, ScaleWrapper scale, DstWrapper output, float globalScale,
                           float shift, float epsilon) {
     using namespace roccv::detail;
+    using src_type = typename SrcWrapper::ValueType;
     using work_type = MakeType<float, NumComponents<typename SrcWrapper::ValueType>>;
     using result_type = DstWrapper::ValueType;
 
@@ -50,28 +51,32 @@ __global__ void normalize(SrcWrapper input, BaseWrapper base, ScaleWrapper scale
     const int baseBatchIdx = base.batches() == 1 ? 0 : b;
     const int scaleBatchIdx = scale.batches() == 1 ? 0 : b;
 
-    ApplyPackedGather(output, b, y, [=] __device__(int n, int yy, int x) -> result_type {
-        const int baseHeightIdx = base.height() == 1 ? 0 : yy;
-        const int baseWidthIdx = base.width() == 1 ? 0 : x;
-        const int scaleHeightIdx = scale.height() == 1 ? 0 : yy;
-        const int scaleWidthIdx = scale.width() == 1 ? 0 : x;
+    ApplyPackedTransform(
+        output, b, y,
+        [=] __device__(int /*n*/, int yy, int x, src_type srcPixel) -> result_type {
+            const int baseHeightIdx = base.height() == 1 ? 0 : yy;
+            const int baseWidthIdx = base.width() == 1 ? 0 : x;
+            const int scaleHeightIdx = scale.height() == 1 ? 0 : yy;
+            const int scaleWidthIdx = scale.width() == 1 ? 0 : x;
 
-        work_type scaleVal;
-        work_type s = StaticCast<work_type>(scale.at(scaleBatchIdx, scaleHeightIdx, scaleWidthIdx, 0));
-        if constexpr (ScaleStddev) {
-            // Scale tensor is the standard deviation; invert to a scale with epsilon added to avoid division by zero.
-            scaleVal = math::vrsqrtf((s * s) + epsilon);
-        } else {
-            // Scale tensor remains normal, calculate assuming the values in the scale tensor are indeed the scale
-            scaleVal = s;
-        }
-        work_type result = (StaticCast<work_type>(input.at(n, yy, x, 0)) -
-                            StaticCast<work_type>(base.at(baseBatchIdx, baseHeightIdx, baseWidthIdx, 0))) *
-                               scaleVal * globalScale +
-                           shift;
+            work_type scaleVal;
+            work_type s = StaticCast<work_type>(scale.at(scaleBatchIdx, scaleHeightIdx, scaleWidthIdx, 0));
+            if constexpr (ScaleStddev) {
+                // Scale tensor is the standard deviation; invert to a scale with epsilon added to avoid division by
+                // zero.
+                scaleVal = math::vrsqrtf((s * s) + epsilon);
+            } else {
+                // Scale tensor remains normal, calculate assuming the values in the scale tensor are indeed the scale
+                scaleVal = s;
+            }
+            work_type result = (StaticCast<work_type>(srcPixel) -
+                                StaticCast<work_type>(base.at(baseBatchIdx, baseHeightIdx, baseWidthIdx, 0))) *
+                                   scaleVal * globalScale +
+                               shift;
 
-        // Saturate cast value back into the output tensor's value type
-        return SaturateCast<result_type>(result);
-    });
+            // Saturate cast value back into the output tensor's value type
+            return SaturateCast<result_type>(result);
+        },
+        input);
 }
 }  // namespace Kernels::Device

--- a/include/kernels/device/packed_apply.hpp
+++ b/include/kernels/device/packed_apply.hpp
@@ -23,8 +23,11 @@
 
 #include <hip/hip_runtime.h>
 
+#include <array>
 #include <cstdint>
+#include <tuple>
 #include <type_traits>
+#include <utility>
 
 #include "core/detail/type_traits.hpp"
 
@@ -164,25 +167,65 @@ __device__ __forceinline__ void ApplyPackedGather(DstWrapper output, int batch, 
     }
 }
 
+namespace detail {
+
 /**
- * @brief Transforms a contiguous run of PackWidth<Dst> pixels at row (batch, y), reading the primary input at the same
- * coordinates. Use this for "elementwise" kernels where the output pixel is a pure function of the input pixel at the
- * matching coordinate — both the load and the store can be packed.
- *
- * Each output pixel is computed by @p pixelFn(srcPixel, batch, y, x), where srcPixel is the primary input pixel at
- * (batch, y, x). The callable receives the coordinates as well, so it can still fetch any secondary/broadcast inputs
- * itself. The source run is widened to a single PackVec<Src> load only when the source pixels are contiguous, aligned,
- * and the source pack width matches the output run (the common same-pixel-size case); otherwise the source is read per
- * pixel. The store side follows the same packed/fallback logic as ApplyPackedGather.
- *
- * @tparam SrcWrapper Primary input wrapper type (must expose ValueType, at(), and isContiguousX()).
- * @tparam DstWrapper Output wrapper type (must expose ValueType, width(), at(), and isContiguousX()).
- * @tparam PixelFn Callable with signature `Dst(Src srcPixel, int batch, int y, int x)` returning the output pixel.
+ * @brief Reads a run of NIX consecutive pixels from one input wrapper at (batch, y, x0 .. x0+NIX-1). The load is
+ * widened to a single PackVec<Src> transaction when the input's pack width matches the run and the row is contiguous
+ * and aligned; otherwise each pixel is read individually. Inputs whose pack width does not match NIX (e.g. a
+ * type-changing or differently-shaped input) always take the per-pixel path.
  */
-template <typename SrcWrapper, typename DstWrapper, typename PixelFn>
-__device__ __forceinline__ void ApplyPackedTransform(SrcWrapper input, DstWrapper output, int batch, int y,
-                                                     PixelFn pixelFn) {
+template <int NIX, typename SrcWrapper>
+__device__ __forceinline__ std::array<typename SrcWrapper::ValueType, NIX> ReadPackedRun(SrcWrapper input, int batch,
+                                                                                         int y, int x0) {
     using Src = typename SrcWrapper::ValueType;
+    std::array<Src, NIX> run;
+
+    constexpr bool kPackedRead = PackEnabled<Src> && (PackWidth<Src> == NIX);
+    if constexpr (kPackedRead) {
+        Src* srcRow = &input.at(batch, y, x0, 0);
+        // Warp-uniform: contiguity/alignment is identical for every thread reading a given row.
+        if (input.isContiguousX() && (reinterpret_cast<uintptr_t>(srcRow) & PackAlignMask<Src>) == 0) {
+            PackVec<Src> v = PackLoad<Src>(srcRow);
+            for (int i = 0; i < NIX; i++) run[i] = UnpackPixel<Src>(v, i);
+        } else {
+            for (int i = 0; i < NIX; i++) run[i] = input.at(batch, y, x0 + i, 0);
+        }
+    } else {
+        for (int i = 0; i < NIX; i++) run[i] = input.at(batch, y, x0 + i, 0);
+    }
+    return run;
+}
+
+/**
+ * @brief Invokes pixelFn(batch, y, x, run0[i], run1[i], ...) by expanding the tuple of per-input runs at element i.
+ */
+template <typename PixelFn, typename Runs, std::size_t... Is>
+__device__ __forceinline__ auto InvokeAtIndex(PixelFn& pixelFn, int batch, int y, int x, int i, Runs& runs,
+                                              std::index_sequence<Is...>) {
+    return pixelFn(batch, y, x, std::get<Is>(runs)[i]...);
+}
+
+}  // namespace detail
+
+/**
+ * @brief Transforms a contiguous run of PackWidth<Dst> pixels at row (batch, y), reading one or more inputs at the same
+ * coordinates. Use this for "elementwise" kernels where the output pixel is a pure function of the input pixel(s) at
+ * the matching coordinate — both the loads and the store can be packed.
+ *
+ * Each output pixel is computed by @p pixelFn(batch, y, x, p0, p1, ...), where pN is the pixel from the Nth input at
+ * (batch, y, x). The callable receives the coordinates as well, so it can still fetch any secondary/broadcast inputs
+ * (which are not contiguous along x) itself. Each input is independently widened to a single PackVec load only when its
+ * pixels are contiguous, aligned, and its pack width matches the output run (the common same-pixel-size case);
+ * otherwise that input is read per pixel. The store side follows the same packed/fallback logic as ApplyPackedGather.
+ *
+ * @tparam DstWrapper Output wrapper type (must expose ValueType, width(), at(), and isContiguousX()).
+ * @tparam PixelFn Callable `Dst(int batch, int y, int x, Src0 p0, Src1 p1, ...)` returning the output pixel.
+ * @tparam SrcWrappers Input wrapper types (each must expose ValueType, at(), and isContiguousX()).
+ */
+template <typename DstWrapper, typename PixelFn, typename... SrcWrappers>
+__device__ __forceinline__ void ApplyPackedTransform(DstWrapper output, int batch, int y, PixelFn pixelFn,
+                                                     SrcWrappers... inputs) {
     using Dst = typename DstWrapper::ValueType;
     constexpr int NIX = PackWidth<Dst>;
 
@@ -191,27 +234,14 @@ __device__ __forceinline__ void ApplyPackedTransform(SrcWrapper input, DstWrappe
     if (x0 >= width) return;
 
     if (x0 + NIX - 1 < width) {
-        // Fast path: the whole NIX-wide run is in bounds.
-        Src src[NIX];
-
-        // A single wide source load only covers the run when the source pack holds exactly NIX pixels. This holds for
-        // same-pixel-size transforms; type-changing ones (e.g. uchar -> float) fall through to per-pixel reads.
-        constexpr bool kPackedRead = PackEnabled<Src> && (PackWidth<Src> == NIX);
-        if constexpr (kPackedRead) {
-            Src* srcRow = &input.at(batch, y, x0, 0);
-            // Warp-uniform: contiguity/alignment is identical for every thread reading a given row.
-            if (input.isContiguousX() && (reinterpret_cast<uintptr_t>(srcRow) & PackAlignMask<Src>) == 0) {
-                PackVec<Src> v = PackLoad<Src>(srcRow);
-                for (int i = 0; i < NIX; i++) src[i] = UnpackPixel<Src>(v, i);
-            } else {
-                for (int i = 0; i < NIX; i++) src[i] = input.at(batch, y, x0 + i, 0);
-            }
-        } else {
-            for (int i = 0; i < NIX; i++) src[i] = input.at(batch, y, x0 + i, 0);
-        }
+        // Fast path: read each input's NIX-wide run (packed per-input where possible), compute, then packed-store.
+        auto runs = std::make_tuple(detail::ReadPackedRun<NIX>(inputs, batch, y, x0)...);
 
         Dst pack[NIX];
-        for (int i = 0; i < NIX; i++) pack[i] = pixelFn(src[i], batch, y, x0 + i);
+        for (int i = 0; i < NIX; i++) {
+            pack[i] =
+                detail::InvokeAtIndex(pixelFn, batch, y, x0 + i, i, runs, std::index_sequence_for<SrcWrappers...>{});
+        }
 
         if constexpr (PackEnabled<Dst>) {
             Dst* dstRow = &output.at(batch, y, x0, 0);
@@ -229,7 +259,7 @@ __device__ __forceinline__ void ApplyPackedTransform(SrcWrapper input, DstWrappe
         for (int i = 0; i < NIX; i++) {
             const int x = x0 + i;
             if (x >= width) break;
-            output.at(batch, y, x, 0) = pixelFn(input.at(batch, y, x, 0), batch, y, x);
+            output.at(batch, y, x, 0) = pixelFn(batch, y, x, inputs.at(batch, y, x, 0)...);
         }
     }
 }

--- a/include/kernels/device/packed_apply.hpp
+++ b/include/kernels/device/packed_apply.hpp
@@ -97,7 +97,7 @@ __device__ __forceinline__ void ApplyPackedRow(DstWrapper output, int batch, int
     if (x0 + NIX - 1 < width) {
         // Fast path: the whole NIX-wide run is in bounds.
         T pack[NIX];
-#pragma unroll
+
         for (int i = 0; i < NIX; i++) pack[i] = pixelFn(batch, y, x0 + i);
 
         if constexpr (PackEnabled<T>) {
@@ -106,16 +106,14 @@ __device__ __forceinline__ void ApplyPackedRow(DstWrapper output, int batch, int
             if (output.isContiguousX() && (reinterpret_cast<uintptr_t>(dstRow) & PackAlignMask<T>) == 0) {
                 *reinterpret_cast<PackVec<T>*>(dstRow) = reinterpret_cast<const PackVec<T>&>(pack);
             } else {
-#pragma unroll
                 for (int i = 0; i < NIX; i++) output.at(batch, y, x0 + i, 0) = pack[i];
             }
         } else {
-#pragma unroll
             for (int i = 0; i < NIX; i++) output.at(batch, y, x0 + i, 0) = pack[i];
         }
     } else {
         // Tail: ragged right edge where fewer than NIX pixels remain.
-#pragma unroll
+
         for (int i = 0; i < NIX; i++) {
             const int x = x0 + i;
             if (x >= width) break;

--- a/include/kernels/device/packed_apply.hpp
+++ b/include/kernels/device/packed_apply.hpp
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#pragma once
+
+#include <hip/hip_runtime.h>
+
+#include <cstdint>
+#include <type_traits>
+
+#include "core/detail/type_traits.hpp"
+
+/**
+ * @file packed_apply.hpp
+ * @brief Reusable vector-pack helpers for per-output-pixel ("elementwise") device kernels.
+ *
+ * Many operators compute one output pixel independently from the input(s) at the same (or a per-pixel-derived) source
+ * coordinate. When the output is an interleaved image, consecutive pixels along x are contiguous in memory, so several
+ * of them can be written with a single wide, aligned store. This removes the sub-word store penalty paid by small pixel
+ * types (notably 3-byte uchar3) and amortizes per-thread setup, which is a large win for these memory-bound kernels.
+ *
+ * Usage: a kernel computes its row/batch indices, bounds-checks them, then calls ApplyPackedRow() with a callable that
+ * returns the output pixel for a given (batch, y, x). The grid must be launched with PackedGrid<DstType>() so that each
+ * thread's x-index maps to a run of PackWidth<DstType> pixels.
+ */
+
+namespace Kernels::Device {
+
+/**
+ * @brief Wide store type used to write a run of output pixels in one transaction. A 3-element pixel is written as a
+ * uint3 (12 bytes); everything else uses uint4 (16 bytes).
+ */
+template <typename T>
+using PackVec = std::conditional_t<roccv::detail::NumElements<T> == 3, uint3, uint4>;
+
+/**
+ * @brief Whether a run of T pixels can be written as a single PackVec<T> store: the pack must hold a whole number of
+ * pixels and be at least one pixel wide. This excludes pixel types as large as or larger than the pack (e.g. double3 at
+ * 24 bytes vs a 12-byte uint3), which simply fall back to per-pixel stores.
+ */
+template <typename T>
+constexpr bool PackEnabled = (sizeof(PackVec<T>) >= sizeof(T)) && (sizeof(PackVec<T>) % sizeof(T) == 0);
+
+/**
+ * @brief Number of pixels of type T produced per thread. When packing applies this is how many pixels fit in one
+ * PackVec<T> (uchar1->16, uchar3->4, uchar4->4, float1->4, float3->1, float4->1); otherwise it is 1.
+ */
+template <typename T>
+constexpr int PackWidth = PackEnabled<T> ? static_cast<int>(sizeof(PackVec<T>) / sizeof(T)) : 1;
+
+/**
+ * @brief Byte alignment required to issue a PackVec<T> store. A uint3 is only 4-byte aligned (three uints); a uint4 is
+ * 16-byte aligned.
+ */
+template <typename T>
+constexpr uintptr_t PackAlignMask =
+    (sizeof(PackVec<T>) == sizeof(uint3) ? sizeof(unsigned int) : sizeof(PackVec<T>)) - 1;
+
+/**
+ * @brief Produces a contiguous run of PackWidth<T> output pixels at row (batch, y) and writes them.
+ *
+ * Each pixel is computed by @p pixelFn(batch, y, x). When the run is fully in bounds, the destination is contiguous in
+ * x, and the row is suitably aligned, the run is written with a single PackVec<T> vector store; otherwise it falls back
+ * to coordinate-correct per-pixel stores. The fallback paths use the wrapper's own indexing, so the result is correct
+ * for any layout/stride — only the fast path requires contiguity, which it checks at runtime.
+ *
+ * @tparam DstWrapper Output wrapper type (must expose ValueType, width(), at(), and isContiguousX()).
+ * @tparam PixelFn Callable with signature `T(int batch, int y, int x)` returning the output pixel.
+ */
+template <typename DstWrapper, typename PixelFn>
+__device__ __forceinline__ void ApplyPackedRow(DstWrapper output, int batch, int y, PixelFn pixelFn) {
+    using T = typename DstWrapper::ValueType;
+    constexpr int NIX = PackWidth<T>;
+
+    const int width = output.width();
+    const int x0 = (blockIdx.x * blockDim.x + threadIdx.x) * NIX;
+    if (x0 >= width) return;
+
+    if (x0 + NIX - 1 < width) {
+        // Fast path: the whole NIX-wide run is in bounds.
+        T pack[NIX];
+#pragma unroll
+        for (int i = 0; i < NIX; i++) pack[i] = pixelFn(batch, y, x0 + i);
+
+        if constexpr (PackEnabled<T>) {
+            T* dstRow = &output.at(batch, y, x0, 0);
+            // Alignment/contiguity is identical for every thread writing a given row, so this branch is warp-uniform.
+            if (output.isContiguousX() && (reinterpret_cast<uintptr_t>(dstRow) & PackAlignMask<T>) == 0) {
+                *reinterpret_cast<PackVec<T>*>(dstRow) = reinterpret_cast<const PackVec<T>&>(pack);
+            } else {
+#pragma unroll
+                for (int i = 0; i < NIX; i++) output.at(batch, y, x0 + i, 0) = pack[i];
+            }
+        } else {
+#pragma unroll
+            for (int i = 0; i < NIX; i++) output.at(batch, y, x0 + i, 0) = pack[i];
+        }
+    } else {
+        // Tail: ragged right edge where fewer than NIX pixels remain.
+#pragma unroll
+        for (int i = 0; i < NIX; i++) {
+            const int x = x0 + i;
+            if (x >= width) break;
+            output.at(batch, y, x, 0) = pixelFn(batch, y, x);
+        }
+    }
+}
+
+/**
+ * @brief Default thread-block shape for packed elementwise kernels.
+ */
+__host__ inline dim3 PackedBlock() { return dim3(32, 4, 1); }
+
+/**
+ * @brief Grid for a packed elementwise launch: the x dimension covers ceil(width / (block.x * PackWidth<T>)) so each
+ * thread handles a PackWidth<T>-pixel run; y/z map to rows and batches as usual.
+ *
+ * @tparam T Output pixel type (determines the pack width).
+ */
+template <typename T>
+__host__ inline dim3 PackedGrid(int64_t width, int64_t height, int64_t batches, dim3 block) {
+    const int64_t nix = PackWidth<T>;
+    return dim3(static_cast<unsigned int>((width + block.x * nix - 1) / (block.x * nix)),
+                static_cast<unsigned int>((height + block.y - 1) / block.y), static_cast<unsigned int>(batches));
+}
+
+}  // namespace Kernels::Device

--- a/include/kernels/device/packed_apply.hpp
+++ b/include/kernels/device/packed_apply.hpp
@@ -30,63 +30,35 @@
 
 /**
  * @file packed_apply.hpp
- * @brief Reusable vector-pack helpers for per-output-pixel ("elementwise") device kernels.
+ * @brief Wide-vector store helpers for device kernels.
  *
- * Many operators compute one output pixel independently from the input(s) at the same (or a per-pixel-derived) source
- * coordinate. When the output is an interleaved image, consecutive pixels along x are contiguous in memory, so several
- * of them can be written with a single wide, aligned store. This removes the sub-word store penalty paid by small pixel
- * types (notably 3-byte uchar3) and amortizes per-thread setup, which is a large win for these memory-bound kernels.
- *
- * Usage: a kernel computes its row/batch indices, bounds-checks them, then calls ApplyPackedGather() (scattered reads,
- * packed store) or ApplyPackedTransform() (packed load and store) with a callable that returns the output pixel. The
- * grid must be launched with PackedGrid<DstType>() so that each thread's x-index maps to a run of PackWidth<DstType>
- * pixels.
+ * Each thread handles a PackWidth<DstType>-pixel run. Call ApplyPackedGather() when source reads are scattered
+ * (gather/geometric kernels) or ApplyPackedTransform() when input and output share the same coordinates (elementwise
+ * kernels). Launch with PackedGrid<DstType>() and PackedBlock().
  */
 
 namespace Kernels::Device {
 
-/**
- * @brief Wide store type used to write a run of output pixels in one transaction. A 3-element pixel is written as a
- * uint3 (12 bytes); everything else uses uint4 (16 bytes).
- */
+/** @brief Wide store type for a run of T pixels: `uint3` for 3-channel types, `uint4` otherwise. */
 template <typename T>
 using PackVec = std::conditional_t<roccv::detail::NumElements<T> == 3, uint3, uint4>;
 
-/**
- * @brief Whether a run of T pixels can be written as a single PackVec<T> store: the pack must hold a whole number of
- * pixels and be at least one pixel wide. This excludes pixel types as large as or larger than the pack (e.g. double3 at
- * 24 bytes vs a 12-byte uint3), which simply fall back to per-pixel stores.
- */
+/** @brief True when `PackVec<T>` holds a whole number of T pixels and is at least one pixel wide. */
 template <typename T>
 constexpr bool PackEnabled = (sizeof(PackVec<T>) >= sizeof(T)) && (sizeof(PackVec<T>) % sizeof(T) == 0);
 
-/**
- * @brief Number of pixels of type T produced per thread. When packing applies this is how many pixels fit in one
- * PackVec<T> (uchar1->16, uchar3->4, uchar4->4, float1->4, float3->1, float4->1); otherwise it is 1.
- */
+/** @brief Number of T pixels handled per thread: `sizeof(PackVec<T>) / sizeof(T)` when packing applies, else 1. */
 template <typename T>
 constexpr int PackWidth = PackEnabled<T> ? static_cast<int>(sizeof(PackVec<T>) / sizeof(T)) : 1;
 
-/**
- * @brief Byte alignment required to issue a PackVec<T> store. A uint3 is only 4-byte aligned (three uints); a uint4 is
- * 16-byte aligned.
- */
+/** @brief Address mask for a `PackVec<T>` access: `alignof - 1`. Zero means the address meets the alignment requirement
+ * (4-byte for `uint3`, 16-byte for `uint4`). */
 template <typename T>
-constexpr uintptr_t PackAlignMask =
-    (sizeof(PackVec<T>) == sizeof(uint3) ? sizeof(unsigned int) : sizeof(PackVec<T>)) - 1;
+constexpr uintptr_t PackAlignMask = alignof(PackVec<T>) - 1;
 
 /**
- * @brief Explicit, type-punning-safe pack/unpack primitives.
- *
- * These exist so the wide-vector load/store is expressed as a defined byte copy rather than a glvalue access through an
- * unrelated type. `__builtin_memcpy` of a compile-time-constant size lowers to a single wide transaction while keeping
- * strict-aliasing intact; `__builtin_assume_aligned` is what lets the compiler widen the access (a bare uchar3* is only
- * 1-byte aligned and would otherwise emit byte-wise transfers). Callers must still gate these on PackAlignMask<T> — the
- * builtins fix the type-punning, not the alignment precondition.
- */
-
-/**
- * @brief Loads a run of PackWidth<T> contiguous pixels at @p row as one wide PackVec<T> transaction.
+ * @brief Loads `PackWidth<T>` contiguous pixels as a single `PackVec<T>` transaction. Caller must ensure alignment.
+ * @param row Pointer to the first pixel in the run. Must be `PackVec<T>`-aligned.
  */
 template <typename T>
 __device__ __forceinline__ PackVec<T> PackLoad(const T* row) {
@@ -96,7 +68,9 @@ __device__ __forceinline__ PackVec<T> PackLoad(const T* row) {
 }
 
 /**
- * @brief Stores a run of PackWidth<T> pixels to @p dst as one wide PackVec<T> transaction.
+ * @brief Stores `PackWidth<T>` pixels as a single `PackVec<T>` transaction. Caller must ensure alignment.
+ * @param dst    Destination pointer. Must be `PackVec<T>`-aligned.
+ * @param pixels Array of `PackWidth<T>` pixels to write.
  */
 template <typename T>
 __device__ __forceinline__ void PackStore(T* dst, const T (&pixels)[PackWidth<T>]) {
@@ -104,8 +78,9 @@ __device__ __forceinline__ void PackStore(T* dst, const T (&pixels)[PackWidth<T>
 }
 
 /**
- * @brief Extracts pixel @p i from a loaded PackVec<T>. Uses a byte-offset copy, so it is correct even when pixels do
- * not align to the 32-bit lanes of the pack (e.g. 3-byte uchar3 pixels straddling uint3 lane boundaries).
+ * @brief Extracts pixel @p i from a loaded `PackVec<T>` using a byte-offset copy.
+ * @param v Packed vector loaded by `PackLoad`.
+ * @param i Pixel index within the pack, in `[0, PackWidth<T>)`.
  */
 template <typename T>
 __device__ __forceinline__ T UnpackPixel(const PackVec<T>& v, int i) {
@@ -115,17 +90,74 @@ __device__ __forceinline__ T UnpackPixel(const PackVec<T>& v, int i) {
 }
 
 /**
- * @brief Produces a contiguous run of PackWidth<T> output pixels at row (batch, y) and writes them. Use this for
- * "gather" kernels whose source reads are scattered by interpolation/border math and therefore cannot be widened — only
- * the store is packed.
+ * @brief Reads @p N contiguous pixels at (batch, y, x0) into @p out. The whole run must be in bounds.
  *
- * Each pixel is computed by @p pixelFn(batch, y, x). When the run is fully in bounds, the destination is contiguous in
- * x, and the row is suitably aligned, the run is written with a single PackVec<T> vector store; otherwise it falls back
- * to coordinate-correct per-pixel stores. The fallback paths use the wrapper's own indexing, so the result is correct
- * for any layout/stride — only the fast path requires contiguity, which it checks at runtime.
+ * Issues a single `PackVec<Src>` load when the source pixels fill the run exactly and the row is aligned and
+ * contiguous; otherwise reads per pixel through the wrapper.
  *
- * @tparam DstWrapper Output wrapper type (must expose ValueType, width(), at(), and isContiguousX()).
- * @tparam PixelFn Callable with signature `T(int batch, int y, int x)` returning the output pixel.
+ * @tparam N          Number of pixels to read.
+ * @tparam SrcWrapper Input wrapper (must expose `ValueType`, `at()`, `isContiguousX()`).
+ * @param input  Input image wrapper.
+ * @param batch  Batch index of the current row.
+ * @param y      Row index of the current row.
+ * @param x0     First pixel index in the run.
+ * @param out    Destination array receiving the @p N pixels.
+ */
+template <int N, typename SrcWrapper>
+__device__ __forceinline__ void PackLoadRow(SrcWrapper input, int batch, int y, int x0,
+                                            typename SrcWrapper::ValueType (&out)[N]) {
+    using Src = typename SrcWrapper::ValueType;
+    if constexpr (PackEnabled<Src> && PackWidth<Src> == N) {
+        Src* srcRow = &input.at(batch, y, x0, 0);
+        if (input.isContiguousX() && (reinterpret_cast<uintptr_t>(srcRow) & PackAlignMask<Src>) == 0) {
+            PackVec<Src> v = PackLoad<Src>(srcRow);
+            for (int i = 0; i < N; i++) out[i] = UnpackPixel<Src>(v, i);
+            return;
+        }
+    }
+    for (int i = 0; i < N; i++) out[i] = input.at(batch, y, x0 + i, 0);
+}
+
+/**
+ * @brief Writes @p N contiguous pixels from @p pack to (batch, y, x0). The whole run must be in bounds.
+ *
+ * Issues a single `PackVec<T>` store when packing is enabled and the row is aligned and contiguous; otherwise writes
+ * per pixel through the wrapper.
+ *
+ * @tparam N          Number of pixels to write (must equal `PackWidth<T>` when packing is enabled).
+ * @tparam DstWrapper Output wrapper (must expose `ValueType`, `at()`, `isContiguousX()`).
+ * @param output Output image wrapper.
+ * @param batch  Batch index of the current row.
+ * @param y      Row index of the current row.
+ * @param x0     First pixel index in the run.
+ * @param pack   Array of @p N pixels to write.
+ */
+template <int N, typename DstWrapper>
+__device__ __forceinline__ void PackStoreRow(DstWrapper output, int batch, int y, int x0,
+                                             const typename DstWrapper::ValueType (&pack)[N]) {
+    using T = typename DstWrapper::ValueType;
+    if constexpr (PackEnabled<T>) {
+        T* dstRow = &output.at(batch, y, x0, 0);
+        if (output.isContiguousX() && (reinterpret_cast<uintptr_t>(dstRow) & PackAlignMask<T>) == 0) {
+            PackStore<T>(dstRow, pack);
+            return;
+        }
+    }
+    for (int i = 0; i < N; i++) output.at(batch, y, x0 + i, 0) = pack[i];
+}
+
+/**
+ * @brief Writes a `PackWidth<T>`-pixel run at (batch, y, x0) using scattered per-pixel reads and a packed store.
+ *
+ * @p pixelFn is called as `pixelFn(batch, y, x)` for each pixel in the run. On aligned, contiguous rows the run is
+ * written as a single `PackVec<T>` store; otherwise falls back to per-pixel writes.
+ *
+ * @tparam DstWrapper Output wrapper (must expose `ValueType`, `width()`, `at()`, `isContiguousX()`).
+ * @tparam PixelFn   `T(int batch, int y, int x)`
+ * @param output   Output image wrapper.
+ * @param batch    Batch index of the current row.
+ * @param y        Row index of the current row.
+ * @param pixelFn  Callable returning the output pixel for a given (batch, y, x).
  */
 template <typename DstWrapper, typename PixelFn>
 __device__ __forceinline__ void ApplyPackedGather(DstWrapper output, int batch, int y, PixelFn pixelFn) {
@@ -139,23 +171,10 @@ __device__ __forceinline__ void ApplyPackedGather(DstWrapper output, int batch, 
     if (x0 + NIX - 1 < width) {
         // Fast path: the whole NIX-wide run is in bounds.
         T pack[NIX];
-
         for (int i = 0; i < NIX; i++) pack[i] = pixelFn(batch, y, x0 + i);
-
-        if constexpr (PackEnabled<T>) {
-            T* dstRow = &output.at(batch, y, x0, 0);
-            // Alignment/contiguity is identical for every thread writing a given row, so this branch is warp-uniform.
-            if (output.isContiguousX() && (reinterpret_cast<uintptr_t>(dstRow) & PackAlignMask<T>) == 0) {
-                PackStore<T>(dstRow, pack);
-            } else {
-                for (int i = 0; i < NIX; i++) output.at(batch, y, x0 + i, 0) = pack[i];
-            }
-        } else {
-            for (int i = 0; i < NIX; i++) output.at(batch, y, x0 + i, 0) = pack[i];
-        }
+        PackStoreRow(output, batch, y, x0, pack);
     } else {
         // Tail: ragged right edge where fewer than NIX pixels remain.
-
         for (int i = 0; i < NIX; i++) {
             const int x = x0 + i;
             if (x >= width) break;
@@ -165,19 +184,19 @@ __device__ __forceinline__ void ApplyPackedGather(DstWrapper output, int batch, 
 }
 
 /**
- * @brief Transforms a contiguous run of PackWidth<Dst> pixels at row (batch, y), reading the primary input at the same
- * coordinates. Use this for "elementwise" kernels where the output pixel is a pure function of the input pixel at the
- * matching coordinate — both the load and the store can be packed.
+ * @brief Reads a `PackWidth<Dst>`-pixel run from @p input and writes the transformed run to @p output at (batch, y).
  *
- * Each output pixel is computed by @p pixelFn(srcPixel, batch, y, x), where srcPixel is the primary input pixel at
- * (batch, y, x). The callable receives the coordinates as well, so it can still fetch any secondary/broadcast inputs
- * itself. The source run is widened to a single PackVec<Src> load only when the source pixels are contiguous, aligned,
- * and the source pack width matches the output run (the common same-pixel-size case); otherwise the source is read per
- * pixel. The store side follows the same packed/fallback logic as ApplyPackedGather.
+ * @p pixelFn is called as `pixelFn(srcPixel, batch, y, x)` for each pixel. Both the load and the store use packed
+ * `PackVec` transactions when the row is aligned and contiguous; otherwise fall back to per-pixel accesses.
  *
- * @tparam SrcWrapper Primary input wrapper type (must expose ValueType, at(), and isContiguousX()).
- * @tparam DstWrapper Output wrapper type (must expose ValueType, width(), at(), and isContiguousX()).
- * @tparam PixelFn Callable with signature `Dst(Src srcPixel, int batch, int y, int x)` returning the output pixel.
+ * @tparam SrcWrapper Input wrapper (must expose `ValueType`, `at()`, `isContiguousX()`).
+ * @tparam DstWrapper Output wrapper (must expose `ValueType`, `width()`, `at()`, `isContiguousX()`).
+ * @tparam PixelFn   `Dst(Src srcPixel, int batch, int y, int x)`
+ * @param input    Input image wrapper.
+ * @param output   Output image wrapper.
+ * @param batch    Batch index of the current row.
+ * @param y        Row index of the current row.
+ * @param pixelFn  Callable returning the output pixel given the source pixel and its (batch, y, x) coordinates.
  */
 template <typename SrcWrapper, typename DstWrapper, typename PixelFn>
 __device__ __forceinline__ void ApplyPackedTransform(SrcWrapper input, DstWrapper output, int batch, int y,
@@ -193,39 +212,14 @@ __device__ __forceinline__ void ApplyPackedTransform(SrcWrapper input, DstWrappe
     if (x0 + NIX - 1 < width) {
         // Fast path: the whole NIX-wide run is in bounds.
         Src src[NIX];
-
-        // A single wide source load only covers the run when the source pack holds exactly NIX pixels. This holds for
-        // same-pixel-size transforms; type-changing ones (e.g. uchar -> float) fall through to per-pixel reads.
-        constexpr bool kPackedRead = PackEnabled<Src> && (PackWidth<Src> == NIX);
-        if constexpr (kPackedRead) {
-            Src* srcRow = &input.at(batch, y, x0, 0);
-            // Warp-uniform: contiguity/alignment is identical for every thread reading a given row.
-            if (input.isContiguousX() && (reinterpret_cast<uintptr_t>(srcRow) & PackAlignMask<Src>) == 0) {
-                PackVec<Src> v = PackLoad<Src>(srcRow);
-                for (int i = 0; i < NIX; i++) src[i] = UnpackPixel<Src>(v, i);
-            } else {
-                for (int i = 0; i < NIX; i++) src[i] = input.at(batch, y, x0 + i, 0);
-            }
-        } else {
-            for (int i = 0; i < NIX; i++) src[i] = input.at(batch, y, x0 + i, 0);
-        }
+        PackLoadRow(input, batch, y, x0, src);
 
         Dst pack[NIX];
         for (int i = 0; i < NIX; i++) pack[i] = pixelFn(src[i], batch, y, x0 + i);
 
-        if constexpr (PackEnabled<Dst>) {
-            Dst* dstRow = &output.at(batch, y, x0, 0);
-            if (output.isContiguousX() && (reinterpret_cast<uintptr_t>(dstRow) & PackAlignMask<Dst>) == 0) {
-                PackStore<Dst>(dstRow, pack);
-            } else {
-                for (int i = 0; i < NIX; i++) output.at(batch, y, x0 + i, 0) = pack[i];
-            }
-        } else {
-            for (int i = 0; i < NIX; i++) output.at(batch, y, x0 + i, 0) = pack[i];
-        }
+        PackStoreRow(output, batch, y, x0, pack);
     } else {
         // Tail: ragged right edge where fewer than NIX pixels remain.
-
         for (int i = 0; i < NIX; i++) {
             const int x = x0 + i;
             if (x >= width) break;
@@ -234,16 +228,18 @@ __device__ __forceinline__ void ApplyPackedTransform(SrcWrapper input, DstWrappe
     }
 }
 
-/**
- * @brief Default thread-block shape for packed elementwise kernels.
- */
+/** @brief Default thread-block shape for packed kernels. */
 __host__ inline dim3 PackedBlock() { return dim3(32, 4, 1); }
 
 /**
- * @brief Grid for a packed elementwise launch: the x dimension covers ceil(width / (block.x * PackWidth<T>)) so each
- * thread handles a PackWidth<T>-pixel run; y/z map to rows and batches as usual.
+ * @brief Grid dimensions for a packed kernel launch: x covers `ceil(width / (block.x * PackWidth<T>))`,
+ * y covers rows, z covers batches.
  *
- * @tparam T Output pixel type (determines the pack width).
+ * @tparam T       Output pixel type.
+ * @param width   Image width in pixels.
+ * @param height  Image height in pixels.
+ * @param batches Batch size.
+ * @param block   Thread-block dimensions, typically from `PackedBlock()`.
  */
 template <typename T>
 __host__ inline dim3 PackedGrid(int64_t width, int64_t height, int64_t batches, dim3 block) {

--- a/include/kernels/device/packed_apply.hpp
+++ b/include/kernels/device/packed_apply.hpp
@@ -23,11 +23,8 @@
 
 #include <hip/hip_runtime.h>
 
-#include <array>
 #include <cstdint>
-#include <tuple>
 #include <type_traits>
-#include <utility>
 
 #include "core/detail/type_traits.hpp"
 
@@ -167,65 +164,25 @@ __device__ __forceinline__ void ApplyPackedGather(DstWrapper output, int batch, 
     }
 }
 
-namespace detail {
-
 /**
- * @brief Reads a run of NIX consecutive pixels from one input wrapper at (batch, y, x0 .. x0+NIX-1). The load is
- * widened to a single PackVec<Src> transaction when the input's pack width matches the run and the row is contiguous
- * and aligned; otherwise each pixel is read individually. Inputs whose pack width does not match NIX (e.g. a
- * type-changing or differently-shaped input) always take the per-pixel path.
- */
-template <int NIX, typename SrcWrapper>
-__device__ __forceinline__ std::array<typename SrcWrapper::ValueType, NIX> ReadPackedRun(SrcWrapper input, int batch,
-                                                                                         int y, int x0) {
-    using Src = typename SrcWrapper::ValueType;
-    std::array<Src, NIX> run;
-
-    constexpr bool kPackedRead = PackEnabled<Src> && (PackWidth<Src> == NIX);
-    if constexpr (kPackedRead) {
-        Src* srcRow = &input.at(batch, y, x0, 0);
-        // Warp-uniform: contiguity/alignment is identical for every thread reading a given row.
-        if (input.isContiguousX() && (reinterpret_cast<uintptr_t>(srcRow) & PackAlignMask<Src>) == 0) {
-            PackVec<Src> v = PackLoad<Src>(srcRow);
-            for (int i = 0; i < NIX; i++) run[i] = UnpackPixel<Src>(v, i);
-        } else {
-            for (int i = 0; i < NIX; i++) run[i] = input.at(batch, y, x0 + i, 0);
-        }
-    } else {
-        for (int i = 0; i < NIX; i++) run[i] = input.at(batch, y, x0 + i, 0);
-    }
-    return run;
-}
-
-/**
- * @brief Invokes pixelFn(batch, y, x, run0[i], run1[i], ...) by expanding the tuple of per-input runs at element i.
- */
-template <typename PixelFn, typename Runs, std::size_t... Is>
-__device__ __forceinline__ auto InvokeAtIndex(PixelFn& pixelFn, int batch, int y, int x, int i, Runs& runs,
-                                              std::index_sequence<Is...>) {
-    return pixelFn(batch, y, x, std::get<Is>(runs)[i]...);
-}
-
-}  // namespace detail
-
-/**
- * @brief Transforms a contiguous run of PackWidth<Dst> pixels at row (batch, y), reading one or more inputs at the same
- * coordinates. Use this for "elementwise" kernels where the output pixel is a pure function of the input pixel(s) at
- * the matching coordinate — both the loads and the store can be packed.
+ * @brief Transforms a contiguous run of PackWidth<Dst> pixels at row (batch, y), reading the primary input at the same
+ * coordinates. Use this for "elementwise" kernels where the output pixel is a pure function of the input pixel at the
+ * matching coordinate — both the load and the store can be packed.
  *
- * Each output pixel is computed by @p pixelFn(batch, y, x, p0, p1, ...), where pN is the pixel from the Nth input at
+ * Each output pixel is computed by @p pixelFn(srcPixel, batch, y, x), where srcPixel is the primary input pixel at
  * (batch, y, x). The callable receives the coordinates as well, so it can still fetch any secondary/broadcast inputs
- * (which are not contiguous along x) itself. Each input is independently widened to a single PackVec load only when its
- * pixels are contiguous, aligned, and its pack width matches the output run (the common same-pixel-size case);
- * otherwise that input is read per pixel. The store side follows the same packed/fallback logic as ApplyPackedGather.
+ * itself. The source run is widened to a single PackVec<Src> load only when the source pixels are contiguous, aligned,
+ * and the source pack width matches the output run (the common same-pixel-size case); otherwise the source is read per
+ * pixel. The store side follows the same packed/fallback logic as ApplyPackedGather.
  *
+ * @tparam SrcWrapper Primary input wrapper type (must expose ValueType, at(), and isContiguousX()).
  * @tparam DstWrapper Output wrapper type (must expose ValueType, width(), at(), and isContiguousX()).
- * @tparam PixelFn Callable `Dst(int batch, int y, int x, Src0 p0, Src1 p1, ...)` returning the output pixel.
- * @tparam SrcWrappers Input wrapper types (each must expose ValueType, at(), and isContiguousX()).
+ * @tparam PixelFn Callable with signature `Dst(Src srcPixel, int batch, int y, int x)` returning the output pixel.
  */
-template <typename DstWrapper, typename PixelFn, typename... SrcWrappers>
-__device__ __forceinline__ void ApplyPackedTransform(DstWrapper output, int batch, int y, PixelFn pixelFn,
-                                                     SrcWrappers... inputs) {
+template <typename SrcWrapper, typename DstWrapper, typename PixelFn>
+__device__ __forceinline__ void ApplyPackedTransform(SrcWrapper input, DstWrapper output, int batch, int y,
+                                                     PixelFn pixelFn) {
+    using Src = typename SrcWrapper::ValueType;
     using Dst = typename DstWrapper::ValueType;
     constexpr int NIX = PackWidth<Dst>;
 
@@ -234,14 +191,27 @@ __device__ __forceinline__ void ApplyPackedTransform(DstWrapper output, int batc
     if (x0 >= width) return;
 
     if (x0 + NIX - 1 < width) {
-        // Fast path: read each input's NIX-wide run (packed per-input where possible), compute, then packed-store.
-        auto runs = std::make_tuple(detail::ReadPackedRun<NIX>(inputs, batch, y, x0)...);
+        // Fast path: the whole NIX-wide run is in bounds.
+        Src src[NIX];
+
+        // A single wide source load only covers the run when the source pack holds exactly NIX pixels. This holds for
+        // same-pixel-size transforms; type-changing ones (e.g. uchar -> float) fall through to per-pixel reads.
+        constexpr bool kPackedRead = PackEnabled<Src> && (PackWidth<Src> == NIX);
+        if constexpr (kPackedRead) {
+            Src* srcRow = &input.at(batch, y, x0, 0);
+            // Warp-uniform: contiguity/alignment is identical for every thread reading a given row.
+            if (input.isContiguousX() && (reinterpret_cast<uintptr_t>(srcRow) & PackAlignMask<Src>) == 0) {
+                PackVec<Src> v = PackLoad<Src>(srcRow);
+                for (int i = 0; i < NIX; i++) src[i] = UnpackPixel<Src>(v, i);
+            } else {
+                for (int i = 0; i < NIX; i++) src[i] = input.at(batch, y, x0 + i, 0);
+            }
+        } else {
+            for (int i = 0; i < NIX; i++) src[i] = input.at(batch, y, x0 + i, 0);
+        }
 
         Dst pack[NIX];
-        for (int i = 0; i < NIX; i++) {
-            pack[i] =
-                detail::InvokeAtIndex(pixelFn, batch, y, x0 + i, i, runs, std::index_sequence_for<SrcWrappers...>{});
-        }
+        for (int i = 0; i < NIX; i++) pack[i] = pixelFn(src[i], batch, y, x0 + i);
 
         if constexpr (PackEnabled<Dst>) {
             Dst* dstRow = &output.at(batch, y, x0, 0);
@@ -259,7 +229,7 @@ __device__ __forceinline__ void ApplyPackedTransform(DstWrapper output, int batc
         for (int i = 0; i < NIX; i++) {
             const int x = x0 + i;
             if (x >= width) break;
-            output.at(batch, y, x, 0) = pixelFn(batch, y, x, inputs.at(batch, y, x, 0)...);
+            output.at(batch, y, x, 0) = pixelFn(input.at(batch, y, x, 0), batch, y, x);
         }
     }
 }

--- a/include/kernels/device/packed_apply.hpp
+++ b/include/kernels/device/packed_apply.hpp
@@ -37,9 +37,10 @@
  * of them can be written with a single wide, aligned store. This removes the sub-word store penalty paid by small pixel
  * types (notably 3-byte uchar3) and amortizes per-thread setup, which is a large win for these memory-bound kernels.
  *
- * Usage: a kernel computes its row/batch indices, bounds-checks them, then calls ApplyPackedRow() with a callable that
- * returns the output pixel for a given (batch, y, x). The grid must be launched with PackedGrid<DstType>() so that each
- * thread's x-index maps to a run of PackWidth<DstType> pixels.
+ * Usage: a kernel computes its row/batch indices, bounds-checks them, then calls ApplyPackedGather() (scattered reads,
+ * packed store) or ApplyPackedTransform() (packed load and store) with a callable that returns the output pixel. The
+ * grid must be launched with PackedGrid<DstType>() so that each thread's x-index maps to a run of PackWidth<DstType>
+ * pixels.
  */
 
 namespace Kernels::Device {
@@ -75,7 +76,48 @@ constexpr uintptr_t PackAlignMask =
     (sizeof(PackVec<T>) == sizeof(uint3) ? sizeof(unsigned int) : sizeof(PackVec<T>)) - 1;
 
 /**
- * @brief Produces a contiguous run of PackWidth<T> output pixels at row (batch, y) and writes them.
+ * @brief Explicit, type-punning-safe pack/unpack primitives.
+ *
+ * These exist so the wide-vector load/store is expressed as a defined byte copy rather than a glvalue access through an
+ * unrelated type. `__builtin_memcpy` of a compile-time-constant size lowers to a single wide transaction while keeping
+ * strict-aliasing intact; `__builtin_assume_aligned` is what lets the compiler widen the access (a bare uchar3* is only
+ * 1-byte aligned and would otherwise emit byte-wise transfers). Callers must still gate these on PackAlignMask<T> — the
+ * builtins fix the type-punning, not the alignment precondition.
+ */
+
+/**
+ * @brief Loads a run of PackWidth<T> contiguous pixels at @p row as one wide PackVec<T> transaction.
+ */
+template <typename T>
+__device__ __forceinline__ PackVec<T> PackLoad(const T* row) {
+    PackVec<T> v;
+    __builtin_memcpy(&v, __builtin_assume_aligned(row, alignof(PackVec<T>)), sizeof(v));
+    return v;
+}
+
+/**
+ * @brief Stores a run of PackWidth<T> pixels to @p dst as one wide PackVec<T> transaction.
+ */
+template <typename T>
+__device__ __forceinline__ void PackStore(T* dst, const T (&pixels)[PackWidth<T>]) {
+    __builtin_memcpy(__builtin_assume_aligned(dst, alignof(PackVec<T>)), &pixels[0], sizeof(pixels));
+}
+
+/**
+ * @brief Extracts pixel @p i from a loaded PackVec<T>. Uses a byte-offset copy, so it is correct even when pixels do
+ * not align to the 32-bit lanes of the pack (e.g. 3-byte uchar3 pixels straddling uint3 lane boundaries).
+ */
+template <typename T>
+__device__ __forceinline__ T UnpackPixel(const PackVec<T>& v, int i) {
+    T out;
+    __builtin_memcpy(&out, reinterpret_cast<const unsigned char*>(&v) + i * sizeof(T), sizeof(T));
+    return out;
+}
+
+/**
+ * @brief Produces a contiguous run of PackWidth<T> output pixels at row (batch, y) and writes them. Use this for
+ * "gather" kernels whose source reads are scattered by interpolation/border math and therefore cannot be widened — only
+ * the store is packed.
  *
  * Each pixel is computed by @p pixelFn(batch, y, x). When the run is fully in bounds, the destination is contiguous in
  * x, and the row is suitably aligned, the run is written with a single PackVec<T> vector store; otherwise it falls back
@@ -86,7 +128,7 @@ constexpr uintptr_t PackAlignMask =
  * @tparam PixelFn Callable with signature `T(int batch, int y, int x)` returning the output pixel.
  */
 template <typename DstWrapper, typename PixelFn>
-__device__ __forceinline__ void ApplyPackedRow(DstWrapper output, int batch, int y, PixelFn pixelFn) {
+__device__ __forceinline__ void ApplyPackedGather(DstWrapper output, int batch, int y, PixelFn pixelFn) {
     using T = typename DstWrapper::ValueType;
     constexpr int NIX = PackWidth<T>;
 
@@ -104,7 +146,7 @@ __device__ __forceinline__ void ApplyPackedRow(DstWrapper output, int batch, int
             T* dstRow = &output.at(batch, y, x0, 0);
             // Alignment/contiguity is identical for every thread writing a given row, so this branch is warp-uniform.
             if (output.isContiguousX() && (reinterpret_cast<uintptr_t>(dstRow) & PackAlignMask<T>) == 0) {
-                *reinterpret_cast<PackVec<T>*>(dstRow) = reinterpret_cast<const PackVec<T>&>(pack);
+                PackStore<T>(dstRow, pack);
             } else {
                 for (int i = 0; i < NIX; i++) output.at(batch, y, x0 + i, 0) = pack[i];
             }
@@ -118,6 +160,76 @@ __device__ __forceinline__ void ApplyPackedRow(DstWrapper output, int batch, int
             const int x = x0 + i;
             if (x >= width) break;
             output.at(batch, y, x, 0) = pixelFn(batch, y, x);
+        }
+    }
+}
+
+/**
+ * @brief Transforms a contiguous run of PackWidth<Dst> pixels at row (batch, y), reading the primary input at the same
+ * coordinates. Use this for "elementwise" kernels where the output pixel is a pure function of the input pixel at the
+ * matching coordinate — both the load and the store can be packed.
+ *
+ * Each output pixel is computed by @p pixelFn(srcPixel, batch, y, x), where srcPixel is the primary input pixel at
+ * (batch, y, x). The callable receives the coordinates as well, so it can still fetch any secondary/broadcast inputs
+ * itself. The source run is widened to a single PackVec<Src> load only when the source pixels are contiguous, aligned,
+ * and the source pack width matches the output run (the common same-pixel-size case); otherwise the source is read per
+ * pixel. The store side follows the same packed/fallback logic as ApplyPackedGather.
+ *
+ * @tparam SrcWrapper Primary input wrapper type (must expose ValueType, at(), and isContiguousX()).
+ * @tparam DstWrapper Output wrapper type (must expose ValueType, width(), at(), and isContiguousX()).
+ * @tparam PixelFn Callable with signature `Dst(Src srcPixel, int batch, int y, int x)` returning the output pixel.
+ */
+template <typename SrcWrapper, typename DstWrapper, typename PixelFn>
+__device__ __forceinline__ void ApplyPackedTransform(SrcWrapper input, DstWrapper output, int batch, int y,
+                                                     PixelFn pixelFn) {
+    using Src = typename SrcWrapper::ValueType;
+    using Dst = typename DstWrapper::ValueType;
+    constexpr int NIX = PackWidth<Dst>;
+
+    const int width = output.width();
+    const int x0 = (blockIdx.x * blockDim.x + threadIdx.x) * NIX;
+    if (x0 >= width) return;
+
+    if (x0 + NIX - 1 < width) {
+        // Fast path: the whole NIX-wide run is in bounds.
+        Src src[NIX];
+
+        // A single wide source load only covers the run when the source pack holds exactly NIX pixels. This holds for
+        // same-pixel-size transforms; type-changing ones (e.g. uchar -> float) fall through to per-pixel reads.
+        constexpr bool kPackedRead = PackEnabled<Src> && (PackWidth<Src> == NIX);
+        if constexpr (kPackedRead) {
+            Src* srcRow = &input.at(batch, y, x0, 0);
+            // Warp-uniform: contiguity/alignment is identical for every thread reading a given row.
+            if (input.isContiguousX() && (reinterpret_cast<uintptr_t>(srcRow) & PackAlignMask<Src>) == 0) {
+                PackVec<Src> v = PackLoad<Src>(srcRow);
+                for (int i = 0; i < NIX; i++) src[i] = UnpackPixel<Src>(v, i);
+            } else {
+                for (int i = 0; i < NIX; i++) src[i] = input.at(batch, y, x0 + i, 0);
+            }
+        } else {
+            for (int i = 0; i < NIX; i++) src[i] = input.at(batch, y, x0 + i, 0);
+        }
+
+        Dst pack[NIX];
+        for (int i = 0; i < NIX; i++) pack[i] = pixelFn(src[i], batch, y, x0 + i);
+
+        if constexpr (PackEnabled<Dst>) {
+            Dst* dstRow = &output.at(batch, y, x0, 0);
+            if (output.isContiguousX() && (reinterpret_cast<uintptr_t>(dstRow) & PackAlignMask<Dst>) == 0) {
+                PackStore<Dst>(dstRow, pack);
+            } else {
+                for (int i = 0; i < NIX; i++) output.at(batch, y, x0 + i, 0) = pack[i];
+            }
+        } else {
+            for (int i = 0; i < NIX; i++) output.at(batch, y, x0 + i, 0) = pack[i];
+        }
+    } else {
+        // Tail: ragged right edge where fewer than NIX pixels remain.
+
+        for (int i = 0; i < NIX; i++) {
+            const int x = x0 + i;
+            if (x >= width) break;
+            output.at(batch, y, x, 0) = pixelFn(input.at(batch, y, x, 0), batch, y, x);
         }
     }
 }

--- a/include/kernels/device/remap_device.hpp
+++ b/include/kernels/device/remap_device.hpp
@@ -40,7 +40,7 @@ __global__ void remap(SrcWrapper input, DstWrapper output, MapWrapper map, int m
     const int b = blockIdx.z;
     if (y >= output.height() || b >= output.batches()) return;
 
-    ApplyPackedRow(output, b, y, [=] __device__(int n, int yy, int x) -> dst_type {
+    ApplyPackedGather(output, b, y, [=] __device__(int n, int yy, int x) -> dst_type {
         float2 dstCoord = make_float2(static_cast<float>(x), static_cast<float>(yy));
 
         float2 mapCoord;

--- a/include/kernels/device/remap_device.hpp
+++ b/include/kernels/device/remap_device.hpp
@@ -22,38 +22,39 @@ THE SOFTWARE.
 #pragma once
 
 #include <hip/hip_runtime.h>
+
 #include "core/detail/internal_structs.hpp"
+#include "kernels/device/packed_apply.hpp"
 #include "operator_types.h"
 
 namespace Kernels {
 namespace Device {
 
 using namespace roccv::detail;
-    
+
 template <typename SrcWrapper, typename DstWrapper, typename MapWrapper>
 __global__ void remap(SrcWrapper input, DstWrapper output, MapWrapper map, int mapBatchSize, RemapParams params) {
-    const int x = blockDim.x * blockIdx.x + threadIdx.x;
+    using dst_type = typename DstWrapper::ValueType;
+
     const int y = blockDim.y * blockIdx.y + threadIdx.y;
     const int b = blockIdx.z;
+    if (y >= output.height() || b >= output.batches()) return;
 
-    float2 srcCoord = make_float2(0.f, 0.f);
-    float2 mapCoord = make_float2(0.f, 0.f);
-    float2 dstCoord = make_float2(0.f, 0.f);
+    ApplyPackedRow(output, b, y, [=] __device__(int n, int yy, int x) -> dst_type {
+        float2 dstCoord = make_float2(static_cast<float>(x), static_cast<float>(yy));
 
-    if (x >= output.width() || y >= output.height()) return;
+        float2 mapCoord;
+        mapCoord.x = (dstCoord.x + params.dstOffset) * params.mapScale.x;
+        mapCoord.y = (dstCoord.y + params.dstOffset) * params.mapScale.y;
 
-    dstCoord.x = static_cast<float>(x);
-    dstCoord.y = static_cast<float>(y);
-                
-    mapCoord.x = (dstCoord.x + params.dstOffset) * params.mapScale.x;
-    mapCoord.y = (dstCoord.y + params.dstOffset) * params.mapScale.y;
-    
-    float2 mapValue = map.at((mapBatchSize == 1 ? 0 : b), mapCoord.y, mapCoord.x, 0);
+        float2 mapValue = map.at((mapBatchSize == 1 ? 0 : n), mapCoord.y, mapCoord.x, 0);
 
-    srcCoord.x = dstCoord.x * params.srcScale.x + mapValue.x * params.valScale.x + params.srcOffset.x;
-    srcCoord.y = dstCoord.y * params.srcScale.y + mapValue.y * params.valScale.y + params.srcOffset.y;
+        float2 srcCoord;
+        srcCoord.x = dstCoord.x * params.srcScale.x + mapValue.x * params.valScale.x + params.srcOffset.x;
+        srcCoord.y = dstCoord.y * params.srcScale.y + mapValue.y * params.valScale.y + params.srcOffset.y;
 
-    output.at(b, y, x, 0) = input.at(b, srcCoord.y, srcCoord.x, 0);
+        return input.at(n, srcCoord.y, srcCoord.x, 0);
+    });
 }
 };  // namespace Device
 };  // namespace Kernels

--- a/include/kernels/device/resize_device.hpp
+++ b/include/kernels/device/resize_device.hpp
@@ -43,7 +43,7 @@ __global__ void resize(SrcWrapper input, DstWrapper output, float scaleX, float 
 
     const float srcY = fmaf(y + 0.5f, scaleY, -0.5f);
 
-    ApplyPackedRow(output, batch, y, [=] __device__(int n, int /*y*/, int x) -> T {
+    ApplyPackedGather(output, batch, y, [=] __device__(int n, int /*y*/, int x) -> T {
         const float srcX = fmaf(x + 0.5f, scaleX, -0.5f);
         return input.at(n, srcY, srcX, 0);
     });

--- a/include/kernels/device/resize_device.hpp
+++ b/include/kernels/device/resize_device.hpp
@@ -23,17 +23,87 @@
 
 #include <hip/hip_runtime.h>
 
+#include <cstdint>
+#include <type_traits>
+
+#include "core/detail/type_traits.hpp"
+
 namespace Kernels::Device {
-template <typename SrcWrapper, typename DstWrapper>
+
+/**
+ * @brief Wide store type used to write a run of output pixels in a single transaction.
+ *
+ * A 3-element pixel (e.g. uchar3) is written as a uint3 (12 bytes); everything else uses uint4 (16 bytes). This packs
+ * several small pixels (uchar1/uchar3/uchar4/float1) into one aligned vector store, which removes the sub-word store
+ * penalty those types otherwise pay. Wide pixels (float3/float4) already fill a transaction, so their pack collapses
+ * to a single pixel (see ResizeNIX).
+ */
+template <typename T>
+using ResizePack = std::conditional_t<roccv::detail::NumElements<T> == 3, uint3, uint4>;
+
+/**
+ * @brief Number of output pixels each thread produces: how many pixels of type T fit in one ResizePack.
+ */
+template <typename T>
+constexpr int ResizeNIX = sizeof(ResizePack<T>) / sizeof(T);
+
+/**
+ * @brief Byte-alignment required to issue a ResizePack store. A uint3 is only 4-byte aligned (three uints), while a
+ * uint4 is 16-byte aligned.
+ */
+template <typename T>
+constexpr uintptr_t ResizePackAlignMask =
+    (sizeof(ResizePack<T>) == sizeof(uint3) ? sizeof(unsigned int) : sizeof(ResizePack<T>)) - 1;
+
+/**
+ * @brief Resizes an image using the interpolation/border logic baked into the source wrapper.
+ *
+ * Each thread emits a contiguous run of NIX output pixels along x. When the run is fully in-bounds and the destination
+ * row is suitably aligned, the run is written with a single ResizePack vector store; otherwise it falls back to
+ * per-pixel stores. Reads and interpolation are unchanged from the scalar path, so results are bit-identical.
+ *
+ * @tparam NIX Output pixels produced per thread (sizeof(DstPack)/sizeof(T)).
+ * @tparam DstPack Vector store type used for the coalesced write.
+ */
+template <int NIX, typename DstPack, typename SrcWrapper, typename DstWrapper>
 __global__ void resize(SrcWrapper input, DstWrapper output, float scaleX, float scaleY) {
-    const int x = blockIdx.x * blockDim.x + threadIdx.x;
+    using T = typename DstWrapper::ValueType;
+
     const int y = blockIdx.y * blockDim.y + threadIdx.y;
     const int batch = blockIdx.z;
+    if (y >= output.height()) return;
 
-    if (x >= output.width() || y >= output.height()) return;
+    const int x0 = (blockIdx.x * blockDim.x + threadIdx.x) * NIX;
+    if (x0 >= output.width()) return;
 
-    float srcX = fmaf(x + 0.5f, scaleX, -0.5f);
-    float srcY = fmaf(y + 0.5f, scaleY, -0.5f);
-    output.at(batch, y, x, 0) = input.at(batch, srcY, srcX, 0);
+    const float srcY = fmaf(y + 0.5f, scaleY, -0.5f);
+
+    if (x0 + NIX - 1 < output.width()) {
+        // Fast path: the whole NIX-wide run is in bounds.
+        T pack[NIX];
+#pragma unroll
+        for (int i = 0; i < NIX; i++) {
+            const float srcX = fmaf(x0 + i + 0.5f, scaleX, -0.5f);
+            pack[i] = input.at(batch, srcY, srcX, 0);
+        }
+
+        T* dstRow = &output.at(batch, y, x0, 0);
+        // Alignment is identical for every thread writing a given row, so this branch is warp-uniform.
+        if ((reinterpret_cast<uintptr_t>(dstRow) & ResizePackAlignMask<T>) == 0) {
+            *reinterpret_cast<DstPack*>(dstRow) = reinterpret_cast<const DstPack&>(pack);
+        } else {
+#pragma unroll
+            for (int i = 0; i < NIX; i++) dstRow[i] = pack[i];
+        }
+    } else {
+        // Tail: ragged right edge where fewer than NIX pixels remain.
+#pragma unroll
+        for (int i = 0; i < NIX; i++) {
+            const int x = x0 + i;
+            if (x >= output.width()) break;
+            const float srcX = fmaf(x + 0.5f, scaleX, -0.5f);
+            output.at(batch, y, x, 0) = input.at(batch, srcY, srcX, 0);
+        }
+    }
 }
 }  // namespace Kernels::Device

--- a/include/kernels/device/resize_device.hpp
+++ b/include/kernels/device/resize_device.hpp
@@ -23,87 +23,29 @@
 
 #include <hip/hip_runtime.h>
 
-#include <cstdint>
-#include <type_traits>
-
-#include "core/detail/type_traits.hpp"
+#include "kernels/device/packed_apply.hpp"
 
 namespace Kernels::Device {
 
 /**
- * @brief Wide store type used to write a run of output pixels in a single transaction.
- *
- * A 3-element pixel (e.g. uchar3) is written as a uint3 (12 bytes); everything else uses uint4 (16 bytes). This packs
- * several small pixels (uchar1/uchar3/uchar4/float1) into one aligned vector store, which removes the sub-word store
- * penalty those types otherwise pay. Wide pixels (float3/float4) already fill a transaction, so their pack collapses
- * to a single pixel (see ResizeNIX).
- */
-template <typename T>
-using ResizePack = std::conditional_t<roccv::detail::NumElements<T> == 3, uint3, uint4>;
-
-/**
- * @brief Number of output pixels each thread produces: how many pixels of type T fit in one ResizePack.
- */
-template <typename T>
-constexpr int ResizeNIX = sizeof(ResizePack<T>) / sizeof(T);
-
-/**
- * @brief Byte-alignment required to issue a ResizePack store. A uint3 is only 4-byte aligned (three uints), while a
- * uint4 is 16-byte aligned.
- */
-template <typename T>
-constexpr uintptr_t ResizePackAlignMask =
-    (sizeof(ResizePack<T>) == sizeof(uint3) ? sizeof(unsigned int) : sizeof(ResizePack<T>)) - 1;
-
-/**
  * @brief Resizes an image using the interpolation/border logic baked into the source wrapper.
  *
- * Each thread emits a contiguous run of NIX output pixels along x. When the run is fully in-bounds and the destination
- * row is suitably aligned, the run is written with a single ResizePack vector store; otherwise it falls back to
- * per-pixel stores. Reads and interpolation are unchanged from the scalar path, so results are bit-identical.
- *
- * @tparam NIX Output pixels produced per thread (sizeof(DstPack)/sizeof(T)).
- * @tparam DstPack Vector store type used for the coalesced write.
+ * Each thread emits a contiguous run of PackWidth output pixels along x via the shared packed-write helper. Reads and
+ * interpolation are unchanged from the scalar path, so results are bit-identical.
  */
-template <int NIX, typename DstPack, typename SrcWrapper, typename DstWrapper>
+template <typename SrcWrapper, typename DstWrapper>
 __global__ void resize(SrcWrapper input, DstWrapper output, float scaleX, float scaleY) {
     using T = typename DstWrapper::ValueType;
 
     const int y = blockIdx.y * blockDim.y + threadIdx.y;
     const int batch = blockIdx.z;
-    if (y >= output.height()) return;
-
-    const int x0 = (blockIdx.x * blockDim.x + threadIdx.x) * NIX;
-    if (x0 >= output.width()) return;
+    if (y >= output.height() || batch >= output.batches()) return;
 
     const float srcY = fmaf(y + 0.5f, scaleY, -0.5f);
 
-    if (x0 + NIX - 1 < output.width()) {
-        // Fast path: the whole NIX-wide run is in bounds.
-        T pack[NIX];
-#pragma unroll
-        for (int i = 0; i < NIX; i++) {
-            const float srcX = fmaf(x0 + i + 0.5f, scaleX, -0.5f);
-            pack[i] = input.at(batch, srcY, srcX, 0);
-        }
-
-        T* dstRow = &output.at(batch, y, x0, 0);
-        // Alignment is identical for every thread writing a given row, so this branch is warp-uniform.
-        if ((reinterpret_cast<uintptr_t>(dstRow) & ResizePackAlignMask<T>) == 0) {
-            *reinterpret_cast<DstPack*>(dstRow) = reinterpret_cast<const DstPack&>(pack);
-        } else {
-#pragma unroll
-            for (int i = 0; i < NIX; i++) dstRow[i] = pack[i];
-        }
-    } else {
-        // Tail: ragged right edge where fewer than NIX pixels remain.
-#pragma unroll
-        for (int i = 0; i < NIX; i++) {
-            const int x = x0 + i;
-            if (x >= output.width()) break;
-            const float srcX = fmaf(x + 0.5f, scaleX, -0.5f);
-            output.at(batch, y, x, 0) = input.at(batch, srcY, srcX, 0);
-        }
-    }
+    ApplyPackedRow(output, batch, y, [=] __device__(int n, int /*y*/, int x) -> T {
+        const float srcX = fmaf(x + 0.5f, scaleX, -0.5f);
+        return input.at(n, srcY, srcX, 0);
+    });
 }
 }  // namespace Kernels::Device

--- a/include/kernels/device/rotate_device.hpp
+++ b/include/kernels/device/rotate_device.hpp
@@ -23,21 +23,25 @@
 
 #include <hip/hip_runtime.h>
 
+#include "kernels/device/packed_apply.hpp"
+
 namespace Kernels::Device {
 template <typename SrcWrapper, typename DstWrapper, typename MatWrapper>
 __global__ void rotate(SrcWrapper src, DstWrapper dst, MatWrapper affineMat) {
-    const int x = blockDim.x * blockIdx.x + threadIdx.x;
+    using dst_type = typename DstWrapper::ValueType;
+
     const int y = blockDim.y * blockIdx.y + threadIdx.y;
     const int b = blockIdx.z;
+    if (y >= dst.height() || b >= dst.batches()) return;
 
-    if (x >= dst.width() || y >= dst.height()) return;
+    ApplyPackedRow(dst, b, y, [=] __device__(int n, int yy, int x) -> dst_type {
+        const double xShift = x - affineMat[2];
+        const double yShift = yy - affineMat[5];
 
-    const double xShift = x - affineMat[2];
-    const double yShift = y - affineMat[5];
+        const float srcX = static_cast<float>(xShift * affineMat[0] + yShift * -affineMat[1]);
+        const float srcY = static_cast<float>(xShift * -affineMat[3] + yShift * affineMat[4]);
 
-    const float srcX = static_cast<float>(xShift * affineMat[0] + yShift * -affineMat[1]);
-    const float srcY = static_cast<float>(xShift * -affineMat[3] + yShift * affineMat[4]);
-
-    dst.at(b, y, x, 0) = src.at(b, srcY, srcX, 0);
+        return src.at(n, srcY, srcX, 0);
+    });
 }
 }  // namespace Kernels::Device

--- a/include/kernels/device/rotate_device.hpp
+++ b/include/kernels/device/rotate_device.hpp
@@ -34,7 +34,7 @@ __global__ void rotate(SrcWrapper src, DstWrapper dst, MatWrapper affineMat) {
     const int b = blockIdx.z;
     if (y >= dst.height() || b >= dst.batches()) return;
 
-    ApplyPackedRow(dst, b, y, [=] __device__(int n, int yy, int x) -> dst_type {
+    ApplyPackedGather(dst, b, y, [=] __device__(int n, int yy, int x) -> dst_type {
         const double xShift = x - affineMat[2];
         const double yShift = yy - affineMat[5];
 

--- a/include/kernels/device/thresholding_device.hpp
+++ b/include/kernels/device/thresholding_device.hpp
@@ -49,8 +49,8 @@ __global__ void binary_generic(SrcWrapper input, DstWrapper output, roccv::Gener
     const double th = thresh.at(z_idx);
     const double mv = maxVal.at(z_idx);
 
-    ApplyPackedTransform(input, output, z_idx, y_idx,
-                         [=] __device__(src_type inputVal, int /*n*/, int /*yy*/, int /*x*/) -> dst_type {
+    ApplyPackedTransform(output, z_idx, y_idx,
+                         [=] __device__(int /*n*/, int /*yy*/, int /*x*/, src_type inputVal) -> dst_type {
         dst_type outputVal;
         for (int i = 0; i < output.channels(); i++) {
             double ip = StaticCast<double>(GetElement(inputVal, i));
@@ -58,7 +58,7 @@ __global__ void binary_generic(SrcWrapper input, DstWrapper output, roccv::Gener
             GetElement(outputVal, i) = StaticCast<base_type>(outVal);
         }
         return outputVal;
-    });
+    }, input);
 }
 
 template <typename SrcWrapper, typename DstWrapper>
@@ -76,8 +76,8 @@ __global__ void binary_inv_generic(SrcWrapper input, DstWrapper output, roccv::G
     const double th = thresh.at(z_idx);
     const double mv = maxVal.at(z_idx);
 
-    ApplyPackedTransform(input, output, z_idx, y_idx,
-                         [=] __device__(src_type inputVal, int /*n*/, int /*yy*/, int /*x*/) -> dst_type {
+    ApplyPackedTransform(output, z_idx, y_idx,
+                         [=] __device__(int /*n*/, int /*yy*/, int /*x*/, src_type inputVal) -> dst_type {
         dst_type outputVal;
         for (int i = 0; i < output.channels(); i++) {
             double ip = StaticCast<double>(GetElement(inputVal, i));
@@ -85,7 +85,7 @@ __global__ void binary_inv_generic(SrcWrapper input, DstWrapper output, roccv::G
             GetElement(outputVal, i) = StaticCast<base_type>(outVal);
         }
         return outputVal;
-    });
+    }, input);
 }
 
 template <typename SrcWrapper, typename DstWrapper>
@@ -101,8 +101,8 @@ __global__ void trunc_generic(SrcWrapper input, DstWrapper output, roccv::Generi
 
     const double th = thresh.at(z_idx);
 
-    ApplyPackedTransform(input, output, z_idx, y_idx,
-                         [=] __device__(src_type inputVal, int /*n*/, int /*yy*/, int /*x*/) -> dst_type {
+    ApplyPackedTransform(output, z_idx, y_idx,
+                         [=] __device__(int /*n*/, int /*yy*/, int /*x*/, src_type inputVal) -> dst_type {
         dst_type outputVal;
         for (int i = 0; i < output.channels(); i++) {
             double ip = StaticCast<double>(GetElement(inputVal, i));
@@ -110,7 +110,7 @@ __global__ void trunc_generic(SrcWrapper input, DstWrapper output, roccv::Generi
             GetElement(outputVal, i) = StaticCast<base_type>(outVal);
         }
         return outputVal;
-    });
+    }, input);
 }
 
 template <typename SrcWrapper, typename DstWrapper>
@@ -126,8 +126,8 @@ __global__ void tozero_generic(SrcWrapper input, DstWrapper output, roccv::Gener
 
     const double th = thresh.at(z_idx);
 
-    ApplyPackedTransform(input, output, z_idx, y_idx,
-                         [=] __device__(src_type inputVal, int /*n*/, int /*yy*/, int /*x*/) -> dst_type {
+    ApplyPackedTransform(output, z_idx, y_idx,
+                         [=] __device__(int /*n*/, int /*yy*/, int /*x*/, src_type inputVal) -> dst_type {
         dst_type outputVal;
         for (int i = 0; i < output.channels(); i++) {
             double ip = StaticCast<double>(GetElement(inputVal, i));
@@ -135,7 +135,7 @@ __global__ void tozero_generic(SrcWrapper input, DstWrapper output, roccv::Gener
             GetElement(outputVal, i) = StaticCast<base_type>(outVal);
         }
         return outputVal;
-    });
+    }, input);
 }
 
 template <typename SrcWrapper, typename DstWrapper>
@@ -151,8 +151,8 @@ __global__ void tozeroinv_generic(SrcWrapper input, DstWrapper output, roccv::Ge
 
     const double th = thresh.at(z_idx);
 
-    ApplyPackedTransform(input, output, z_idx, y_idx,
-                         [=] __device__(src_type inputVal, int /*n*/, int /*yy*/, int /*x*/) -> dst_type {
+    ApplyPackedTransform(output, z_idx, y_idx,
+                         [=] __device__(int /*n*/, int /*yy*/, int /*x*/, src_type inputVal) -> dst_type {
         dst_type outputVal;
         for (int i = 0; i < output.channels(); i++) {
             double ip = StaticCast<double>(GetElement(inputVal, i));
@@ -160,7 +160,7 @@ __global__ void tozeroinv_generic(SrcWrapper input, DstWrapper output, roccv::Ge
             GetElement(outputVal, i) = StaticCast<base_type>(outVal);
         }
         return outputVal;
-    });
+    }, input);
 }
 }  // namespace Device
 }  // namespace Kernels

--- a/include/kernels/device/thresholding_device.hpp
+++ b/include/kernels/device/thresholding_device.hpp
@@ -49,8 +49,8 @@ __global__ void binary_generic(SrcWrapper input, DstWrapper output, roccv::Gener
     const double th = thresh.at(z_idx);
     const double mv = maxVal.at(z_idx);
 
-    ApplyPackedTransform(output, z_idx, y_idx,
-                         [=] __device__(int /*n*/, int /*yy*/, int /*x*/, src_type inputVal) -> dst_type {
+    ApplyPackedTransform(input, output, z_idx, y_idx,
+                         [=] __device__(src_type inputVal, int /*n*/, int /*yy*/, int /*x*/) -> dst_type {
         dst_type outputVal;
         for (int i = 0; i < output.channels(); i++) {
             double ip = StaticCast<double>(GetElement(inputVal, i));
@@ -58,7 +58,7 @@ __global__ void binary_generic(SrcWrapper input, DstWrapper output, roccv::Gener
             GetElement(outputVal, i) = StaticCast<base_type>(outVal);
         }
         return outputVal;
-    }, input);
+    });
 }
 
 template <typename SrcWrapper, typename DstWrapper>
@@ -76,8 +76,8 @@ __global__ void binary_inv_generic(SrcWrapper input, DstWrapper output, roccv::G
     const double th = thresh.at(z_idx);
     const double mv = maxVal.at(z_idx);
 
-    ApplyPackedTransform(output, z_idx, y_idx,
-                         [=] __device__(int /*n*/, int /*yy*/, int /*x*/, src_type inputVal) -> dst_type {
+    ApplyPackedTransform(input, output, z_idx, y_idx,
+                         [=] __device__(src_type inputVal, int /*n*/, int /*yy*/, int /*x*/) -> dst_type {
         dst_type outputVal;
         for (int i = 0; i < output.channels(); i++) {
             double ip = StaticCast<double>(GetElement(inputVal, i));
@@ -85,7 +85,7 @@ __global__ void binary_inv_generic(SrcWrapper input, DstWrapper output, roccv::G
             GetElement(outputVal, i) = StaticCast<base_type>(outVal);
         }
         return outputVal;
-    }, input);
+    });
 }
 
 template <typename SrcWrapper, typename DstWrapper>
@@ -101,8 +101,8 @@ __global__ void trunc_generic(SrcWrapper input, DstWrapper output, roccv::Generi
 
     const double th = thresh.at(z_idx);
 
-    ApplyPackedTransform(output, z_idx, y_idx,
-                         [=] __device__(int /*n*/, int /*yy*/, int /*x*/, src_type inputVal) -> dst_type {
+    ApplyPackedTransform(input, output, z_idx, y_idx,
+                         [=] __device__(src_type inputVal, int /*n*/, int /*yy*/, int /*x*/) -> dst_type {
         dst_type outputVal;
         for (int i = 0; i < output.channels(); i++) {
             double ip = StaticCast<double>(GetElement(inputVal, i));
@@ -110,7 +110,7 @@ __global__ void trunc_generic(SrcWrapper input, DstWrapper output, roccv::Generi
             GetElement(outputVal, i) = StaticCast<base_type>(outVal);
         }
         return outputVal;
-    }, input);
+    });
 }
 
 template <typename SrcWrapper, typename DstWrapper>
@@ -126,8 +126,8 @@ __global__ void tozero_generic(SrcWrapper input, DstWrapper output, roccv::Gener
 
     const double th = thresh.at(z_idx);
 
-    ApplyPackedTransform(output, z_idx, y_idx,
-                         [=] __device__(int /*n*/, int /*yy*/, int /*x*/, src_type inputVal) -> dst_type {
+    ApplyPackedTransform(input, output, z_idx, y_idx,
+                         [=] __device__(src_type inputVal, int /*n*/, int /*yy*/, int /*x*/) -> dst_type {
         dst_type outputVal;
         for (int i = 0; i < output.channels(); i++) {
             double ip = StaticCast<double>(GetElement(inputVal, i));
@@ -135,7 +135,7 @@ __global__ void tozero_generic(SrcWrapper input, DstWrapper output, roccv::Gener
             GetElement(outputVal, i) = StaticCast<base_type>(outVal);
         }
         return outputVal;
-    }, input);
+    });
 }
 
 template <typename SrcWrapper, typename DstWrapper>
@@ -151,8 +151,8 @@ __global__ void tozeroinv_generic(SrcWrapper input, DstWrapper output, roccv::Ge
 
     const double th = thresh.at(z_idx);
 
-    ApplyPackedTransform(output, z_idx, y_idx,
-                         [=] __device__(int /*n*/, int /*yy*/, int /*x*/, src_type inputVal) -> dst_type {
+    ApplyPackedTransform(input, output, z_idx, y_idx,
+                         [=] __device__(src_type inputVal, int /*n*/, int /*yy*/, int /*x*/) -> dst_type {
         dst_type outputVal;
         for (int i = 0; i < output.channels(); i++) {
             double ip = StaticCast<double>(GetElement(inputVal, i));
@@ -160,7 +160,7 @@ __global__ void tozeroinv_generic(SrcWrapper input, DstWrapper output, roccv::Ge
             GetElement(outputVal, i) = StaticCast<base_type>(outVal);
         }
         return outputVal;
-    }, input);
+    });
 }
 }  // namespace Device
 }  // namespace Kernels

--- a/include/kernels/device/thresholding_device.hpp
+++ b/include/kernels/device/thresholding_device.hpp
@@ -49,8 +49,8 @@ __global__ void binary_generic(SrcWrapper input, DstWrapper output, roccv::Gener
     const double th = thresh.at(z_idx);
     const double mv = maxVal.at(z_idx);
 
-    ApplyPackedRow(output, z_idx, y_idx, [=] __device__(int n, int yy, int x) -> dst_type {
-        src_type inputVal = input.at(n, yy, x, 0);
+    ApplyPackedTransform(input, output, z_idx, y_idx,
+                         [=] __device__(src_type inputVal, int /*n*/, int /*yy*/, int /*x*/) -> dst_type {
         dst_type outputVal;
         for (int i = 0; i < output.channels(); i++) {
             double ip = StaticCast<double>(GetElement(inputVal, i));
@@ -76,8 +76,8 @@ __global__ void binary_inv_generic(SrcWrapper input, DstWrapper output, roccv::G
     const double th = thresh.at(z_idx);
     const double mv = maxVal.at(z_idx);
 
-    ApplyPackedRow(output, z_idx, y_idx, [=] __device__(int n, int yy, int x) -> dst_type {
-        src_type inputVal = input.at(n, yy, x, 0);
+    ApplyPackedTransform(input, output, z_idx, y_idx,
+                         [=] __device__(src_type inputVal, int /*n*/, int /*yy*/, int /*x*/) -> dst_type {
         dst_type outputVal;
         for (int i = 0; i < output.channels(); i++) {
             double ip = StaticCast<double>(GetElement(inputVal, i));
@@ -101,8 +101,8 @@ __global__ void trunc_generic(SrcWrapper input, DstWrapper output, roccv::Generi
 
     const double th = thresh.at(z_idx);
 
-    ApplyPackedRow(output, z_idx, y_idx, [=] __device__(int n, int yy, int x) -> dst_type {
-        src_type inputVal = input.at(n, yy, x, 0);
+    ApplyPackedTransform(input, output, z_idx, y_idx,
+                         [=] __device__(src_type inputVal, int /*n*/, int /*yy*/, int /*x*/) -> dst_type {
         dst_type outputVal;
         for (int i = 0; i < output.channels(); i++) {
             double ip = StaticCast<double>(GetElement(inputVal, i));
@@ -126,8 +126,8 @@ __global__ void tozero_generic(SrcWrapper input, DstWrapper output, roccv::Gener
 
     const double th = thresh.at(z_idx);
 
-    ApplyPackedRow(output, z_idx, y_idx, [=] __device__(int n, int yy, int x) -> dst_type {
-        src_type inputVal = input.at(n, yy, x, 0);
+    ApplyPackedTransform(input, output, z_idx, y_idx,
+                         [=] __device__(src_type inputVal, int /*n*/, int /*yy*/, int /*x*/) -> dst_type {
         dst_type outputVal;
         for (int i = 0; i < output.channels(); i++) {
             double ip = StaticCast<double>(GetElement(inputVal, i));
@@ -151,8 +151,8 @@ __global__ void tozeroinv_generic(SrcWrapper input, DstWrapper output, roccv::Ge
 
     const double th = thresh.at(z_idx);
 
-    ApplyPackedRow(output, z_idx, y_idx, [=] __device__(int n, int yy, int x) -> dst_type {
-        src_type inputVal = input.at(n, yy, x, 0);
+    ApplyPackedTransform(input, output, z_idx, y_idx,
+                         [=] __device__(src_type inputVal, int /*n*/, int /*yy*/, int /*x*/) -> dst_type {
         dst_type outputVal;
         for (int i = 0; i < output.channels(); i++) {
             double ip = StaticCast<double>(GetElement(inputVal, i));

--- a/include/kernels/device/thresholding_device.hpp
+++ b/include/kernels/device/thresholding_device.hpp
@@ -28,6 +28,7 @@ THE SOFTWARE.
 
 #include "core/detail/casting.hpp"
 #include "core/detail/type_traits.hpp"
+#include "kernels/device/packed_apply.hpp"
 #include "operator_types.h"
 
 namespace Kernels {
@@ -36,124 +37,130 @@ template <typename SrcWrapper, typename DstWrapper>
 __global__ void binary_generic(SrcWrapper input, DstWrapper output, roccv::GenericTensorWrapper<double> thresh,
                                roccv::GenericTensorWrapper<double> maxVal) {
     using namespace roccv::detail;
-    const auto x_idx = threadIdx.x + blockIdx.x * blockDim.x;
-    const auto y_idx = threadIdx.y + blockIdx.y * blockDim.y;
-    const auto z_idx = threadIdx.z + blockIdx.z * blockDim.z;
-
     using src_type = typename SrcWrapper::ValueType;
     using dst_type = typename DstWrapper::ValueType;
     using base_type = BaseType<dst_type>;
 
-    if (x_idx < output.width() && y_idx < output.height()) {
-        double th = thresh.at(z_idx);
-        double mv = maxVal.at(z_idx);
-        src_type inputVal = input.at(z_idx, y_idx, x_idx, 0);
+    const auto y_idx = threadIdx.y + blockIdx.y * blockDim.y;
+    const auto z_idx = blockIdx.z;
+    if (y_idx >= output.height() || z_idx >= output.batches()) return;
+
+    // Threshold/max are per-image; fetch once per thread.
+    const double th = thresh.at(z_idx);
+    const double mv = maxVal.at(z_idx);
+
+    ApplyPackedRow(output, z_idx, y_idx, [=] __device__(int n, int yy, int x) -> dst_type {
+        src_type inputVal = input.at(n, yy, x, 0);
         dst_type outputVal;
         for (int i = 0; i < output.channels(); i++) {
             double ip = StaticCast<double>(GetElement(inputVal, i));
             double outVal = ip > th ? mv : 0;
             GetElement(outputVal, i) = StaticCast<base_type>(outVal);
         }
-        output.at(z_idx, y_idx, x_idx, 0) = outputVal;
-    }
+        return outputVal;
+    });
 }
 
 template <typename SrcWrapper, typename DstWrapper>
 __global__ void binary_inv_generic(SrcWrapper input, DstWrapper output, roccv::GenericTensorWrapper<double> thresh,
                                    roccv::GenericTensorWrapper<double> maxVal) {
     using namespace roccv::detail;
-    const auto x_idx = threadIdx.x + blockIdx.x * blockDim.x;
-    const auto y_idx = threadIdx.y + blockIdx.y * blockDim.y;
-    const auto z_idx = threadIdx.z + blockIdx.z * blockDim.z;
-
     using src_type = typename SrcWrapper::ValueType;
     using dst_type = typename DstWrapper::ValueType;
     using base_type = BaseType<dst_type>;
 
-    if (x_idx < output.width() && y_idx < output.height()) {
-        double th = thresh.at(z_idx);
-        double mv = maxVal.at(z_idx);
-        src_type inputVal = input.at(z_idx, y_idx, x_idx, 0);
+    const auto y_idx = threadIdx.y + blockIdx.y * blockDim.y;
+    const auto z_idx = blockIdx.z;
+    if (y_idx >= output.height() || z_idx >= output.batches()) return;
+
+    const double th = thresh.at(z_idx);
+    const double mv = maxVal.at(z_idx);
+
+    ApplyPackedRow(output, z_idx, y_idx, [=] __device__(int n, int yy, int x) -> dst_type {
+        src_type inputVal = input.at(n, yy, x, 0);
         dst_type outputVal;
         for (int i = 0; i < output.channels(); i++) {
             double ip = StaticCast<double>(GetElement(inputVal, i));
             double outVal = ip > th ? 0 : mv;
             GetElement(outputVal, i) = StaticCast<base_type>(outVal);
         }
-        output.at(z_idx, y_idx, x_idx, 0) = outputVal;
-    }
+        return outputVal;
+    });
 }
 
 template <typename SrcWrapper, typename DstWrapper>
 __global__ void trunc_generic(SrcWrapper input, DstWrapper output, roccv::GenericTensorWrapper<double> thresh) {
     using namespace roccv::detail;
-    const auto x_idx = threadIdx.x + blockIdx.x * blockDim.x;
-    const auto y_idx = threadIdx.y + blockIdx.y * blockDim.y;
-    const auto z_idx = threadIdx.z + blockIdx.z * blockDim.z;
-
     using src_type = typename SrcWrapper::ValueType;
     using dst_type = typename DstWrapper::ValueType;
     using base_type = BaseType<dst_type>;
 
-    if (x_idx < output.width() && y_idx < output.height()) {
-        double th = thresh.at(z_idx);
-        src_type inputVal = input.at(z_idx, y_idx, x_idx, 0);
+    const auto y_idx = threadIdx.y + blockIdx.y * blockDim.y;
+    const auto z_idx = blockIdx.z;
+    if (y_idx >= output.height() || z_idx >= output.batches()) return;
+
+    const double th = thresh.at(z_idx);
+
+    ApplyPackedRow(output, z_idx, y_idx, [=] __device__(int n, int yy, int x) -> dst_type {
+        src_type inputVal = input.at(n, yy, x, 0);
         dst_type outputVal;
         for (int i = 0; i < output.channels(); i++) {
             double ip = StaticCast<double>(GetElement(inputVal, i));
             double outVal = ip > th ? th : ip;
             GetElement(outputVal, i) = StaticCast<base_type>(outVal);
         }
-        output.at(z_idx, y_idx, x_idx, 0) = outputVal;
-    }
+        return outputVal;
+    });
 }
 
 template <typename SrcWrapper, typename DstWrapper>
 __global__ void tozero_generic(SrcWrapper input, DstWrapper output, roccv::GenericTensorWrapper<double> thresh) {
     using namespace roccv::detail;
-    const auto x_idx = threadIdx.x + blockIdx.x * blockDim.x;
-    const auto y_idx = threadIdx.y + blockIdx.y * blockDim.y;
-    const auto z_idx = threadIdx.z + blockIdx.z * blockDim.z;
-
     using src_type = typename SrcWrapper::ValueType;
     using dst_type = typename DstWrapper::ValueType;
     using base_type = BaseType<dst_type>;
 
-    if (x_idx < output.width() && y_idx < output.height()) {
-        double th = thresh.at(z_idx);
-        src_type inputVal = input.at(z_idx, y_idx, x_idx, 0);
+    const auto y_idx = threadIdx.y + blockIdx.y * blockDim.y;
+    const auto z_idx = blockIdx.z;
+    if (y_idx >= output.height() || z_idx >= output.batches()) return;
+
+    const double th = thresh.at(z_idx);
+
+    ApplyPackedRow(output, z_idx, y_idx, [=] __device__(int n, int yy, int x) -> dst_type {
+        src_type inputVal = input.at(n, yy, x, 0);
         dst_type outputVal;
         for (int i = 0; i < output.channels(); i++) {
             double ip = StaticCast<double>(GetElement(inputVal, i));
             double outVal = ip > th ? ip : 0;
             GetElement(outputVal, i) = StaticCast<base_type>(outVal);
         }
-        output.at(z_idx, y_idx, x_idx, 0) = outputVal;
-    }
+        return outputVal;
+    });
 }
 
 template <typename SrcWrapper, typename DstWrapper>
 __global__ void tozeroinv_generic(SrcWrapper input, DstWrapper output, roccv::GenericTensorWrapper<double> thresh) {
     using namespace roccv::detail;
-    const auto x_idx = threadIdx.x + blockIdx.x * blockDim.x;
-    const auto y_idx = threadIdx.y + blockIdx.y * blockDim.y;
-    const auto z_idx = threadIdx.z + blockIdx.z * blockDim.z;
-
     using src_type = typename SrcWrapper::ValueType;
     using dst_type = typename DstWrapper::ValueType;
     using base_type = BaseType<dst_type>;
 
-    if (x_idx >= output.width() || y_idx >= output.height()) return;
+    const auto y_idx = threadIdx.y + blockIdx.y * blockDim.y;
+    const auto z_idx = blockIdx.z;
+    if (y_idx >= output.height() || z_idx >= output.batches()) return;
 
-    double th = thresh.at(z_idx);
-    src_type inputVal = input.at(z_idx, y_idx, x_idx, 0);
-    dst_type outputVal;
-    for (int i = 0; i < output.channels(); i++) {
-        double ip = StaticCast<double>(GetElement(inputVal, i));
-        double outVal = ip > th ? 0 : ip;
-        GetElement(outputVal, i) = StaticCast<base_type>(outVal);
-    }
-    output.at(z_idx, y_idx, x_idx, 0) = outputVal;
+    const double th = thresh.at(z_idx);
+
+    ApplyPackedRow(output, z_idx, y_idx, [=] __device__(int n, int yy, int x) -> dst_type {
+        src_type inputVal = input.at(n, yy, x, 0);
+        dst_type outputVal;
+        for (int i = 0; i < output.channels(); i++) {
+            double ip = StaticCast<double>(GetElement(inputVal, i));
+            double outVal = ip > th ? 0 : ip;
+            GetElement(outputVal, i) = StaticCast<base_type>(outVal);
+        }
+        return outputVal;
+    });
 }
 }  // namespace Device
 }  // namespace Kernels

--- a/include/kernels/device/warp_affine_device.hpp
+++ b/include/kernels/device/warp_affine_device.hpp
@@ -29,6 +29,9 @@ THE SOFTWARE.
 namespace Kernels {
 namespace Device {
 
+// NOTE: warp_affine is gather-read-bound (arbitrary affine source coordinates have no row locality), so the packed
+// vector-write strategy used by the elementwise/resize kernels regresses it (serialized per-thread gathers + register
+// pressure collapse occupancy). It is intentionally left as a scalar one-output-pixel-per-thread kernel.
 template <typename SrcWrapper, typename DstWrapper, typename Mat>
 __global__ void warp_affine(SrcWrapper input, DstWrapper output, Mat mat) {
     const int x = blockDim.x * blockIdx.x + threadIdx.x;

--- a/include/kernels/device/warp_perspective_device.hpp
+++ b/include/kernels/device/warp_perspective_device.hpp
@@ -29,6 +29,8 @@ THE SOFTWARE.
 namespace Kernels {
 namespace Device {
 
+// NOTE: like warp_affine, warp_perspective is gather-read-bound and regresses under the packed vector-write strategy,
+// so it is intentionally kept as a scalar one-output-pixel-per-thread kernel.
 template <typename SrcWrapper, typename DstWrapper, typename Mat>
 __global__ void warp_perspective(SrcWrapper input, DstWrapper output, Mat mat) {
     const int x = blockDim.x * blockIdx.x + threadIdx.x;

--- a/src/op_brightness_contrast.cpp
+++ b/src/op_brightness_contrast.cpp
@@ -105,9 +105,9 @@ void dispatch_brightness_contrast_channels(hipStream_t stream, const Tensor &inp
     // Launch CPU/GPU kernel depending on requested device type.
     switch (device) {
         case eDeviceType::GPU: {
-            dim3 block(64, 16);
-            dim3 grid((outputWrapper.width() + block.x - 1) / block.x, (outputWrapper.height() + block.y - 1) / block.y,
-                      outputWrapper.batches());
+            dim3 block = Kernels::Device::PackedBlock();
+            dim3 grid = Kernels::Device::PackedGrid<DST_DT_NC>(outputWrapper.width(), outputWrapper.height(),
+                                                               outputWrapper.batches(), block);
             Kernels::Device::brightness_contrast<<<grid, block, 0, stream>>>(inputWrapper, outputWrapper, bc_wrappers);
             break;
         }

--- a/src/op_composite.cpp
+++ b/src/op_composite.cpp
@@ -21,6 +21,8 @@
 
 #include "op_composite.hpp"
 
+#include <functional>
+
 #include "common/validation_helpers.hpp"
 #include "core/wrappers/image_wrapper.hpp"
 #include "kernels/device/composite_device.hpp"
@@ -55,37 +57,42 @@ void dispatch_composite_masktype(hipStream_t stream, const Tensor& foreground, c
 template <typename SrcType, typename DstType>
 void dispatch_composite_dsttype(hipStream_t stream, const Tensor& foreground, const Tensor& background,
                                 const Tensor& mask, const Tensor& output, eDeviceType device) {
-    // Mask is validated upstream to be single-channel U8 or F32.
-    switch (mask.dtype().etype()) {
-        case eDataType::DATA_TYPE_U8:
-            dispatch_composite_masktype<SrcType, DstType, uchar1>(stream, foreground, background, mask, output, device);
-            break;
-        case eDataType::DATA_TYPE_F32:
-            dispatch_composite_masktype<SrcType, DstType, float1>(stream, foreground, background, mask, output, device);
-            break;
-        default:
-            throw Exception("Operator does not support the given datatype for the mask tensor.",
-                            eStatusType::NOT_IMPLEMENTED);
+    // clang-format off
+    static const std::unordered_map<eDataType, std::array<std::function<void(hipStream_t, const Tensor&, const Tensor&, const Tensor&, const Tensor&, eDeviceType)>, 4>>
+        funcs = {
+            {eDataType::DATA_TYPE_U8, {dispatch_composite_masktype<SrcType, DstType, uchar1>, 0, 0, 0}},
+            {eDataType::DATA_TYPE_F32, {dispatch_composite_masktype<SrcType, DstType, float1>, 0, 0, 0}}
+        };
+    // clang-format on
+
+    if (!funcs.contains(mask.dtype().etype())) {
+        throw Exception("Operator does not support the given datatype for the mask tensor.",
+                        eStatusType::NOT_IMPLEMENTED);
     }
+
+    auto func = funcs.at(mask.dtype().etype())[mask.shape(mask.layout().channels_index()) - 1];
+    if (func == 0) {
+        throw Exception("Operator does not support the given channel count for the mask tensor.",
+                        eStatusType::NOT_IMPLEMENTED);
+    }
+
+    func(stream, foreground, background, mask, output, device);
 }
 
 template <typename SrcType>
 void dispatch_composite_srctype(hipStream_t stream, const Tensor& foreground, const Tensor& background,
                                 const Tensor& mask, const Tensor& output, eDeviceType device) {
-    // Output is validated upstream to be U8 or F32 with 3 or 4 channels.
-    const eDataType dtype = output.dtype().etype();
-    const int64_t channels = output.shape(output.layout().channels_index());
+    // clang-format off
+    static const std::unordered_map<eDataType, std::array<std::function<void(hipStream_t, const Tensor&, const Tensor&, const Tensor&, const Tensor&, eDeviceType)>, 4>>
+        funcs = {
+            {eDataType::DATA_TYPE_U8,  {0, 0, dispatch_composite_dsttype<SrcType, uchar3>, dispatch_composite_dsttype<SrcType, uchar4>}},
+            {eDataType::DATA_TYPE_F32, {0, 0, dispatch_composite_dsttype<SrcType, float3>, dispatch_composite_dsttype<SrcType, float4>}}
+        };
+    // clang-format on
 
-    if (dtype == eDataType::DATA_TYPE_U8 && channels == 3)
-        dispatch_composite_dsttype<SrcType, uchar3>(stream, foreground, background, mask, output, device);
-    else if (dtype == eDataType::DATA_TYPE_U8 && channels == 4)
-        dispatch_composite_dsttype<SrcType, uchar4>(stream, foreground, background, mask, output, device);
-    else if (dtype == eDataType::DATA_TYPE_F32 && channels == 3)
-        dispatch_composite_dsttype<SrcType, float3>(stream, foreground, background, mask, output, device);
-    else if (dtype == eDataType::DATA_TYPE_F32 && channels == 4)
-        dispatch_composite_dsttype<SrcType, float4>(stream, foreground, background, mask, output, device);
-    else
-        throw Exception("Not mapped to a defined function.", eStatusType::INVALID_OPERATION);
+    auto func = funcs.at(output.dtype().etype())[output.shape(output.layout().channels_index()) - 1];
+    if (func == 0) throw Exception("Not mapped to a defined function.", eStatusType::INVALID_OPERATION);
+    func(stream, foreground, background, mask, output, device);
 }
 
 void Composite::operator()(hipStream_t stream, const Tensor& foreground, const Tensor& background, const Tensor& mask,
@@ -136,16 +143,16 @@ void Composite::operator()(hipStream_t stream, const Tensor& foreground, const T
 
     CHECK_TENSOR_CHANNELS(output, 3, 4);
 
-    // Foreground/background are validated upstream to be 3-channel U8 or F32.
-    switch (foreground.dtype().etype()) {
-        case eDataType::DATA_TYPE_U8:
-            dispatch_composite_srctype<uchar3>(stream, foreground, background, mask, output, device);
-            break;
-        case eDataType::DATA_TYPE_F32:
-            dispatch_composite_srctype<float3>(stream, foreground, background, mask, output, device);
-            break;
-        default:
-            throw Exception("Not mapped to a defined function.", eStatusType::INVALID_OPERATION);
-    }
+    // clang-format off
+    static const std::unordered_map<eDataType, std::array<std::function<void(hipStream_t, const Tensor&, const Tensor&, const Tensor&, const Tensor&, eDeviceType)>, 4>>
+        funcs = {
+            {eDataType::DATA_TYPE_U8,  {0, 0, dispatch_composite_srctype<uchar3>, 0}},
+            {eDataType::DATA_TYPE_F32, {0, 0, dispatch_composite_srctype<float3>, 0}}
+        };
+    // clang-format on
+
+    auto func = funcs.at(foreground.dtype().etype())[foreground.shape(output.layout().channels_index()) - 1];
+    if (func == 0) throw Exception("Not mapped to a defined function.", eStatusType::INVALID_OPERATION);
+    func(stream, foreground, background, mask, output, device);
 }
 };  // namespace roccv

--- a/src/op_composite.cpp
+++ b/src/op_composite.cpp
@@ -21,8 +21,6 @@
 
 #include "op_composite.hpp"
 
-#include <functional>
-
 #include "common/validation_helpers.hpp"
 #include "core/wrappers/image_wrapper.hpp"
 #include "kernels/device/composite_device.hpp"
@@ -57,42 +55,37 @@ void dispatch_composite_masktype(hipStream_t stream, const Tensor& foreground, c
 template <typename SrcType, typename DstType>
 void dispatch_composite_dsttype(hipStream_t stream, const Tensor& foreground, const Tensor& background,
                                 const Tensor& mask, const Tensor& output, eDeviceType device) {
-    // clang-format off
-    static const std::unordered_map<eDataType, std::array<std::function<void(hipStream_t, const Tensor&, const Tensor&, const Tensor&, const Tensor&, eDeviceType)>, 4>>
-        funcs = {
-            {eDataType::DATA_TYPE_U8, {dispatch_composite_masktype<SrcType, DstType, uchar1>, 0, 0, 0}},
-            {eDataType::DATA_TYPE_F32, {dispatch_composite_masktype<SrcType, DstType, float1>, 0, 0, 0}}
-        };
-    // clang-format on
-
-    if (!funcs.contains(mask.dtype().etype())) {
-        throw Exception("Operator does not support the given datatype for the mask tensor.",
-                        eStatusType::NOT_IMPLEMENTED);
+    // Mask is validated upstream to be single-channel U8 or F32.
+    switch (mask.dtype().etype()) {
+        case eDataType::DATA_TYPE_U8:
+            dispatch_composite_masktype<SrcType, DstType, uchar1>(stream, foreground, background, mask, output, device);
+            break;
+        case eDataType::DATA_TYPE_F32:
+            dispatch_composite_masktype<SrcType, DstType, float1>(stream, foreground, background, mask, output, device);
+            break;
+        default:
+            throw Exception("Operator does not support the given datatype for the mask tensor.",
+                            eStatusType::NOT_IMPLEMENTED);
     }
-
-    auto func = funcs.at(mask.dtype().etype())[mask.shape(mask.layout().channels_index()) - 1];
-    if (func == 0) {
-        throw Exception("Operator does not support the given channel count for the mask tensor.",
-                        eStatusType::NOT_IMPLEMENTED);
-    }
-
-    func(stream, foreground, background, mask, output, device);
 }
 
 template <typename SrcType>
 void dispatch_composite_srctype(hipStream_t stream, const Tensor& foreground, const Tensor& background,
                                 const Tensor& mask, const Tensor& output, eDeviceType device) {
-    // clang-format off
-    static const std::unordered_map<eDataType, std::array<std::function<void(hipStream_t, const Tensor&, const Tensor&, const Tensor&, const Tensor&, eDeviceType)>, 4>>
-        funcs = {
-            {eDataType::DATA_TYPE_U8,  {0, 0, dispatch_composite_dsttype<SrcType, uchar3>, dispatch_composite_dsttype<SrcType, uchar4>}},
-            {eDataType::DATA_TYPE_F32, {0, 0, dispatch_composite_dsttype<SrcType, float3>, dispatch_composite_dsttype<SrcType, float4>}}
-        };
-    // clang-format on
+    // Output is validated upstream to be U8 or F32 with 3 or 4 channels.
+    const eDataType dtype = output.dtype().etype();
+    const int64_t channels = output.shape(output.layout().channels_index());
 
-    auto func = funcs.at(output.dtype().etype())[output.shape(output.layout().channels_index()) - 1];
-    if (func == 0) throw Exception("Not mapped to a defined function.", eStatusType::INVALID_OPERATION);
-    func(stream, foreground, background, mask, output, device);
+    if (dtype == eDataType::DATA_TYPE_U8 && channels == 3)
+        dispatch_composite_dsttype<SrcType, uchar3>(stream, foreground, background, mask, output, device);
+    else if (dtype == eDataType::DATA_TYPE_U8 && channels == 4)
+        dispatch_composite_dsttype<SrcType, uchar4>(stream, foreground, background, mask, output, device);
+    else if (dtype == eDataType::DATA_TYPE_F32 && channels == 3)
+        dispatch_composite_dsttype<SrcType, float3>(stream, foreground, background, mask, output, device);
+    else if (dtype == eDataType::DATA_TYPE_F32 && channels == 4)
+        dispatch_composite_dsttype<SrcType, float4>(stream, foreground, background, mask, output, device);
+    else
+        throw Exception("Not mapped to a defined function.", eStatusType::INVALID_OPERATION);
 }
 
 void Composite::operator()(hipStream_t stream, const Tensor& foreground, const Tensor& background, const Tensor& mask,
@@ -143,16 +136,16 @@ void Composite::operator()(hipStream_t stream, const Tensor& foreground, const T
 
     CHECK_TENSOR_CHANNELS(output, 3, 4);
 
-    // clang-format off
-    static const std::unordered_map<eDataType, std::array<std::function<void(hipStream_t, const Tensor&, const Tensor&, const Tensor&, const Tensor&, eDeviceType)>, 4>>
-        funcs = {
-            {eDataType::DATA_TYPE_U8,  {0, 0, dispatch_composite_srctype<uchar3>, 0}},
-            {eDataType::DATA_TYPE_F32, {0, 0, dispatch_composite_srctype<float3>, 0}}
-        };
-    // clang-format on
-
-    auto func = funcs.at(foreground.dtype().etype())[foreground.shape(output.layout().channels_index()) - 1];
-    if (func == 0) throw Exception("Not mapped to a defined function.", eStatusType::INVALID_OPERATION);
-    func(stream, foreground, background, mask, output, device);
+    // Foreground/background are validated upstream to be 3-channel U8 or F32.
+    switch (foreground.dtype().etype()) {
+        case eDataType::DATA_TYPE_U8:
+            dispatch_composite_srctype<uchar3>(stream, foreground, background, mask, output, device);
+            break;
+        case eDataType::DATA_TYPE_F32:
+            dispatch_composite_srctype<float3>(stream, foreground, background, mask, output, device);
+            break;
+        default:
+            throw Exception("Not mapped to a defined function.", eStatusType::INVALID_OPERATION);
+    }
 }
 };  // namespace roccv

--- a/src/op_composite.cpp
+++ b/src/op_composite.cpp
@@ -40,9 +40,9 @@ void dispatch_composite_masktype(hipStream_t stream, const Tensor& foreground, c
 
     switch (device) {
         case eDeviceType::GPU: {
-            dim3 block(64, 16);
-            dim3 grid((outputWrapper.width() + block.x - 1) / block.x, (outputWrapper.height() + block.y - 1) / block.y,
-                      outputWrapper.batches());
+            dim3 block = Kernels::Device::PackedBlock();
+            dim3 grid = Kernels::Device::PackedGrid<DstType>(outputWrapper.width(), outputWrapper.height(),
+                                                             outputWrapper.batches(), block);
             Kernels::Device::composite<<<grid, block, 0, stream>>>(fgWrapper, bgWrapper, maskWrapper, outputWrapper);
             break;
         }

--- a/src/op_convert_to.cpp
+++ b/src/op_convert_to.cpp
@@ -21,22 +21,22 @@ THE SOFTWARE.
 */
 #include "op_convert_to.hpp"
 
+#include <hip/hip_runtime.h>
+
 #include <functional>
 
-#include <hip/hip_runtime.h>
-#include "core/wrappers/image_wrapper.hpp"
 #include "common/validation_helpers.hpp"
 #include "core/detail/casting.hpp"
 #include "core/detail/type_traits.hpp"
+#include "core/wrappers/image_wrapper.hpp"
 #include "kernels/device/convert_to_device.hpp"
 #include "kernels/host/convert_to_host.hpp"
 
 namespace roccv {
 
 template <typename SRC_DT, typename DST_DT, int NC>
-void dispatch_convert_to_channels(hipStream_t stream, const Tensor &input, const Tensor &output,
-                                       double alpha, double beta, eDeviceType device) {
-    
+void dispatch_convert_to_channels(hipStream_t stream, const Tensor &input, const Tensor &output, double alpha,
+                                  double beta, eDeviceType device) {
     using SRC_DT_NC = detail::MakeType<SRC_DT, NC>;
     using DST_DT_NC = detail::MakeType<DST_DT, NC>;
 
@@ -47,16 +47,16 @@ void dispatch_convert_to_channels(hipStream_t stream, const Tensor &input, const
     using DST_BT = detail::BaseType<DST_DT>;
 
     using DT_AB = decltype(float() * SRC_BT() * DST_BT());
-    
+
     DT_AB alpha_ab = detail::SaturateCast<DT_AB>(alpha);
     DT_AB beta_ab = detail::SaturateCast<DT_AB>(beta);
 
     // Launch CPU/GPU kernel depending on requested device type.
     switch (device) {
         case eDeviceType::GPU: {
-            dim3 block(64, 16);
-            dim3 grid((outputWrapper.width() + block.x - 1) / block.x, (outputWrapper.height() + block.y - 1) / block.y,
-                      outputWrapper.batches());
+            dim3 block = Kernels::Device::PackedBlock();
+            dim3 grid = Kernels::Device::PackedGrid<DST_DT_NC>(outputWrapper.width(), outputWrapper.height(),
+                                                               outputWrapper.batches(), block);
             Kernels::Device::convert_to<<<grid, block, 0, stream>>>(inputWrapper, outputWrapper, alpha_ab, beta_ab);
             break;
         }
@@ -68,16 +68,14 @@ void dispatch_convert_to_channels(hipStream_t stream, const Tensor &input, const
 }
 
 template <typename SRC_DT, typename DST_DT>
-void dispatch_convert_to_output_dtype(hipStream_t stream, const Tensor &input, const Tensor &output,
-                                       double alpha, double beta, eDeviceType device) {
-
+void dispatch_convert_to_output_dtype(hipStream_t stream, const Tensor &input, const Tensor &output, double alpha,
+                                      double beta, eDeviceType device) {
     int64_t channels = output.shape(output.layout().channels_index());
     // Select kernel dispatcher based on number of channels.
     // clang-format off
     static const std::array<std::function<void(hipStream_t, const Tensor &, const Tensor &, double, double, eDeviceType)>, 4>
         funcs = {dispatch_convert_to_channels<SRC_DT, DST_DT, 1>, dispatch_convert_to_channels<SRC_DT, DST_DT, 2>, dispatch_convert_to_channels<SRC_DT, DST_DT, 3>, dispatch_convert_to_channels<SRC_DT, DST_DT, 4>};
-        
-            
+
     // clang-format on
 
     auto func = funcs.at(channels - 1);
@@ -86,11 +84,10 @@ void dispatch_convert_to_output_dtype(hipStream_t stream, const Tensor &input, c
 }
 
 template <typename SRC_DT>
-void dispatch_convert_to_input_dtype(hipStream_t stream, const Tensor &input, const Tensor &output,
-                                       double alpha, double beta, eDeviceType device) {
-    
+void dispatch_convert_to_input_dtype(hipStream_t stream, const Tensor &input, const Tensor &output, double alpha,
+                                     double beta, eDeviceType device) {
     eDataType output_dtype = output.dtype().etype();
-    
+
     // Select kernel dispatcher based on a base input datatype.
     // clang-format off
     static const std::unordered_map<eDataType, std::function<void(hipStream_t, const Tensor &, const Tensor &, double, double, eDeviceType)>>

--- a/src/op_copy_make_border.cpp
+++ b/src/op_copy_make_border.cpp
@@ -43,9 +43,9 @@ void dispatch_copy_make_border_border_mode(hipStream_t stream, const Tensor& inp
 
     switch (device) {
         case eDeviceType::GPU: {
-            dim3 block_dim(64, 16);
-            dim3 grid_dim((out_desc.width() + block_dim.x - 1) / block_dim.x,
-                          (out_desc.height() + block_dim.y - 1) / block_dim.y, out_desc.batches());
+            dim3 block_dim = Kernels::Device::PackedBlock();
+            dim3 grid_dim =
+                Kernels::Device::PackedGrid<T>(out_desc.width(), out_desc.height(), out_desc.batches(), block_dim);
             Kernels::Device::copy_make_border<<<grid_dim, block_dim, 0, stream>>>(in_desc, out_desc, top, left);
             break;
         }
@@ -83,8 +83,7 @@ void dispatch_copy_make_border(hipStream_t stream, const Tensor& input, const Te
 }
 
 void CopyMakeBorder::operator()(hipStream_t stream, const Tensor& input, const Tensor& output, int32_t top,
-                                int32_t left, eBorderType border_mode, float4 border_value,
-                                eDeviceType device) const {
+                                int32_t left, eBorderType border_mode, float4 border_value, eDeviceType device) const {
     CHECK_TENSOR_DEVICE(input, device);
     CHECK_TENSOR_LAYOUT(input, eTensorLayout::TENSOR_LAYOUT_NHWC, eTensorLayout::TENSOR_LAYOUT_HWC);
     CHECK_TENSOR_DATATYPES(input, eDataType::DATA_TYPE_U8, eDataType::DATA_TYPE_S8, eDataType::DATA_TYPE_U16,

--- a/src/op_custom_crop.cpp
+++ b/src/op_custom_crop.cpp
@@ -40,9 +40,9 @@ void dispatch_custom_crop_dtype(hipStream_t stream, const Tensor& input, const T
 
     switch (device) {
         case eDeviceType::GPU: {
-            dim3 block(64, 16);
-            dim3 grid((outputWrapper.width() + block.x - 1) / block.x, (outputWrapper.height() + block.y - 1) / block.y,
-                      outputWrapper.batches());
+            dim3 block = Kernels::Device::PackedBlock();
+            dim3 grid = Kernels::Device::PackedGrid<T>(outputWrapper.width(), outputWrapper.height(),
+                                                       outputWrapper.batches(), block);
             Kernels::Device::custom_crop<<<grid, block, 0, stream>>>(inputWrapper, outputWrapper, cropRect);
             break;
         }

--- a/src/op_cvt_color.cpp
+++ b/src/op_cvt_color.cpp
@@ -81,18 +81,21 @@ void CvtColor::operator()(hipStream_t stream, const Tensor &input, Tensor &outpu
     if (device == eDeviceType::GPU) {
         // Dispatch appropriate device kernel based on given conversion code
 
-        dim3 blockSize(32, 16);
-        dim3 gridSize((width + blockSize.x - 1) / blockSize.x, (height + blockSize.y - 1) / blockSize.y, samples);
+        // Packed launches: pixel runs along x are written with a single vector store. Grayscale outputs a 1-channel
+        // pixel (different pack width) so it gets its own grid; all other conversions output a 3-channel pixel.
+        dim3 blockSize = Kernels::Device::PackedBlock();
+        dim3 gridSize = Kernels::Device::PackedGrid<uchar3>(width, height, samples, blockSize);
+        dim3 grayGridSize = Kernels::Device::PackedGrid<uchar1>(width, height, samples, blockSize);
 
         switch (conversionCode) {
             case eColorConversionCode::COLOR_BGR2GRAY:
                 Kernels::Device::rgb_or_bgr_to_grayscale<uchar3, eSwizzle::ZYXW>
-                    <<<gridSize, blockSize, 0, stream>>>(ImageWrapper<uchar3>(input), ImageWrapper<uchar1>(output));
+                    <<<grayGridSize, blockSize, 0, stream>>>(ImageWrapper<uchar3>(input), ImageWrapper<uchar1>(output));
                 break;
 
             case eColorConversionCode::COLOR_RGB2GRAY:
                 Kernels::Device::rgb_or_bgr_to_grayscale<uchar3, eSwizzle::XYZW>
-                    <<<gridSize, blockSize, 0, stream>>>(ImageWrapper<uchar3>(input), ImageWrapper<uchar1>(output));
+                    <<<grayGridSize, blockSize, 0, stream>>>(ImageWrapper<uchar3>(input), ImageWrapper<uchar1>(output));
                 break;
 
             case eColorConversionCode::COLOR_BGR2RGB:

--- a/src/op_flip.cpp
+++ b/src/op_flip.cpp
@@ -42,9 +42,9 @@ void dispatch_flip_axis(hipStream_t stream, const Tensor& input, const Tensor& o
 
     switch (device) {
         case eDeviceType::GPU: {
-            dim3 block(64, 16);
-            dim3 grid((outputWrapper.width() + block.x - 1) / block.x, (outputWrapper.height() + block.y - 1) / block.y,
-                      outputWrapper.batches());
+            dim3 block = Kernels::Device::PackedBlock();
+            dim3 grid = Kernels::Device::PackedGrid<T>(outputWrapper.width(), outputWrapper.height(),
+                                                       outputWrapper.batches(), block);
             Kernels::Device::flip<FlipType><<<grid, block, 0, stream>>>(inputWrapper, outputWrapper);
             break;
         }
@@ -70,8 +70,8 @@ void dispatch_flip_dtype(hipStream_t stream, const Tensor& input, const Tensor& 
     }
 
     // Dispatch proper kernel based on provided flip type.
-    std::unordered_map<eAxis, std::function<void(hipStream_t stream, const Tensor& input, const Tensor& output,
-                                                 eDeviceType device)>>
+    std::unordered_map<
+        eAxis, std::function<void(hipStream_t stream, const Tensor& input, const Tensor& output, eDeviceType device)>>
         funcs = {{eAxis::X, dispatch_flip_axis<T, eAxis::X>},
                  {eAxis::Y, dispatch_flip_axis<T, eAxis::Y>},
                  {eAxis::BOTH, dispatch_flip_axis<T, eAxis::BOTH>}};

--- a/src/op_gamma_contrast.cpp
+++ b/src/op_gamma_contrast.cpp
@@ -47,9 +47,9 @@ void dispatch_gamma_contrast_dtype(hipStream_t stream, const Tensor &input, cons
     ImageWrapper<T> outputWrapper(output);
 
     if (device == eDeviceType::GPU) {
-        dim3 block(64, 16);
-        dim3 grid((outputWrapper.width() + block.x - 1) / block.x, (outputWrapper.height() + block.y - 1) / block.y,
-                  outputWrapper.batches());
+        dim3 block = Kernels::Device::PackedBlock();
+        dim3 grid = Kernels::Device::PackedGrid<T>(outputWrapper.width(), outputWrapper.height(),
+                                                   outputWrapper.batches(), block);
 
         Kernels::Device::gamma_contrast<<<grid, block, 0, stream>>>(inputWrapper, outputWrapper, gamma);
     } else if (device == eDeviceType::CPU) {

--- a/src/op_normalize.cpp
+++ b/src/op_normalize.cpp
@@ -49,9 +49,9 @@ void dispatch_normalize_stddev(hipStream_t stream, const Tensor& input, const Te
 
     switch (device) {
         case eDeviceType::GPU: {
-            dim3 block(32, 8);
-            dim3 grid((outputWrap.width() + block.x - 1) / block.x, (outputWrap.height() + block.y - 1) / block.y,
-                      outputWrap.batches());
+            dim3 block = Kernels::Device::PackedBlock();
+            dim3 grid =
+                Kernels::Device::PackedGrid<T>(outputWrap.width(), outputWrap.height(), outputWrap.batches(), block);
             Kernels::Device::normalize<ScaleStddev>
                 <<<grid, block, 0, stream>>>(inputWrap, baseWrap, scaleWrap, outputWrap, global_scale, shift, epsilon);
             break;
@@ -112,7 +112,8 @@ void Normalize::operator()(hipStream_t stream, const Tensor& input, const Tensor
     // TODO: Need to support scalar base/scale tensors at some point. Will require some extra handling on the kernel
     // level. Once in place, this check can be removed.
     CHECK_TENSOR_COMPARISON(base.shape(base.layout().channels_index()) == input.shape(input.layout().channels_index()));
-    CHECK_TENSOR_COMPARISON(scale.shape(scale.layout().channels_index()) == input.shape(input.layout().channels_index()));
+    CHECK_TENSOR_COMPARISON(scale.shape(scale.layout().channels_index()) ==
+                            input.shape(input.layout().channels_index()));
 
     // Create kernel dispatching table based on input/output datatype and number of channels.
     // clang-format off

--- a/src/op_remap.cpp
+++ b/src/op_remap.cpp
@@ -91,9 +91,9 @@ void dispatch_remap_mapInterp(hipStream_t stream, const Tensor &input, const Ten
     // Launch CPU/GPU kernel depending on requested device type.
     switch (device) {
         case eDeviceType::GPU: {
-            dim3 block(64, 16);
-            dim3 grid((outputWrapper.width() + block.x - 1) / block.x, (outputWrapper.height() + block.y - 1) / block.y,
-                      outputWrapper.batches());
+            dim3 block = Kernels::Device::PackedBlock();
+            dim3 grid = Kernels::Device::PackedGrid<T>(outputWrapper.width(), outputWrapper.height(),
+                                                       outputWrapper.batches(), block);
             Kernels::Device::remap<<<grid, block, 0, stream>>>(inputWrapper, outputWrapper, wrappedMapTensor,
                                                                mapBatchSize, params);
             break;

--- a/src/op_resize.cpp
+++ b/src/op_resize.cpp
@@ -45,14 +45,11 @@ void dispatch_resize_interp(hipStream_t stream, const Tensor& input, const Tenso
 
     switch (device) {
         case eDeviceType::GPU: {
-            // Each thread emits a run of NIX output pixels along x for a single coalesced vector write.
-            constexpr int NIX = Kernels::Device::ResizeNIX<T>;
-            using DstPack = Kernels::Device::ResizePack<T>;
+            // Each thread emits a run of PackWidth<T> output pixels along x for a single coalesced vector write.
             dim3 block(64, 8);
-            dim3 grid((outputWrapper.width() + block.x * NIX - 1) / (block.x * NIX),
-                      (outputWrapper.height() + block.y - 1) / block.y, outputWrapper.batches());
-            Kernels::Device::resize<NIX, DstPack>
-                <<<grid, block, 0, stream>>>(inputWrapper, outputWrapper, scaleX, scaleY);
+            dim3 grid = Kernels::Device::PackedGrid<T>(outputWrapper.width(), outputWrapper.height(),
+                                                       outputWrapper.batches(), block);
+            Kernels::Device::resize<<<grid, block, 0, stream>>>(inputWrapper, outputWrapper, scaleX, scaleY);
             break;
         }
 

--- a/src/op_resize.cpp
+++ b/src/op_resize.cpp
@@ -45,10 +45,14 @@ void dispatch_resize_interp(hipStream_t stream, const Tensor& input, const Tenso
 
     switch (device) {
         case eDeviceType::GPU: {
-            dim3 block(64, 16);
-            dim3 grid((outputWrapper.width() + block.x - 1) / block.x, (outputWrapper.height() + block.y - 1) / block.y,
-                      outputWrapper.batches());
-            Kernels::Device::resize<<<grid, block, 0, stream>>>(inputWrapper, outputWrapper, scaleX, scaleY);
+            // Each thread emits a run of NIX output pixels along x for a single coalesced vector write.
+            constexpr int NIX = Kernels::Device::ResizeNIX<T>;
+            using DstPack = Kernels::Device::ResizePack<T>;
+            dim3 block(64, 8);
+            dim3 grid((outputWrapper.width() + block.x * NIX - 1) / (block.x * NIX),
+                      (outputWrapper.height() + block.y - 1) / block.y, outputWrapper.batches());
+            Kernels::Device::resize<NIX, DstPack>
+                <<<grid, block, 0, stream>>>(inputWrapper, outputWrapper, scaleX, scaleY);
             break;
         }
 
@@ -62,13 +66,13 @@ void dispatch_resize_interp(hipStream_t stream, const Tensor& input, const Tenso
 template <typename T>
 void dispatch_resize_dtype(hipStream_t stream, const Tensor& input, const Tensor& output,
                            eInterpolationType interpolation, eDeviceType device) {
-    static const std::unordered_map<
-        eInterpolationType,
-        std::function<void(hipStream_t stream, const Tensor& input, const Tensor& output, eDeviceType device)>>
-        funcs = {{eInterpolationType::INTERP_TYPE_NEAREST, dispatch_resize_interp<T, eInterpolationType::INTERP_TYPE_NEAREST>},
-                 {eInterpolationType::INTERP_TYPE_LINEAR, dispatch_resize_interp<T, eInterpolationType::INTERP_TYPE_LINEAR>},
-                 {eInterpolationType::INTERP_TYPE_CUBIC, dispatch_resize_interp<T, eInterpolationType::INTERP_TYPE_CUBIC>}
-                };
+    static const std::unordered_map<eInterpolationType, std::function<void(hipStream_t stream, const Tensor& input,
+                                                                           const Tensor& output, eDeviceType device)>>
+        funcs = {
+            {eInterpolationType::INTERP_TYPE_NEAREST,
+             dispatch_resize_interp<T, eInterpolationType::INTERP_TYPE_NEAREST>},
+            {eInterpolationType::INTERP_TYPE_LINEAR, dispatch_resize_interp<T, eInterpolationType::INTERP_TYPE_LINEAR>},
+            {eInterpolationType::INTERP_TYPE_CUBIC, dispatch_resize_interp<T, eInterpolationType::INTERP_TYPE_CUBIC>}};
 
     if (!funcs.contains(interpolation)) {
         throw Exception("Operation does not support the given interpolation mode.", eStatusType::NOT_IMPLEMENTED);
@@ -78,8 +82,8 @@ void dispatch_resize_dtype(hipStream_t stream, const Tensor& input, const Tensor
     func(stream, input, output, device);
 }
 
-void Resize::operator()(hipStream_t stream, const Tensor& input, const Tensor& output,
-                        eInterpolationType interpolation, eDeviceType device) const {
+void Resize::operator()(hipStream_t stream, const Tensor& input, const Tensor& output, eInterpolationType interpolation,
+                        eDeviceType device) const {
     CHECK_TENSOR_DEVICE(input, device);
     CHECK_TENSOR_DEVICE(output, device);
 

--- a/src/op_rotate.cpp
+++ b/src/op_rotate.cpp
@@ -59,9 +59,9 @@ void dispatch_rotate_interp(hipStream_t stream, const Tensor &input, const Tenso
 
     switch (device) {
         case eDeviceType::GPU: {
-            dim3 block(32, 16);
-            dim3 grid((outputWrap.width() + block.x - 1) / block.x, (outputWrap.height() + block.y - 1) / block.y,
-                      outputWrap.batches());
+            dim3 block = Kernels::Device::PackedBlock();
+            dim3 grid =
+                Kernels::Device::PackedGrid<T>(outputWrap.width(), outputWrap.height(), outputWrap.batches(), block);
             Kernels::Device::rotate<<<grid, block, 0, stream>>>(inputWrap, outputWrap, matWrap);
             break;
         }
@@ -74,8 +74,8 @@ void dispatch_rotate_interp(hipStream_t stream, const Tensor &input, const Tenso
 }
 
 template <typename T>
-void dispatch_rotate_type(hipStream_t stream, const Tensor &input, const Tensor &output, double angleDeg,
-                          double2 shift, eInterpolationType interpolation, eDeviceType device) {
+void dispatch_rotate_type(hipStream_t stream, const Tensor &input, const Tensor &output, double angleDeg, double2 shift,
+                          eInterpolationType interpolation, eDeviceType device) {
     // clang-format off
     static const std::unordered_map<eInterpolationType,
                                     std::function<void(hipStream_t, const Tensor &, const Tensor &, double,
@@ -94,8 +94,8 @@ void dispatch_rotate_type(hipStream_t stream, const Tensor &input, const Tensor 
     func(stream, input, output, angleDeg, shift, device);
 }
 
-void Rotate::operator()(hipStream_t stream, const Tensor &input, const Tensor &output, double angleDeg,
-                        double2 shift, eInterpolationType interpolation, eDeviceType device) const {
+void Rotate::operator()(hipStream_t stream, const Tensor &input, const Tensor &output, double angleDeg, double2 shift,
+                        eInterpolationType interpolation, eDeviceType device) const {
     CHECK_TENSOR_DEVICE(input, device);
     CHECK_TENSOR_CHANNELS(input, 1, 3, 4);
     CHECK_TENSOR_DATATYPES(input, eDataType::DATA_TYPE_U8, eDataType::DATA_TYPE_S8, eDataType::DATA_TYPE_U16,

--- a/src/op_thresholding.cpp
+++ b/src/op_thresholding.cpp
@@ -50,8 +50,8 @@ void dispatch_threshold_dtype(hipStream_t stream, const Tensor &input, const Ten
     const auto width = input.shape()[input.shape().layout().width_index()];
 
     if (device == eDeviceType::GPU) {
-        dim3 block(64, 16);
-        dim3 grid((width + block.x - 1) / block.x, (height + block.y - 1) / block.y, outputWrapper.batches());
+        dim3 block = Kernels::Device::PackedBlock();
+        dim3 grid = Kernels::Device::PackedGrid<T>(width, height, outputWrapper.batches(), block);
 
         switch (m_threshType) {
             case THRESH_BINARY:

--- a/tests/roccv/cpp/src/tests/core/detail/test_saturate_cast_device.cpp
+++ b/tests/roccv/cpp/src/tests/core/detail/test_saturate_cast_device.cpp
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+/*
+ * Golden-model equivalence test for the device float -> uint8 SaturateCast fast path.
+ *
+ * On device, SaturateCast<uchar>(float) lowers to the hardware v_cvt_pk_u8_f32 instruction
+ * (see CvtPackedSaturateU8 in core/detail/casting.hpp). This test launches that device path over a
+ * representative set of float inputs and asserts it produces byte-for-byte identical results to the
+ * host (generic clamp-then-IEEE-round) reference path -- which is the golden model the operator
+ * GPU-vs-CPU tests rely on.
+ */
+
+#include <core/hip_assert.h>
+#include <hip/hip_runtime.h>
+
+#include <core/detail/casting.hpp>
+#include <core/detail/type_traits.hpp>
+#include <cstdint>
+#include <vector>
+
+#include "test_helpers.hpp"
+
+using namespace roccv::detail;
+using namespace roccv::tests;
+using namespace roccv;
+
+namespace {
+
+__global__ void SaturateCastScalarKernel(const float* in, unsigned char* out, int n) {
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= n) return;
+    out[i] = SaturateCast<unsigned char>(in[i]);
+}
+
+__global__ void SaturateCastVec4Kernel(const float4* in, uchar4* out, int n) {
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= n) return;
+    out[i] = SaturateCast<uchar4>(in[i]);
+}
+
+/**
+ * @brief Builds a set of float inputs that exercises the rounding ties, clamp endpoints, negatives, and
+ * out-of-range values that the fast path must handle identically to the host reference.
+ */
+std::vector<float> BuildInputs() {
+    std::vector<float> inputs;
+
+    // Dense sweep across and beyond the [0, 255] range at 1/8 steps. This hits every integer, every
+    // .5 tie (round-to-even), and the quarter/eighth fractions in between, plus out-of-range tails.
+    for (float v = -8.0f; v <= 264.0f; v += 0.125f) inputs.push_back(v);
+
+    // Explicit critical values.
+    const float extras[] = {-0.0f,
+                            0.0f,
+                            0.5f,
+                            1.5f,
+                            2.5f,
+                            126.5f,
+                            127.5f,
+                            128.5f,
+                            253.5f,
+                            254.5f,
+                            255.0f,
+                            255.5f,
+                            255.4999f,
+                            255.5001f,
+                            256.0f,
+                            -1.0f,
+                            -0.5f,
+                            -100.0f,
+                            1000.0f,
+                            std::numeric_limits<float>::max(),
+                            std::numeric_limits<float>::lowest()};
+    for (float v : extras) inputs.push_back(v);
+
+    return inputs;
+}
+
+/** @brief Runs the scalar float -> uint8 device path and compares it byte-for-byte to the host reference. */
+void TestScalar(const std::vector<float>& inputs) {
+    const int n = static_cast<int>(inputs.size());
+
+    // Host golden reference (generic clamp-then-IEEE-round path).
+    std::vector<unsigned char> reference(n);
+    for (int i = 0; i < n; i++) reference[i] = SaturateCast<unsigned char>(inputs[i]);
+
+    float* d_in = nullptr;
+    unsigned char* d_out = nullptr;
+    HIP_VALIDATE_NO_ERRORS(hipMalloc(&d_in, n * sizeof(float)));
+    HIP_VALIDATE_NO_ERRORS(hipMalloc(&d_out, n * sizeof(unsigned char)));
+    HIP_VALIDATE_NO_ERRORS(hipMemcpy(d_in, inputs.data(), n * sizeof(float), hipMemcpyHostToDevice));
+
+    const int block = 256;
+    const int grid = (n + block - 1) / block;
+    SaturateCastScalarKernel<<<grid, block, 0, 0>>>(d_in, d_out, n);
+    HIP_VALIDATE_NO_ERRORS(hipGetLastError());
+    HIP_VALIDATE_NO_ERRORS(hipDeviceSynchronize());
+
+    std::vector<unsigned char> result(n);
+    HIP_VALIDATE_NO_ERRORS(hipMemcpy(result.data(), d_out, n * sizeof(unsigned char), hipMemcpyDeviceToHost));
+
+    HIP_VALIDATE_NO_ERRORS(hipFree(d_in));
+    HIP_VALIDATE_NO_ERRORS(hipFree(d_out));
+
+    CompareVectors(result, reference);
+}
+
+/** @brief Runs the float4 -> uchar4 device path and compares it byte-for-byte to the host reference. */
+void TestVec4(const std::vector<float>& scalarInputs) {
+    // Pack the scalar inputs into float4s (truncating the ragged tail).
+    const int n = static_cast<int>(scalarInputs.size()) / 4;
+
+    std::vector<float4> inputs(n);
+    for (int i = 0; i < n; i++) {
+        inputs[i] =
+            float4{scalarInputs[i * 4 + 0], scalarInputs[i * 4 + 1], scalarInputs[i * 4 + 2], scalarInputs[i * 4 + 3]};
+    }
+
+    // Host golden reference, flattened to bytes for an exact comparison.
+    std::vector<unsigned char> reference(n * 4);
+    for (int i = 0; i < n; i++) {
+        uchar4 ref = SaturateCast<uchar4>(inputs[i]);
+        reference[i * 4 + 0] = ref.x;
+        reference[i * 4 + 1] = ref.y;
+        reference[i * 4 + 2] = ref.z;
+        reference[i * 4 + 3] = ref.w;
+    }
+
+    float4* d_in = nullptr;
+    uchar4* d_out = nullptr;
+    HIP_VALIDATE_NO_ERRORS(hipMalloc(&d_in, n * sizeof(float4)));
+    HIP_VALIDATE_NO_ERRORS(hipMalloc(&d_out, n * sizeof(uchar4)));
+    HIP_VALIDATE_NO_ERRORS(hipMemcpy(d_in, inputs.data(), n * sizeof(float4), hipMemcpyHostToDevice));
+
+    const int block = 256;
+    const int grid = (n + block - 1) / block;
+    SaturateCastVec4Kernel<<<grid, block, 0, 0>>>(d_in, d_out, n);
+    HIP_VALIDATE_NO_ERRORS(hipGetLastError());
+    HIP_VALIDATE_NO_ERRORS(hipDeviceSynchronize());
+
+    std::vector<uchar4> resultVec(n);
+    HIP_VALIDATE_NO_ERRORS(hipMemcpy(resultVec.data(), d_out, n * sizeof(uchar4), hipMemcpyDeviceToHost));
+
+    HIP_VALIDATE_NO_ERRORS(hipFree(d_in));
+    HIP_VALIDATE_NO_ERRORS(hipFree(d_out));
+
+    std::vector<unsigned char> result(n * 4);
+    for (int i = 0; i < n; i++) {
+        result[i * 4 + 0] = resultVec[i].x;
+        result[i * 4 + 1] = resultVec[i].y;
+        result[i * 4 + 2] = resultVec[i].z;
+        result[i * 4 + 3] = resultVec[i].w;
+    }
+
+    CompareVectors(result, reference);
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    (void)argc;
+    (void)argv;
+
+    TEST_CASES_BEGIN();
+
+    const std::vector<float> inputs = BuildInputs();
+
+    // Device float -> uint8 fast path must match the host golden model exactly.
+    TEST_CASE(TestScalar(inputs));
+
+    // Device float4 -> uchar4 fast path (the packed-store case) must also match exactly.
+    TEST_CASE(TestVec4(inputs));
+
+    TEST_CASES_END();
+}


### PR DESCRIPTION
### Summary

Introduces `packed_apply.hpp`, a reusable helper for wide-vector (16-byte) GPU stores, and applies it across all elementwise and geometric operators. This amortizes per-thread setup and eliminates sub-word store penalties for small pixel types (notably `uchar3`), yielding measurable throughput gains on memory-bound kernels.

### Changes

**New helper — `include/kernels/device/packed_apply.hpp`**
- `ApplyPackedGather` — scattered reads (e.g. geometric transforms) + packed output store
- `ApplyPackedTransform` — packed read + packed store for same-coordinate elementwise ops
- `PackedGrid<T>` / `PackedBlock()` — launch helpers that size grids so each thread handles a `PackWidth<T>`-pixel run
- Runtime alignment guard: falls back to scalar stores on unaligned rows/tails

**Kernel updates**
- All elementwise operators (`brightness_contrast`, `convert_to`, `cvt_color`, `flip`, `gamma_contrast`, `normalize`, `thresholding`, `composite`, `custom_crop`) migrated to `ApplyPackedGather` or `ApplyPackedTransform`
- Geometric operators (`resize`, `rotate`, `remap`, `copy_make_border`, `warp_affine`, `warp_perspective`) use `ApplyPackedGather` for packed output writes

**Reverted experiments**
- Multi-input packed reads+writes and host-side Composite latency reduction were explored and reverted — gather-bound (scattered-read) kernels did not benefit from packed input reads
