### PR TITLE
[Optimization] Use int32 instead of int64 for indexing tensor wrappers.

### DIFF
--- a/benchmarks/config.json
+++ b/benchmarks/config.json
@@ -27,6 +27,13 @@
             "width": 1920,
             "runs": 25,
             "warmup_runs": 10
+        },
+        {
+            "samples": 128,
+            "height": 1080,
+            "width": 1920,
+            "runs": 25,
+            "warmup_runs": 10
         }
     ]
 }

--- a/benchmarks/config.json
+++ b/benchmarks/config.json
@@ -27,13 +27,6 @@
             "width": 1920,
             "runs": 25,
             "warmup_runs": 10
-        },
-        {
-            "samples": 128,
-            "height": 1080,
-            "width": 1920,
-            "runs": 25,
-            "warmup_runs": 10
         }
     ]
 }

--- a/include/common/validation_helpers.hpp
+++ b/include/common/validation_helpers.hpp
@@ -25,7 +25,6 @@ THE SOFTWARE.
 #include <vector>
 
 #include "core/tensor.hpp"
-#include "operator_types.h"
 
 /**
  * @brief Validates whether a tensor is located on a specified device.
@@ -85,6 +84,38 @@ THE SOFTWARE.
             throw roccv::Exception("Unsupported channel count: " #tensor, eStatusType::INVALID_COMBINATION); \
         }                                                                                                    \
     } while (0);
+
+/**
+ * @brief Check if a tensor requires int64_t for wrapper indexing based on batch byte stride.
+ *
+ * @param tensor The tensor to check.
+ * @return True if the maximum addressable byte offset exceeds int32_t range, false otherwise.
+ */
+inline bool needsInt64Wrapper(const roccv::Tensor &tensor) {
+    int batch_idx = tensor.layout().batch_index();
+    if (batch_idx == -1) {
+        int h_idx = tensor.layout().height_index();
+        int64_t maxStride = tensor.stride(h_idx) * tensor.shape(h_idx);
+        return maxStride > std::numeric_limits<int32_t>::max();
+    }
+    int64_t maxStride = tensor.stride(batch_idx) * tensor.shape(batch_idx);
+    return maxStride > std::numeric_limits<int32_t>::max();
+}
+
+/**
+ * @brief Check if any tensor dimension exceeds int32_t range.
+ *
+ * @param tensor The tensor to check.
+ * @return True if any dimension value exceeds int32_t::max, false otherwise.
+ */
+inline bool hasDimExceedingInt32(const roccv::Tensor &tensor) {
+    for (int i = 0; i < tensor.rank(); ++i) {
+        if (tensor.shape(i) > std::numeric_limits<int32_t>::max()) {
+            return true;
+        }
+    }
+    return false;
+}
 
 /**
  * @brief Validates that a tensor can be indexed with int32_t wrappers.

--- a/include/common/validation_helpers.hpp
+++ b/include/common/validation_helpers.hpp
@@ -24,6 +24,7 @@ THE SOFTWARE.
 #include <algorithm>
 #include <vector>
 
+#include "operator_types.h"
 #include "core/tensor.hpp"
 
 /**
@@ -84,3 +85,13 @@ THE SOFTWARE.
             throw roccv::Exception("Unsupported channel count: " #tensor, eStatusType::INVALID_COMBINATION); \
         }                                                                                                    \
     } while (0);
+
+/**
+ * @brief Validates that a tensor can be indexed with int32_t wrappers.
+ *
+ */
+#define CHECK_TENSOR_INT32_INDEXING(tensor)                                                     \
+    if (needsInt64Wrapper(tensor)) {                                                            \
+        throw roccv::Exception("Tensor dimensions exceed int32_t indexing limits",             \
+                               eStatusType::INVALID_OPERATION);                                 \
+    }

--- a/include/common/validation_helpers.hpp
+++ b/include/common/validation_helpers.hpp
@@ -24,8 +24,8 @@ THE SOFTWARE.
 #include <algorithm>
 #include <vector>
 
-#include "operator_types.h"
 #include "core/tensor.hpp"
+#include "operator_types.h"
 
 /**
  * @brief Validates whether a tensor is located on a specified device.
@@ -90,8 +90,7 @@ THE SOFTWARE.
  * @brief Validates that a tensor can be indexed with int32_t wrappers.
  *
  */
-#define CHECK_TENSOR_INT32_INDEXING(tensor)                                                     \
-    if (needsInt64Wrapper(tensor)) {                                                            \
-        throw roccv::Exception("Tensor dimensions exceed int32_t indexing limits",             \
-                               eStatusType::INVALID_OPERATION);                                 \
+#define CHECK_TENSOR_INT32_INDEXING(tensor)                                                                         \
+    if (needsInt64Wrapper(tensor)) {                                                                                \
+        throw roccv::Exception("Tensor dimensions exceed int32_t indexing limits", eStatusType::INVALID_OPERATION); \
     }

--- a/include/core/detail/sampling_helpers.hpp
+++ b/include/core/detail/sampling_helpers.hpp
@@ -110,6 +110,23 @@ __device__ __host__ __forceinline__ int64_t clamp_i64(int64_t v, int64_t lo, int
 }
 
 /**
+ * @brief Clamp a signed integer to a closed interval (templated version).
+ * @tparam IndexT Index type (int32_t or int64_t).
+ * @param v Value to clamp.
+ * @param lo Lower bound (inclusive).
+ * @param hi Upper bound (inclusive); must satisfy @p lo <= @p hi.
+ * @return @p v restricted to the inclusive interval between @p lo and @p hi.
+ */
+template<typename IndexT>
+__device__ __host__ __forceinline__ IndexT clamp(IndexT v, IndexT lo, IndexT hi) {
+    if constexpr (std::is_same_v<IndexT, int32_t>) {
+        return clamp_i32(v, lo, hi);
+    } else {
+        return clamp_i64(v, lo, hi);
+    }
+}
+
+/**
  * @brief Euclidean (non-negative) modulo for 32-bit operands.
  * @param a Dividend.
  * @param modulus Strictly positive modulus.
@@ -161,12 +178,12 @@ __device__ __host__ inline int64_t euclid_mod_i64_fast(int64_t a, int64_t modulu
  * @tparam IndexT Index type (int32_t or int64_t).
  * @param x Source coordinate in pixels.
  * @return Largest IndexT not greater than @p x (i.e. floor), suitable as the left/top neighbor index for bilinear/cubic.
- * @note On device, uses a floor intrinsic; on host uses @c floorf().
+ * @note On device, uses a floor intrinsic compatible with HIP @c __float2ll_rd lowering; on host uses @c floorf().
  */
 template<typename IndexT>
 __device__ __host__ __forceinline__ IndexT interp_floor(float x) {
 #if defined(__HIP_DEVICE_COMPILE__) || defined(__CUDA_ARCH__)
-    return static_cast<IndexT>(__builtin_elementwise_floor(x));
+    return static_cast<IndexT>(static_cast<long long>(__builtin_elementwise_floor(x)));
 #else
     return static_cast<IndexT>(floorf(x));
 #endif
@@ -184,61 +201,6 @@ __device__ __host__ __forceinline__ IndexT interp_nearest(float x) {
         return static_cast<int32_t>(std::lroundf(x));
     } else {
         return static_cast<int64_t>(std::llroundf(x));
-    }
-}
-
-/**
- * @brief Convert a subpixel coordinate to the 32-bit integer grid index below @p x (floor).
- * @param x Source coordinate in pixels.
- * @return Largest int32 not greater than @p x (i.e. floor), suitable as the left/top neighbor index for bilinear/cubic.
- * @note On device, uses a floor intrinsic; on host uses @c floorf().
- */
-__device__ __host__ __forceinline__ int32_t interp_floor_i32(float x) {
-    return interp_floor<int32_t>(x);
-}
-
-/**
- * @brief Convert a subpixel coordinate to the integer grid index below @p x (floor).
- * @param x Source coordinate in pixels.
- * @return Largest int64 not greater than @p x (i.e. floor), suitable as the left/top neighbor index for bilinear/cubic.
- * @note On device, uses a floor intrinsic compatible with HIP @c __float2ll_rd lowering; on host uses @c floorf().
- */
-__device__ __host__ __forceinline__ int64_t interp_floor_i64(float x) {
-    return interp_floor<int64_t>(x);
-}
-
-/**
- * @brief Nearest-neighbor rounding of a subpixel coordinate to a 32-bit integer index.
- * @param x Source coordinate in pixels.
- * @return Integer closest to @p x, with half values rounded away from zero (same convention as @c std::lroundf()).
- */
-__device__ __host__ __forceinline__ int32_t interp_nearest_i32(float x) {
-    return interp_nearest<int32_t>(x);
-}
-
-/**
- * @brief Nearest-neighbor rounding of a subpixel coordinate to an integer index.
- * @param x Source coordinate in pixels.
- * @return Integer closest to @p x, with half values rounded away from zero (same convention as @c std::llroundf()).
- */
-__device__ __host__ __forceinline__ int64_t interp_nearest_i64(float x) {
-    return interp_nearest<int64_t>(x);
-}
-
-/**
- * @brief Clamp a signed integer to a closed interval (templated version).
- * @tparam IndexT Index type (int32_t or int64_t).
- * @param v Value to clamp.
- * @param lo Lower bound (inclusive).
- * @param hi Upper bound (inclusive); must satisfy @p lo <= @p hi.
- * @return @p v restricted to the inclusive interval between @p lo and @p hi.
- */
-template<typename IndexT>
-__device__ __host__ __forceinline__ IndexT clamp(IndexT v, IndexT lo, IndexT hi) {
-    if constexpr (std::is_same_v<IndexT, int32_t>) {
-        return clamp_i32(v, lo, hi);
-    } else {
-        return clamp_i64(v, lo, hi);
     }
 }
 }  // namespace detail

--- a/include/core/detail/sampling_helpers.hpp
+++ b/include/core/detail/sampling_helpers.hpp
@@ -158,16 +158,43 @@ __device__ __host__ inline int64_t euclid_mod_i64_fast(int64_t a, int64_t modulu
 
 /**
  * @brief Convert a subpixel coordinate to the integer grid index below @p x (floor).
+ * @tparam IndexT Index type (int32_t or int64_t).
+ * @param x Source coordinate in pixels.
+ * @return Largest IndexT not greater than @p x (i.e. floor), suitable as the left/top neighbor index for bilinear/cubic.
+ * @note On device, uses a floor intrinsic; on host uses @c floorf().
+ */
+template<typename IndexT>
+__device__ __host__ __forceinline__ IndexT interp_floor(float x) {
+#if defined(__HIP_DEVICE_COMPILE__) || defined(__CUDA_ARCH__)
+    return static_cast<IndexT>(__builtin_elementwise_floor(x));
+#else
+    return static_cast<IndexT>(floorf(x));
+#endif
+}
+
+/**
+ * @brief Nearest-neighbor rounding of a subpixel coordinate to an integer index.
+ * @tparam IndexT Index type (int32_t or int64_t).
+ * @param x Source coordinate in pixels.
+ * @return Integer closest to @p x, with half values rounded away from zero.
+ */
+template<typename IndexT>
+__device__ __host__ __forceinline__ IndexT interp_nearest(float x) {
+    if constexpr (std::is_same_v<IndexT, int32_t>) {
+        return static_cast<int32_t>(std::lroundf(x));
+    } else {
+        return static_cast<int64_t>(std::llroundf(x));
+    }
+}
+
+/**
+ * @brief Convert a subpixel coordinate to the 32-bit integer grid index below @p x (floor).
  * @param x Source coordinate in pixels.
  * @return Largest int32 not greater than @p x (i.e. floor), suitable as the left/top neighbor index for bilinear/cubic.
  * @note On device, uses a floor intrinsic; on host uses @c floorf().
  */
 __device__ __host__ __forceinline__ int32_t interp_floor_i32(float x) {
-#if defined(__HIP_DEVICE_COMPILE__) || defined(__CUDA_ARCH__)
-    return static_cast<int32_t>(__builtin_elementwise_floor(x));
-#else
-    return static_cast<int32_t>(floorf(x));
-#endif
+    return interp_floor<int32_t>(x);
 }
 
 /**
@@ -177,20 +204,16 @@ __device__ __host__ __forceinline__ int32_t interp_floor_i32(float x) {
  * @note On device, uses a floor intrinsic compatible with HIP @c __float2ll_rd lowering; on host uses @c floorf().
  */
 __device__ __host__ __forceinline__ int64_t interp_floor_i64(float x) {
-#if defined(__HIP_DEVICE_COMPILE__) || defined(__CUDA_ARCH__)
-    return static_cast<int64_t>(static_cast<long long>(__builtin_elementwise_floor(x)));
-#else
-    return static_cast<int64_t>(floorf(x));
-#endif
+    return interp_floor<int64_t>(x);
 }
 
 /**
- * @brief Nearest-neighbor rounding of a subpixel coordinate to an integer index.
+ * @brief Nearest-neighbor rounding of a subpixel coordinate to a 32-bit integer index.
  * @param x Source coordinate in pixels.
  * @return Integer closest to @p x, with half values rounded away from zero (same convention as @c std::lroundf()).
  */
 __device__ __host__ __forceinline__ int32_t interp_nearest_i32(float x) {
-    return static_cast<int32_t>(std::lroundf(x));
+    return interp_nearest<int32_t>(x);
 }
 
 /**
@@ -199,40 +222,24 @@ __device__ __host__ __forceinline__ int32_t interp_nearest_i32(float x) {
  * @return Integer closest to @p x, with half values rounded away from zero (same convention as @c std::llroundf()).
  */
 __device__ __host__ __forceinline__ int64_t interp_nearest_i64(float x) {
-    return static_cast<int64_t>(std::llroundf(x));
+    return interp_nearest<int64_t>(x);
 }
 
 /**
- * @brief Map one axis coordinate for OpenCV-style @c BORDER_REFLECT (edge pixels duplicated; not @c BORDER_REFLECT101).
- * @param coord Possibly out-of-bounds coordinate along the axis (width or height index space).
- * @param extent Positive extent of the axis (number of samples, e.g. image width or height).
- * @return In-bounds index in <tt>[0, extent)</tt> after reflection.
- * @note Period is <tt>2 * extent</tt>. Implementation uses Euclidean modulo then
- *       <tt>min(val, 2*extent - 1 - val)</tt>.
+ * @brief Clamp a signed integer to a closed interval (templated version).
+ * @tparam IndexT Index type (int32_t or int64_t).
+ * @param v Value to clamp.
+ * @param lo Lower bound (inclusive).
+ * @param hi Upper bound (inclusive); must satisfy @p lo <= @p hi.
+ * @return @p v restricted to the inclusive interval between @p lo and @p hi.
  */
-__device__ __host__ inline int32_t reflect_border_coord_i32(int32_t coord, int32_t extent) {
-    const int32_t scale = extent * 2;
-    int32_t val = euclid_mod_i32(coord, scale);
-    const int32_t inv = scale - 1 - val;
-    return min_i32(val, inv);
-}
-
-/**
- * @brief Map one axis coordinate for OpenCV-style @c BORDER_REFLECT101 (endpoints are not repeated in the reflection).
- * @param coord Possibly out-of-bounds coordinate along the axis.
- * @param extent Positive extent of the axis (number of samples). If @p extent is at most 1, returns @c 0.
- * @return In-bounds index in <tt>[0, extent)</tt> after reflection.
- * @note Period is <tt>2 * extent - 2</tt> when @p extent is greater than 1.
- */
-__device__ __host__ inline int32_t reflect101_border_coord_i32(int32_t coord, int32_t extent) {
-    if (extent <= 1) {
-        return 0;
+template<typename IndexT>
+__device__ __host__ __forceinline__ IndexT clamp(IndexT v, IndexT lo, IndexT hi) {
+    if constexpr (std::is_same_v<IndexT, int32_t>) {
+        return clamp_i32(v, lo, hi);
+    } else {
+        return clamp_i64(v, lo, hi);
     }
-    const int32_t scale = 2 * extent - 2;
-    const int32_t v = euclid_mod_i32(coord, scale);
-    const int32_t inner = (extent - 1) - v;
-    return (extent - 1) - abs_i32(inner);
 }
-
 }  // namespace detail
 }  // namespace roccv

--- a/include/core/detail/sampling_helpers.hpp
+++ b/include/core/detail/sampling_helpers.hpp
@@ -117,7 +117,7 @@ __device__ __host__ __forceinline__ int64_t clamp_i64(int64_t v, int64_t lo, int
  * @param hi Upper bound (inclusive); must satisfy @p lo <= @p hi.
  * @return @p v restricted to the inclusive interval between @p lo and @p hi.
  */
-template<typename IndexT>
+template <typename IndexT>
 __device__ __host__ __forceinline__ IndexT clamp(IndexT v, IndexT lo, IndexT hi) {
     if constexpr (std::is_same_v<IndexT, int32_t>) {
         return clamp_i32(v, lo, hi);
@@ -177,10 +177,11 @@ __device__ __host__ inline int64_t euclid_mod_i64_fast(int64_t a, int64_t modulu
  * @brief Convert a subpixel coordinate to the integer grid index below @p x (floor).
  * @tparam IndexT Index type (int32_t or int64_t).
  * @param x Source coordinate in pixels.
- * @return Largest IndexT not greater than @p x (i.e. floor), suitable as the left/top neighbor index for bilinear/cubic.
+ * @return Largest IndexT not greater than @p x (i.e. floor), suitable as the left/top neighbor index for
+ * bilinear/cubic.
  * @note On device, uses a floor intrinsic compatible with HIP @c __float2ll_rd lowering; on host uses @c floorf().
  */
-template<typename IndexT>
+template <typename IndexT>
 __device__ __host__ __forceinline__ IndexT interp_floor(float x) {
 #if defined(__HIP_DEVICE_COMPILE__) || defined(__CUDA_ARCH__)
     return static_cast<IndexT>(static_cast<long long>(__builtin_elementwise_floor(x)));
@@ -195,7 +196,7 @@ __device__ __host__ __forceinline__ IndexT interp_floor(float x) {
  * @param x Source coordinate in pixels.
  * @return Integer closest to @p x, with half values rounded away from zero.
  */
-template<typename IndexT>
+template <typename IndexT>
 __device__ __host__ __forceinline__ IndexT interp_nearest(float x) {
     if constexpr (std::is_same_v<IndexT, int32_t>) {
         return static_cast<int32_t>(std::lroundf(x));

--- a/include/core/detail/sampling_helpers.hpp
+++ b/include/core/detail/sampling_helpers.hpp
@@ -72,12 +72,31 @@ __device__ __host__ __forceinline__ int32_t min_i32(int32_t a, int32_t b) { retu
 __device__ __host__ __forceinline__ int64_t min_i64(int64_t a, int64_t b) { return a < b ? a : b; }
 
 /**
+ * @brief Maximum of two 32-bit signed integers.
+ * @param a First operand.
+ * @param b Second operand.
+ * @return The greater of @p a and @p b.
+ */
+__device__ __host__ __forceinline__ int32_t max_i32(int32_t a, int32_t b) { return a > b ? a : b; }
+
+/**
  * @brief Maximum of two 64-bit signed integers.
  * @param a First operand.
  * @param b Second operand.
  * @return The greater of @p a and @p b.
  */
 __device__ __host__ __forceinline__ int64_t max_i64(int64_t a, int64_t b) { return a > b ? a : b; }
+
+/**
+ * @brief Clamp a signed 32-bit integer to a closed interval.
+ * @param v Value to clamp.
+ * @param lo Lower bound (inclusive).
+ * @param hi Upper bound (inclusive); must satisfy @p lo <= @p hi.
+ * @return @p v restricted to the inclusive interval between @p lo and @p hi.
+ */
+__device__ __host__ __forceinline__ int32_t clamp_i32(int32_t v, int32_t lo, int32_t hi) {
+    return min_i32(max_i32(v, lo), hi);
+}
 
 /**
  * @brief Clamp a signed 64-bit integer to a closed interval.
@@ -140,6 +159,20 @@ __device__ __host__ inline int64_t euclid_mod_i64_fast(int64_t a, int64_t modulu
 /**
  * @brief Convert a subpixel coordinate to the integer grid index below @p x (floor).
  * @param x Source coordinate in pixels.
+ * @return Largest int32 not greater than @p x (i.e. floor), suitable as the left/top neighbor index for bilinear/cubic.
+ * @note On device, uses a floor intrinsic; on host uses @c floorf().
+ */
+__device__ __host__ __forceinline__ int32_t interp_floor_i32(float x) {
+#if defined(__HIP_DEVICE_COMPILE__) || defined(__CUDA_ARCH__)
+    return static_cast<int32_t>(__builtin_elementwise_floor(x));
+#else
+    return static_cast<int32_t>(floorf(x));
+#endif
+}
+
+/**
+ * @brief Convert a subpixel coordinate to the integer grid index below @p x (floor).
+ * @param x Source coordinate in pixels.
  * @return Largest int64 not greater than @p x (i.e. floor), suitable as the left/top neighbor index for bilinear/cubic.
  * @note On device, uses a floor intrinsic compatible with HIP @c __float2ll_rd lowering; on host uses @c floorf().
  */
@@ -154,10 +187,51 @@ __device__ __host__ __forceinline__ int64_t interp_floor_i64(float x) {
 /**
  * @brief Nearest-neighbor rounding of a subpixel coordinate to an integer index.
  * @param x Source coordinate in pixels.
+ * @return Integer closest to @p x, with half values rounded away from zero (same convention as @c std::lroundf()).
+ */
+__device__ __host__ __forceinline__ int32_t interp_nearest_i32(float x) {
+    return static_cast<int32_t>(std::lroundf(x));
+}
+
+/**
+ * @brief Nearest-neighbor rounding of a subpixel coordinate to an integer index.
+ * @param x Source coordinate in pixels.
  * @return Integer closest to @p x, with half values rounded away from zero (same convention as @c std::llroundf()).
  */
 __device__ __host__ __forceinline__ int64_t interp_nearest_i64(float x) {
     return static_cast<int64_t>(std::llroundf(x));
+}
+
+/**
+ * @brief Map one axis coordinate for OpenCV-style @c BORDER_REFLECT (edge pixels duplicated; not @c BORDER_REFLECT101).
+ * @param coord Possibly out-of-bounds coordinate along the axis (width or height index space).
+ * @param extent Positive extent of the axis (number of samples, e.g. image width or height).
+ * @return In-bounds index in <tt>[0, extent)</tt> after reflection.
+ * @note Period is <tt>2 * extent</tt>. Implementation uses Euclidean modulo then
+ *       <tt>min(val, 2*extent - 1 - val)</tt>.
+ */
+__device__ __host__ inline int32_t reflect_border_coord_i32(int32_t coord, int32_t extent) {
+    const int32_t scale = extent * 2;
+    int32_t val = euclid_mod_i32(coord, scale);
+    const int32_t inv = scale - 1 - val;
+    return min_i32(val, inv);
+}
+
+/**
+ * @brief Map one axis coordinate for OpenCV-style @c BORDER_REFLECT101 (endpoints are not repeated in the reflection).
+ * @param coord Possibly out-of-bounds coordinate along the axis.
+ * @param extent Positive extent of the axis (number of samples). If @p extent is at most 1, returns @c 0.
+ * @return In-bounds index in <tt>[0, extent)</tt> after reflection.
+ * @note Period is <tt>2 * extent - 2</tt> when @p extent is greater than 1.
+ */
+__device__ __host__ inline int32_t reflect101_border_coord_i32(int32_t coord, int32_t extent) {
+    if (extent <= 1) {
+        return 0;
+    }
+    const int32_t scale = 2 * extent - 2;
+    const int32_t v = euclid_mod_i32(coord, scale);
+    const int32_t inner = (extent - 1) - v;
+    return (extent - 1) - abs_i32(inner);
 }
 
 }  // namespace detail

--- a/include/core/tensor.hpp
+++ b/include/core/tensor.hpp
@@ -142,6 +142,14 @@ class Tensor {
     TensorLayout layout() const;
 
     /**
+     * @brief Returns the stride at a given dimension.
+     *
+     * @param[in] d The index of the dimension.
+     * @return The stride in bytes for the specified dimension.
+     */
+    int64_t stride(int d) const;
+
+    /**
      * @brief Exports the tensor data of the tensor
      *
      * @return Tensor data of the tensor

--- a/include/core/wrappers/border_wrapper.hpp
+++ b/include/core/wrappers/border_wrapper.hpp
@@ -201,8 +201,8 @@ class BorderWrapper {
                 x = detail::euclid_mod_i32(w, imgWidth);
                 y = detail::euclid_mod_i32(h, imgHeight);
             } else {
-                x = detail::euclid_mod_i64(w, imgWidth);
-                y = detail::euclid_mod_i64(h, imgHeight);
+                x = detail::euclid_mod_i64_fast(w, imgWidth);
+                y = detail::euclid_mod_i64_fast(h, imgHeight);
             }
         }
 

--- a/include/core/wrappers/border_wrapper.hpp
+++ b/include/core/wrappers/border_wrapper.hpp
@@ -39,7 +39,7 @@ namespace detail {
  *       separate branch on @p extent alone. For int64_t on device, a 32-bit remainder path is used when @p extent
  *       and @p coord are in a safe range.
  */
-template<typename IndexT>
+template <typename IndexT>
 __device__ __host__ inline IndexT reflect_border_coord(IndexT coord, IndexT extent) {
     if constexpr (std::is_same_v<IndexT, int32_t>) {
         const int32_t scale = extent * 2;
@@ -75,7 +75,7 @@ __device__ __host__ inline IndexT reflect_border_coord(IndexT coord, IndexT exte
  *       <tt>(extent - 1) - abs((extent - 1) - v)</tt>. For int64_t on device, a 32-bit path applies when values
  *       fit a fixed bound.
  */
-template<typename IndexT>
+template <typename IndexT>
 __device__ __host__ inline IndexT reflect101_border_coord(IndexT coord, IndexT extent) {
     if (extent <= 1) {
         return 0;

--- a/include/core/wrappers/border_wrapper.hpp
+++ b/include/core/wrappers/border_wrapper.hpp
@@ -30,59 +30,78 @@ namespace roccv {
 namespace detail {
 /**
  * @brief Map one axis coordinate for OpenCV-style @c BORDER_REFLECT (edge pixels duplicated; not @c BORDER_REFLECT101).
+ * @tparam IndexT Index type (int32_t or int64_t).
  * @param coord Possibly out-of-bounds coordinate along the axis (width or height index space).
  * @param extent Positive extent of the axis (number of samples, e.g. image width or height).
  * @return In-bounds index in <tt>[0, extent)</tt> after reflection.
  * @note Period is <tt>2 * extent</tt>. Implementation uses Euclidean modulo then
  *       <tt>min(val, 2*extent - 1 - val)</tt>, which matches comparing @c val to @c extent with a ternary, without a
- *       separate branch on @p extent alone. On device, a 32-bit remainder path is used when @p extent and @p coord are
- *       in a safe range.
+ *       separate branch on @p extent alone. For int64_t on device, a 32-bit remainder path is used when @p extent
+ *       and @p coord are in a safe range.
  */
-__device__ __host__ inline int64_t reflect_border_coord_i64(int64_t coord, int64_t extent) {
-#if defined(__HIP_DEVICE_COMPILE__) || defined(__CUDA_ARCH__)
-    constexpr int64_t kLim = int64_t{1} << 30;
-    if (extent > 0 && extent < kLim && coord > -kLim && coord < kLim) {
-        const int32_t e = static_cast<int32_t>(extent);
-        const int32_t scale = e * 2;
-        int32_t val = static_cast<int32_t>(coord) % scale;
-        if (val < 0) val += scale;
+template<typename IndexT>
+__device__ __host__ inline IndexT reflect_border_coord(IndexT coord, IndexT extent) {
+    if constexpr (std::is_same_v<IndexT, int32_t>) {
+        const int32_t scale = extent * 2;
+        int32_t val = euclid_mod_i32(coord, scale);
         const int32_t inv = scale - 1 - val;
-        return static_cast<int64_t>(min_i32(val, inv));
-    }
+        return min_i32(val, inv);
+    } else {
+#if defined(__HIP_DEVICE_COMPILE__) || defined(__CUDA_ARCH__)
+        constexpr int64_t kLim = int64_t{1} << 30;
+        if (extent > 0 && extent < kLim && coord > -kLim && coord < kLim) {
+            const int32_t e = static_cast<int32_t>(extent);
+            const int32_t scale = e * 2;
+            int32_t val = static_cast<int32_t>(coord) % scale;
+            if (val < 0) val += scale;
+            const int32_t inv = scale - 1 - val;
+            return static_cast<int64_t>(min_i32(val, inv));
+        }
 #endif
-    const int64_t scale = extent * 2;
-    const int64_t val = euclid_mod_i64(coord, scale);
-    const int64_t inv = scale - 1 - val;
-    return min_i64(val, inv);
+        const int64_t scale = extent * 2;
+        const int64_t val = euclid_mod_i64(coord, scale);
+        const int64_t inv = scale - 1 - val;
+        return min_i64(val, inv);
+    }
 }
 
 /**
  * @brief Map one axis coordinate for OpenCV-style @c BORDER_REFLECT101 (endpoints are not repeated in the reflection).
+ * @tparam IndexT Index type (int32_t or int64_t).
  * @param coord Possibly out-of-bounds coordinate along the axis.
  * @param extent Positive extent of the axis (number of samples). If @p extent is at most 1, returns @c 0.
  * @return In-bounds index in <tt>[0, extent)</tt> after reflection.
  * @note Period is <tt>2 * extent - 2</tt> when @p extent is greater than 1. Uses Euclidean modulo then folds with
- *       <tt>(extent - 1) - abs((extent - 1) - v)</tt>. On device, a 32-bit path applies when values fit a fixed bound.
+ *       <tt>(extent - 1) - abs((extent - 1) - v)</tt>. For int64_t on device, a 32-bit path applies when values
+ *       fit a fixed bound.
  */
-__device__ __host__ inline int64_t reflect101_border_coord_i64(int64_t coord, int64_t extent) {
+template<typename IndexT>
+__device__ __host__ inline IndexT reflect101_border_coord(IndexT coord, IndexT extent) {
     if (extent <= 1) {
         return 0;
     }
-    const int64_t scale = 2 * extent - 2;
+    if constexpr (std::is_same_v<IndexT, int32_t>) {
+        const int32_t scale = 2 * extent - 2;
+        int32_t v = euclid_mod_i32(coord, scale);
+        const int32_t inner = (extent - 1) - v;
+        return (extent - 1) - abs_i32(inner);
+    } else {
+        const int64_t scale = 2 * extent - 2;
 #if defined(__HIP_DEVICE_COMPILE__) || defined(__CUDA_ARCH__)
-    constexpr int64_t kLim = int64_t{1} << 30;
-    if (extent < kLim && coord > -kLim && coord < kLim && scale > 0 && scale < kLim) {
-        const int32_t e = static_cast<int32_t>(extent);
-        const int32_t s = e * 2 - 2;
-        int32_t v = euclid_mod_i32(static_cast<int32_t>(coord), s);
-        const int32_t inner = (e - 1) - v;
-        const int32_t a = abs_i32(inner);
-        return static_cast<int64_t>((e - 1) - a);
-    }
+        constexpr int64_t kLim = int64_t{1} << 30;
+        if (extent < kLim && coord > -kLim && coord < kLim && scale > 0 && scale < kLim) {
+            const int32_t e = static_cast<int32_t>(extent);
+            const int32_t s = e * 2 - 2;
+            int32_t v = euclid_mod_i32(static_cast<int32_t>(coord), s);
+            const int32_t inner = (e - 1) - v;
+            const int32_t a = abs_i32(inner);
+            return static_cast<int64_t>((e - 1) - a);
+        }
 #endif
-    const int64_t v = euclid_mod_i64_fast(coord, scale);
-    const int64_t inner = (extent - 1) - v;
-    return (extent - 1) - abs_i64(inner);
+        const int64_t v = euclid_mod_i64_fast(coord, scale);
+        const int64_t inner = (extent - 1) - v;
+        return (extent - 1) - abs_i64(inner);
+    }
 }
 }  // namespace detail
 
@@ -92,8 +111,9 @@ __device__ __host__ inline int64_t reflect101_border_coord_i64(int64_t coord, in
  *
  * @tparam T The underlying data type of the tensor.
  * @tparam BorderType The border type to use when coordinates are out of bounds.
+ * @tparam IndexT The datatype to use for indexing/stride calculations (int32_t or int64_t)
  */
-template <typename T, eBorderType BorderType>
+template <typename T, eBorderType BorderType, typename IndexT = int32_t>
 class BorderWrapper {
    public:
     /**
@@ -111,13 +131,13 @@ class BorderWrapper {
      * @param image_wrapper The ImageWrapper to wrap around the BorderWrapper.
      * @param border_value The fallback border color to use when using a constant border mode.
      */
-    BorderWrapper(ImageWrapper<T> image_wrapper, T border_value)
+    BorderWrapper(ImageWrapper<T, IndexT> image_wrapper, T border_value)
         : m_desc(image_wrapper), m_border_value(border_value) {}
 
     /**
      * @brief Sample the underlying image with no border logic. Caller must ensure coordinates are in-range.
      */
-    __device__ __host__ inline const T at_inbounds(int32_t n, int32_t h, int32_t w, int32_t c) const {
+    __device__ __host__ inline const T at_inbounds(IndexT n, IndexT h, IndexT w, IndexT c) const {
         return m_desc.at(n, h, w, c);
     }
 
@@ -131,7 +151,7 @@ class BorderWrapper {
      * @param c The channel index.
      * @return A reference to the underlying data or a fallback border value of type T.
      */
-    __device__ __host__ const T at(int32_t n, int32_t h, int32_t w, int32_t c) const {
+    __device__ __host__ const T at(IndexT n, IndexT h, IndexT w, IndexT c) const {
         // Constant border type implementation. This is a special case which doesn't remap values, but rather returns
         // the provided constant value.
         if constexpr (BorderType == eBorderType::BORDER_TYPE_CONSTANT) {
@@ -150,35 +170,40 @@ class BorderWrapper {
         }
 
         // Otherwise, do some additional calculations to map the provided x and y coordinates to be within bounds.
-        int32_t x = w, y = h;
-        int32_t imgWidth = width(), imgHeight = height();
+        IndexT x = w, y = h;
+        IndexT imgWidth = width(), imgHeight = height();
 
         // Reflect border type implementation. (Note: This is NOT REFLECT101, pixels at the border will be duplicated as
         // is the intended behavior for this border mode.)
         if constexpr (BorderType == eBorderType::BORDER_TYPE_REFLECT) {
             if (w < 0 || w >= imgWidth) {
-                x = detail::reflect_border_coord_i32(w, imgWidth);
+                x = detail::reflect_border_coord<IndexT>(w, imgWidth);
             }
             if (h < 0 || h >= imgHeight) {
-                y = detail::reflect_border_coord_i32(h, imgHeight);
+                y = detail::reflect_border_coord<IndexT>(h, imgHeight);
             }
         }
 
         if constexpr (BorderType == eBorderType::BORDER_TYPE_REFLECT101) {
-            x = detail::reflect101_border_coord_i32(w, imgWidth);
-            y = detail::reflect101_border_coord_i32(h, imgHeight);
+            x = detail::reflect101_border_coord<IndexT>(w, imgWidth);
+            y = detail::reflect101_border_coord<IndexT>(h, imgHeight);
         }
 
         // Replicate: clamp to edge. Equivalent to per-axis OOB snap; min/max maps cleanly to GPU integer ops.
         if constexpr (BorderType == eBorderType::BORDER_TYPE_REPLICATE) {
-            x = detail::clamp_i32(w, 0, imgWidth - 1);
-            y = detail::clamp_i32(h, 0, imgHeight - 1);
+            x = detail::clamp<IndexT>(w, 0, imgWidth - 1);
+            y = detail::clamp<IndexT>(h, 0, imgHeight - 1);
         }
 
         // Wrap border type implementation
         if constexpr (BorderType == eBorderType::BORDER_TYPE_WRAP) {
-            x = detail::euclid_mod_i32(w, imgWidth);
-            y = detail::euclid_mod_i32(h, imgHeight);
+            if constexpr (std::is_same_v<IndexT, int32_t>) {
+                x = detail::euclid_mod_i32(w, imgWidth);
+                y = detail::euclid_mod_i32(h, imgHeight);
+            } else {
+                x = detail::euclid_mod_i64(w, imgWidth);
+                y = detail::euclid_mod_i64(h, imgHeight);
+            }
         }
 
         return m_desc.at(n, y, x, c);
@@ -189,31 +214,31 @@ class BorderWrapper {
      *
      * @return Image height.
      */
-    __device__ __host__ inline int32_t height() const { return m_desc.height(); }
+    __device__ __host__ inline IndexT height() const { return m_desc.height(); }
 
     /**
      * @brief Retrieves the width of the image.
      *
      * @return Image width.
      */
-    __device__ __host__ inline int32_t width() const { return m_desc.width(); }
+    __device__ __host__ inline IndexT width() const { return m_desc.width(); }
 
     /**
      * @brief Retrieves the number of batches in the image tensor.
      *
      * @return Number of batches.
      */
-    __device__ __host__ inline int32_t batches() const { return m_desc.batches(); }
+    __device__ __host__ inline IndexT batches() const { return m_desc.batches(); }
 
     /**
      * @brief Retrieves the number of channels in the image.
      *
      * @return Image channels.
      */
-    __device__ __host__ inline int32_t channels() const { return m_desc.channels(); }
+    __device__ __host__ inline IndexT channels() const { return m_desc.channels(); }
 
    private:
-    ImageWrapper<T> m_desc;
+    ImageWrapper<T, IndexT> m_desc;
     T m_border_value;
 };
 }  // namespace roccv

--- a/include/core/wrappers/border_wrapper.hpp
+++ b/include/core/wrappers/border_wrapper.hpp
@@ -117,7 +117,7 @@ class BorderWrapper {
     /**
      * @brief Sample the underlying image with no border logic. Caller must ensure coordinates are in-range.
      */
-    __device__ __host__ inline const T at_inbounds(int64_t n, int64_t h, int64_t w, int64_t c) const {
+    __device__ __host__ inline const T at_inbounds(int32_t n, int32_t h, int32_t w, int32_t c) const {
         return m_desc.at(n, h, w, c);
     }
 
@@ -131,7 +131,7 @@ class BorderWrapper {
      * @param c The channel index.
      * @return A reference to the underlying data or a fallback border value of type T.
      */
-    __device__ __host__ const T at(int64_t n, int64_t h, int64_t w, int64_t c) const {
+    __device__ __host__ const T at(int32_t n, int32_t h, int32_t w, int32_t c) const {
         // Constant border type implementation. This is a special case which doesn't remap values, but rather returns
         // the provided constant value.
         if constexpr (BorderType == eBorderType::BORDER_TYPE_CONSTANT) {
@@ -150,35 +150,35 @@ class BorderWrapper {
         }
 
         // Otherwise, do some additional calculations to map the provided x and y coordinates to be within bounds.
-        int64_t x = w, y = h;
-        int64_t imgWidth = width(), imgHeight = height();
+        int32_t x = w, y = h;
+        int32_t imgWidth = width(), imgHeight = height();
 
         // Reflect border type implementation. (Note: This is NOT REFLECT101, pixels at the border will be duplicated as
         // is the intended behavior for this border mode.)
         if constexpr (BorderType == eBorderType::BORDER_TYPE_REFLECT) {
             if (w < 0 || w >= imgWidth) {
-                x = detail::reflect_border_coord_i64(w, imgWidth);
+                x = detail::reflect_border_coord_i32(w, imgWidth);
             }
             if (h < 0 || h >= imgHeight) {
-                y = detail::reflect_border_coord_i64(h, imgHeight);
+                y = detail::reflect_border_coord_i32(h, imgHeight);
             }
         }
 
         if constexpr (BorderType == eBorderType::BORDER_TYPE_REFLECT101) {
-            x = detail::reflect101_border_coord_i64(w, imgWidth);
-            y = detail::reflect101_border_coord_i64(h, imgHeight);
+            x = detail::reflect101_border_coord_i32(w, imgWidth);
+            y = detail::reflect101_border_coord_i32(h, imgHeight);
         }
 
         // Replicate: clamp to edge. Equivalent to per-axis OOB snap; min/max maps cleanly to GPU integer ops.
         if constexpr (BorderType == eBorderType::BORDER_TYPE_REPLICATE) {
-            x = detail::clamp_i64(w, 0, imgWidth - 1);
-            y = detail::clamp_i64(h, 0, imgHeight - 1);
+            x = detail::clamp_i32(w, 0, imgWidth - 1);
+            y = detail::clamp_i32(h, 0, imgHeight - 1);
         }
 
         // Wrap border type implementation
         if constexpr (BorderType == eBorderType::BORDER_TYPE_WRAP) {
-            x = detail::euclid_mod_i64_fast(w, imgWidth);
-            y = detail::euclid_mod_i64_fast(h, imgHeight);
+            x = detail::euclid_mod_i32(w, imgWidth);
+            y = detail::euclid_mod_i32(h, imgHeight);
         }
 
         return m_desc.at(n, y, x, c);
@@ -189,28 +189,28 @@ class BorderWrapper {
      *
      * @return Image height.
      */
-    __device__ __host__ inline int64_t height() const { return m_desc.height(); }
+    __device__ __host__ inline int32_t height() const { return m_desc.height(); }
 
     /**
      * @brief Retrieves the width of the image.
      *
      * @return Image width.
      */
-    __device__ __host__ inline int64_t width() const { return m_desc.width(); }
+    __device__ __host__ inline int32_t width() const { return m_desc.width(); }
 
     /**
      * @brief Retrieves the number of batches in the image tensor.
      *
      * @return Number of batches.
      */
-    __device__ __host__ inline int64_t batches() const { return m_desc.batches(); }
+    __device__ __host__ inline int32_t batches() const { return m_desc.batches(); }
 
     /**
      * @brief Retrieves the number of channels in the image.
      *
      * @return Image channels.
      */
-    __device__ __host__ inline int64_t channels() const { return m_desc.channels(); }
+    __device__ __host__ inline int32_t channels() const { return m_desc.channels(); }
 
    private:
     ImageWrapper<T> m_desc;

--- a/include/core/wrappers/image_wrapper.hpp
+++ b/include/core/wrappers/image_wrapper.hpp
@@ -35,8 +35,9 @@ namespace roccv {
  * methods for accessing the underlying data within HIP kernels.
  *
  * @tparam T The datatype of the underlying tensor data.
+ * @tparam IndexT The datatype to use for indexing/stride calculations (int32_t or int64_t)
  */
-template <typename T>
+template <typename T, typename IndexT = int32_t>
 class ImageWrapper {
    public:
     using ValueType = T;
@@ -62,13 +63,13 @@ class ImageWrapper {
 
         // Handle HWC/CHW layout, which doesn't have shapes/strides for the batch dimension. We set the batch shape to 1
         // and the strides to 0.
-        int32_t num_batches = indexes.n == -1 ? 1 : static_cast<int32_t>(tensor.shape(indexes.n));
-        int32_t batch_stride = indexes.n == -1 ? 0 : static_cast<int32_t>(tdata.stride(indexes.n));
+        IndexT num_batches = indexes.n == -1 ? 1 : static_cast<IndexT>(tensor.shape(indexes.n));
+        IndexT batch_stride = indexes.n == -1 ? 0 : static_cast<IndexT>(tdata.stride(indexes.n));
 
-        shape = {num_batches, static_cast<int32_t>(tdata.shape(indexes.h)), static_cast<int32_t>(tdata.shape(indexes.w)),
-                 static_cast<int32_t>(tdata.shape(indexes.c))};
-        stride = {batch_stride, static_cast<int32_t>(tdata.stride(indexes.h)), static_cast<int32_t>(tdata.stride(indexes.w)),
-                  static_cast<int32_t>(tdata.stride(indexes.c))};
+        shape = {num_batches, static_cast<IndexT>(tdata.shape(indexes.h)), static_cast<IndexT>(tdata.shape(indexes.w)),
+                 static_cast<IndexT>(tdata.shape(indexes.c))};
+        stride = {batch_stride, static_cast<IndexT>(tdata.stride(indexes.h)), static_cast<IndexT>(tdata.stride(indexes.w)),
+                  static_cast<IndexT>(tdata.stride(indexes.c))};
         data = static_cast<unsigned char*>(tdata.basePtr());
     }
 
@@ -80,7 +81,7 @@ class ImageWrapper {
      * @param width The width of each image within the batch.
      * @param height The height of each image within the batch.
      */
-    ImageWrapper(std::vector<BaseType>& input, int32_t batchSize, int32_t width, int32_t height) {
+    ImageWrapper(std::vector<BaseType>& input, IndexT batchSize, IndexT width, IndexT height) {
         // Calculate strides based on input (byte-wise strides)
         stride.c = sizeof(BaseType);
         stride.w = stride.c * detail::NumElements<T>;
@@ -105,7 +106,7 @@ class ImageWrapper {
      * @param width The width of each image within the batch.
      * @param height The height of each image within the batch.
      */
-    ImageWrapper(void* input, int32_t batchSize, int32_t width, int32_t height) {
+    ImageWrapper(void* input, IndexT batchSize, IndexT width, IndexT height) {
         // Calculate strides based on input (byte-wise strides)
         stride.c = sizeof(BaseType);
         stride.w = stride.c * detail::NumElements<T>;
@@ -130,11 +131,11 @@ class ImageWrapper {
      * @param c Channel coordinates.
      * @return A reference to the underlying data at given coordinates.
      */
-    __device__ __host__ T& at(int32_t n, int32_t h, int32_t w, int32_t c) {
+    __device__ __host__ T& at(IndexT n, IndexT h, IndexT w, IndexT c) {
         return *(reinterpret_cast<T*>(data + (stride.n * n) + (stride.h * h) + (stride.w * w) + (stride.c * c)));
     }
 
-    __device__ __host__ const T at(int32_t n, int32_t h, int32_t w, int32_t c) const {
+    __device__ __host__ const T at(IndexT n, IndexT h, IndexT w, IndexT c) const {
         return *(reinterpret_cast<T*>(data + (stride.n * n) + (stride.h * h) + (stride.w * w) + (stride.c * c)));
     }
 
@@ -143,32 +144,32 @@ class ImageWrapper {
      *
      * @return Image height.
      */
-    __device__ __host__ inline int32_t height() const { return shape.h; }
+    __device__ __host__ inline IndexT height() const { return shape.h; }
 
     /**
      * @brief Retrieves the width of the image.
      *
      * @return Image width.
      */
-    __device__ __host__ inline int32_t width() const { return shape.w; }
+    __device__ __host__ inline IndexT width() const { return shape.w; }
 
     /**
      * @brief Retrieves the number of batches in the image tensor.
      *
      * @return Number of batches.
      */
-    __device__ __host__ inline int32_t batches() const { return shape.n; }
+    __device__ __host__ inline IndexT batches() const { return shape.n; }
 
     /**
-     * @brief Retries the number of channels in the image.
+     * @brief Retrieves the number of channels in the image.
      *
      * @return Image channels.
      */
-    __device__ __host__ inline int32_t channels() const { return shape.c; }
+    __device__ __host__ inline IndexT channels() const { return shape.c; }
 
    private:
     struct ImageShape {
-        int32_t n, h, w, c;
+        IndexT n, h, w, c;
     };
 
     ImageShape shape;

--- a/include/core/wrappers/image_wrapper.hpp
+++ b/include/core/wrappers/image_wrapper.hpp
@@ -62,11 +62,13 @@ class ImageWrapper {
 
         // Handle HWC/CHW layout, which doesn't have shapes/strides for the batch dimension. We set the batch shape to 1
         // and the strides to 0.
-        int64_t num_batches = indexes.n == -1 ? 1 : tensor.shape(indexes.n);
-        int64_t batch_stride = indexes.n == -1 ? 0 : tdata.stride(indexes.n);
+        int32_t num_batches = indexes.n == -1 ? 1 : static_cast<int32_t>(tensor.shape(indexes.n));
+        int32_t batch_stride = indexes.n == -1 ? 0 : static_cast<int32_t>(tdata.stride(indexes.n));
 
-        shape = {num_batches, tdata.shape(indexes.h), tdata.shape(indexes.w), tdata.shape(indexes.c)};
-        stride = {batch_stride, tdata.stride(indexes.h), tdata.stride(indexes.w), tdata.stride(indexes.c)};
+        shape = {num_batches, static_cast<int32_t>(tdata.shape(indexes.h)), static_cast<int32_t>(tdata.shape(indexes.w)),
+                 static_cast<int32_t>(tdata.shape(indexes.c))};
+        stride = {batch_stride, static_cast<int32_t>(tdata.stride(indexes.h)), static_cast<int32_t>(tdata.stride(indexes.w)),
+                  static_cast<int32_t>(tdata.stride(indexes.c))};
         data = static_cast<unsigned char*>(tdata.basePtr());
     }
 
@@ -128,11 +130,11 @@ class ImageWrapper {
      * @param c Channel coordinates.
      * @return A reference to the underlying data at given coordinates.
      */
-    __device__ __host__ T& at(int64_t n, int64_t h, int64_t w, int64_t c) {
+    __device__ __host__ T& at(int32_t n, int32_t h, int32_t w, int32_t c) {
         return *(reinterpret_cast<T*>(data + (stride.n * n) + (stride.h * h) + (stride.w * w) + (stride.c * c)));
     }
 
-    __device__ __host__ const T at(int64_t n, int64_t h, int64_t w, int64_t c) const {
+    __device__ __host__ const T at(int32_t n, int32_t h, int32_t w, int32_t c) const {
         return *(reinterpret_cast<T*>(data + (stride.n * n) + (stride.h * h) + (stride.w * w) + (stride.c * c)));
     }
 
@@ -141,32 +143,32 @@ class ImageWrapper {
      *
      * @return Image height.
      */
-    __device__ __host__ inline int64_t height() const { return shape.h; }
+    __device__ __host__ inline int32_t height() const { return shape.h; }
 
     /**
      * @brief Retrieves the width of the image.
      *
      * @return Image width.
      */
-    __device__ __host__ inline int64_t width() const { return shape.w; }
+    __device__ __host__ inline int32_t width() const { return shape.w; }
 
     /**
      * @brief Retrieves the number of batches in the image tensor.
      *
      * @return Number of batches.
      */
-    __device__ __host__ inline int64_t batches() const { return shape.n; }
+    __device__ __host__ inline int32_t batches() const { return shape.n; }
 
     /**
      * @brief Retries the number of channels in the image.
      *
      * @return Image channels.
      */
-    __device__ __host__ inline int64_t channels() const { return shape.c; }
+    __device__ __host__ inline int32_t channels() const { return shape.c; }
 
    private:
     struct ImageShape {
-        int64_t n, h, w, c;
+        int32_t n, h, w, c;
     };
 
     ImageShape shape;

--- a/include/core/wrappers/image_wrapper.hpp
+++ b/include/core/wrappers/image_wrapper.hpp
@@ -68,8 +68,8 @@ class ImageWrapper {
 
         shape = {num_batches, static_cast<IndexT>(tdata.shape(indexes.h)), static_cast<IndexT>(tdata.shape(indexes.w)),
                  static_cast<IndexT>(tdata.shape(indexes.c))};
-        stride = {batch_stride, static_cast<IndexT>(tdata.stride(indexes.h)), static_cast<IndexT>(tdata.stride(indexes.w)),
-                  static_cast<IndexT>(tdata.stride(indexes.c))};
+        stride = {batch_stride, static_cast<IndexT>(tdata.stride(indexes.h)),
+                  static_cast<IndexT>(tdata.stride(indexes.w)), static_cast<IndexT>(tdata.stride(indexes.c))};
         data = static_cast<unsigned char*>(tdata.basePtr());
     }
 

--- a/include/core/wrappers/interpolation_wrapper.hpp
+++ b/include/core/wrappers/interpolation_wrapper.hpp
@@ -81,9 +81,9 @@ class InterpolationWrapper {
      * @param w Width coordinates.
      * @return An interpolated value.
      */
-    inline __device__ __host__ const T at(int64_t n, float h, float w, int64_t c) const {
+    inline __device__ __host__ const T at(int32_t n, float h, float w, int32_t c) const {
         if constexpr (I == eInterpolationType::INTERP_TYPE_NEAREST) {
-            return m_desc.at(n, detail::interp_nearest_i64(h), detail::interp_nearest_i64(w), c);
+            return m_desc.at(n, detail::interp_nearest_i32(h), detail::interp_nearest_i32(w), c);
         } else if constexpr (I == eInterpolationType::INTERP_TYPE_LINEAR) {
             // Bilinear interpolation implementation
             // v1 -- v2
@@ -92,10 +92,10 @@ class InterpolationWrapper {
 
             using WorkType = detail::MakeType<float, detail::NumElements<T>>;
 
-            const int64_t x0 = detail::interp_floor_i64(w);
-            const int64_t y0 = detail::interp_floor_i64(h);
-            const int64_t x1 = x0 + 1;
-            const int64_t y1 = y0 + 1;
+            const int32_t x0 = detail::interp_floor_i32(w);
+            const int32_t y0 = detail::interp_floor_i32(h);
+            const int32_t x1 = x0 + 1;
+            const int32_t y1 = y0 + 1;
             const float fx = w - static_cast<float>(x0);
             const float fy = h - static_cast<float>(y0);
             const float omfx = 1.f - fx;
@@ -126,8 +126,8 @@ class InterpolationWrapper {
             using namespace roccv::detail;
             using WorkType = detail::MakeType<float, detail::NumElements<T>>;
 
-            const int64_t int_x = detail::interp_floor_i64(w);
-            const int64_t int_y = detail::interp_floor_i64(h);
+            const int32_t int_x = detail::interp_floor_i32(w);
+            const int32_t int_y = detail::interp_floor_i32(h);
 
             float weight_x[4], weight_y[4];
             CalBicubicWeights(w - static_cast<float>(int_x), weight_x);
@@ -172,10 +172,10 @@ class InterpolationWrapper {
         }
     }
 
-    __device__ __host__ inline int64_t height() const { return m_desc.height(); }
-    __device__ __host__ inline int64_t width() const { return m_desc.width(); }
-    __device__ __host__ inline int64_t batches() const { return m_desc.batches(); }
-    __device__ __host__ inline int64_t channels() const { return m_desc.channels(); }
+    __device__ __host__ inline int32_t height() const { return m_desc.height(); }
+    __device__ __host__ inline int32_t width() const { return m_desc.width(); }
+    __device__ __host__ inline int32_t batches() const { return m_desc.batches(); }
+    __device__ __host__ inline int32_t channels() const { return m_desc.channels(); }
 
    private:
     BorderWrapper<T, B> m_desc;

--- a/include/core/wrappers/interpolation_wrapper.hpp
+++ b/include/core/wrappers/interpolation_wrapper.hpp
@@ -37,8 +37,9 @@ namespace roccv {
  * @tparam C Number of channels in data type.
  * @tparam B Border type to use for interpolation.
  * @tparam I Interpolation type to use.
+ * @tparam IndexT The datatype to use for indexing/stride calculations (int32_t or int64_t)
  */
-template <typename T, eBorderType B, eInterpolationType I>
+template <typename T, eBorderType B, eInterpolationType I, typename IndexT = int32_t>
 class InterpolationWrapper {
    public:
     /**
@@ -81,9 +82,9 @@ class InterpolationWrapper {
      * @param w Width coordinates.
      * @return An interpolated value.
      */
-    inline __device__ __host__ const T at(int32_t n, float h, float w, int32_t c) const {
+    inline __device__ __host__ const T at(IndexT n, IndexT h, IndexT w, IndexT c) const {
         if constexpr (I == eInterpolationType::INTERP_TYPE_NEAREST) {
-            return m_desc.at(n, detail::interp_nearest_i32(h), detail::interp_nearest_i32(w), c);
+            return m_desc.at(n, detail::interp_nearest<IndexT>(h), detail::interp_nearest<IndexT>(w), c);
         } else if constexpr (I == eInterpolationType::INTERP_TYPE_LINEAR) {
             // Bilinear interpolation implementation
             // v1 -- v2
@@ -92,10 +93,10 @@ class InterpolationWrapper {
 
             using WorkType = detail::MakeType<float, detail::NumElements<T>>;
 
-            const int32_t x0 = detail::interp_floor_i32(w);
-            const int32_t y0 = detail::interp_floor_i32(h);
-            const int32_t x1 = x0 + 1;
-            const int32_t y1 = y0 + 1;
+            const IndexT x0 = detail::interp_floor<IndexT>(w);
+            const IndexT y0 = detail::interp_floor<IndexT>(h);
+            const IndexT x1 = x0 + 1;
+            const IndexT y1 = y0 + 1;
             const float fx = w - static_cast<float>(x0);
             const float fy = h - static_cast<float>(y0);
             const float omfx = 1.f - fx;
@@ -126,8 +127,8 @@ class InterpolationWrapper {
             using namespace roccv::detail;
             using WorkType = detail::MakeType<float, detail::NumElements<T>>;
 
-            const int32_t int_x = detail::interp_floor_i32(w);
-            const int32_t int_y = detail::interp_floor_i32(h);
+            const IndexT int_x = detail::interp_floor<IndexT>(w);
+            const IndexT int_y = detail::interp_floor<IndexT>(h);
 
             float weight_x[4], weight_y[4];
             CalBicubicWeights(w - static_cast<float>(int_x), weight_x);
@@ -172,10 +173,10 @@ class InterpolationWrapper {
         }
     }
 
-    __device__ __host__ inline int32_t height() const { return m_desc.height(); }
-    __device__ __host__ inline int32_t width() const { return m_desc.width(); }
-    __device__ __host__ inline int32_t batches() const { return m_desc.batches(); }
-    __device__ __host__ inline int32_t channels() const { return m_desc.channels(); }
+    __device__ __host__ inline IndexT height() const { return m_desc.height(); }
+    __device__ __host__ inline IndexT width() const { return m_desc.width(); }
+    __device__ __host__ inline IndexT batches() const { return m_desc.batches(); }
+    __device__ __host__ inline IndexT channels() const { return m_desc.channels(); }
 
    private:
     BorderWrapper<T, B> m_desc;

--- a/include/core/wrappers/interpolation_wrapper.hpp
+++ b/include/core/wrappers/interpolation_wrapper.hpp
@@ -78,11 +78,12 @@ class InterpolationWrapper {
      * @brief Retrieves an interpolated value at given image batch coordinates.
      *
      * @param n Batch index.
-     * @param h Height coordinates.
-     * @param w Width coordinates.
+     * @param h Height coordinates (sub-pixel, floating point).
+     * @param w Width coordinates (sub-pixel, floating point).
+     * @param c Channel index.
      * @return An interpolated value.
      */
-    inline __device__ __host__ const T at(IndexT n, IndexT h, IndexT w, IndexT c) const {
+    inline __device__ __host__ const T at(IndexT n, float h, float w, IndexT c) const {
         if constexpr (I == eInterpolationType::INTERP_TYPE_NEAREST) {
             return m_desc.at(n, detail::interp_nearest<IndexT>(h), detail::interp_nearest<IndexT>(w), c);
         } else if constexpr (I == eInterpolationType::INTERP_TYPE_LINEAR) {

--- a/include/kernels/device/bnd_box_device.hpp
+++ b/include/kernels/device/bnd_box_device.hpp
@@ -39,9 +39,9 @@ __global__ void bndbox_kernel(SrcWrapper input, DstWrapper output, const Rect_t 
     // Working type for internal pixel format, which has 4 channels.
     using WorkType = detail::MakeType<BT, 4>;
 
-    const auto x_idx = threadIdx.x + blockIdx.x * blockDim.x;
-    const auto y_idx = threadIdx.y + blockIdx.y * blockDim.y;
-    const auto b_idx = blockIdx.z;
+    const int32_t x_idx = threadIdx.x + blockIdx.x * blockDim.x;
+    const int32_t y_idx = threadIdx.y + blockIdx.y * blockDim.y;
+    const int32_t b_idx = blockIdx.z;
 
     if (x_idx >= width || y_idx >= height || b_idx >= batch) {
         return;

--- a/include/kernels/device/bnd_box_device.hpp
+++ b/include/kernels/device/bnd_box_device.hpp
@@ -39,9 +39,9 @@ __global__ void bndbox_kernel(SrcWrapper input, DstWrapper output, const Rect_t 
     // Working type for internal pixel format, which has 4 channels.
     using WorkType = detail::MakeType<BT, 4>;
 
-    const int32_t x_idx = threadIdx.x + blockIdx.x * blockDim.x;
-    const int32_t y_idx = threadIdx.y + blockIdx.y * blockDim.y;
-    const int32_t b_idx = blockIdx.z;
+    const int x_idx = threadIdx.x + blockIdx.x * blockDim.x;
+    const int y_idx = threadIdx.y + blockIdx.y * blockDim.y;
+    const int b_idx = blockIdx.z;
 
     if (x_idx >= width || y_idx >= height || b_idx >= batch) {
         return;

--- a/include/kernels/device/cvt_color_device.hpp
+++ b/include/kernels/device/cvt_color_device.hpp
@@ -39,9 +39,9 @@ __global__ void rgb_or_bgr_to_yuv(SrcWrapper input, DstWrapper output, float del
 
     using work_type_t = MakeType<float, NumElements<T>>;
 
-    const int32_t x_idx = threadIdx.x + blockIdx.x * blockDim.x;
-    const int32_t y_idx = threadIdx.y + blockIdx.y * blockDim.y;
-    const int32_t z_idx = blockIdx.z;
+    const int x_idx = threadIdx.x + blockIdx.x * blockDim.x;
+    const int y_idx = threadIdx.y + blockIdx.y * blockDim.y;
+    const int z_idx = blockIdx.z;
 
     if (x_idx >= output.width() || y_idx >= output.height()) return;
 

--- a/include/kernels/device/cvt_color_device.hpp
+++ b/include/kernels/device/cvt_color_device.hpp
@@ -39,9 +39,9 @@ __global__ void rgb_or_bgr_to_yuv(SrcWrapper input, DstWrapper output, float del
 
     using work_type_t = MakeType<float, NumElements<T>>;
 
-    const auto x_idx = threadIdx.x + blockIdx.x * blockDim.x;
-    const auto y_idx = threadIdx.y + blockIdx.y * blockDim.y;
-    const auto z_idx = blockIdx.z;
+    const int32_t x_idx = threadIdx.x + blockIdx.x * blockDim.x;
+    const int32_t y_idx = threadIdx.y + blockIdx.y * blockDim.y;
+    const int32_t z_idx = blockIdx.z;
 
     if (x_idx >= output.width() || y_idx >= output.height()) return;
 

--- a/include/kernels/device/histogram_device.hpp
+++ b/include/kernels/device/histogram_device.hpp
@@ -29,7 +29,7 @@ THE SOFTWARE.
 namespace Kernels {
 namespace Device {
 
-template<typename T, typename SrcWrapper>
+template <typename T, typename SrcWrapper>
 __global__ void histogram_kernel(SrcWrapper input, roccv::GenericTensorWrapper<T> histogram) {
     extern __shared__ __align__(sizeof(T)) unsigned char smem[];
     T *local_histogram = reinterpret_cast<T *>(smem);
@@ -78,9 +78,7 @@ __global__ void histogram_kernel(SrcWrapper input, MaskWrapper mask, roccv::Gene
 
     if (gid < input.height() * input.width()) {
         if (mask.at(z_idx, y_idx, x_idx, 0) != 0) {
-            atomicAdd(
-                &local_histogram[input.at(z_idx, y_idx, x_idx, 0).x],
-                1);
+            atomicAdd(&local_histogram[input.at(z_idx, y_idx, x_idx, 0).x], 1);
         }
     }
     __syncthreads();  // wait for all of the threads in this block to finish

--- a/include/kernels/device/histogram_device.hpp
+++ b/include/kernels/device/histogram_device.hpp
@@ -34,10 +34,10 @@ __global__ void histogram_kernel(SrcWrapper input, roccv::GenericTensorWrapper<T
     extern __shared__ __align__(sizeof(T)) unsigned char smem[];
     T *local_histogram = reinterpret_cast<T *>(smem);
 
-    const int32_t z_idx = blockIdx.z;
-    const int32_t gid = blockIdx.x * blockDim.x + threadIdx.x;
-    const int32_t x_idx = gid % input.width();
-    const int32_t y_idx = gid / input.width();
+    const int z_idx = blockIdx.z;
+    const int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    const int x_idx = gid % input.width();
+    const int y_idx = gid / input.width();
 
     // thread index in block
     const auto tid = threadIdx.x;  // histogram index

--- a/include/kernels/device/histogram_device.hpp
+++ b/include/kernels/device/histogram_device.hpp
@@ -34,10 +34,10 @@ __global__ void histogram_kernel(SrcWrapper input, roccv::GenericTensorWrapper<T
     extern __shared__ __align__(sizeof(T)) unsigned char smem[];
     T *local_histogram = reinterpret_cast<T *>(smem);
 
-    const auto z_idx = blockIdx.z;
-    const auto gid = blockIdx.x * blockDim.x + threadIdx.x;
-    const auto x_idx = gid % input.width();
-    const auto y_idx = gid / input.width();
+    const int32_t z_idx = blockIdx.z;
+    const int32_t gid = blockIdx.x * blockDim.x + threadIdx.x;
+    const int32_t x_idx = gid % input.width();
+    const int32_t y_idx = gid / input.width();
 
     // thread index in block
     const auto tid = threadIdx.x;  // histogram index
@@ -64,10 +64,10 @@ __global__ void histogram_kernel(SrcWrapper input, MaskWrapper mask, roccv::Gene
     extern __shared__ __align__(sizeof(T)) unsigned char smem[];
     T *local_histogram = reinterpret_cast<T *>(smem);
 
-    const auto z_idx = blockIdx.z;
-    const auto gid = blockIdx.x * blockDim.x + threadIdx.x;
-    const auto x_idx = gid % input.width();
-    const auto y_idx = gid / input.width();
+    const int32_t z_idx = blockIdx.z;
+    const int32_t gid = blockIdx.x * blockDim.x + threadIdx.x;
+    const int32_t x_idx = gid % input.width();
+    const int32_t y_idx = gid / input.width();
 
     // thread index in block
     const auto tid = threadIdx.x;  // histogram index

--- a/include/kernels/device/histogram_device.hpp
+++ b/include/kernels/device/histogram_device.hpp
@@ -64,10 +64,10 @@ __global__ void histogram_kernel(SrcWrapper input, MaskWrapper mask, roccv::Gene
     extern __shared__ __align__(sizeof(T)) unsigned char smem[];
     T *local_histogram = reinterpret_cast<T *>(smem);
 
-    const int32_t z_idx = blockIdx.z;
-    const int32_t gid = blockIdx.x * blockDim.x + threadIdx.x;
-    const int32_t x_idx = gid % input.width();
-    const int32_t y_idx = gid / input.width();
+    const int z_idx = blockIdx.z;
+    const int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    const int x_idx = gid % input.width();
+    const int y_idx = gid / input.width();
 
     // thread index in block
     const auto tid = threadIdx.x;  // histogram index

--- a/include/kernels/device/thresholding_device.hpp
+++ b/include/kernels/device/thresholding_device.hpp
@@ -36,9 +36,9 @@ template <typename SrcWrapper, typename DstWrapper>
 __global__ void binary_generic(SrcWrapper input, DstWrapper output, roccv::GenericTensorWrapper<double> thresh,
                                roccv::GenericTensorWrapper<double> maxVal) {
     using namespace roccv::detail;
-    const auto x_idx = threadIdx.x + blockIdx.x * blockDim.x;
-    const auto y_idx = threadIdx.y + blockIdx.y * blockDim.y;
-    const auto z_idx = threadIdx.z + blockIdx.z * blockDim.z;
+    const int32_t x_idx = threadIdx.x + blockIdx.x * blockDim.x;
+    const int32_t y_idx = threadIdx.y + blockIdx.y * blockDim.y;
+    const int32_t z_idx = threadIdx.z + blockIdx.z * blockDim.z;
 
     using src_type = typename SrcWrapper::ValueType;
     using dst_type = typename DstWrapper::ValueType;
@@ -62,9 +62,9 @@ template <typename SrcWrapper, typename DstWrapper>
 __global__ void binary_inv_generic(SrcWrapper input, DstWrapper output, roccv::GenericTensorWrapper<double> thresh,
                                    roccv::GenericTensorWrapper<double> maxVal) {
     using namespace roccv::detail;
-    const auto x_idx = threadIdx.x + blockIdx.x * blockDim.x;
-    const auto y_idx = threadIdx.y + blockIdx.y * blockDim.y;
-    const auto z_idx = threadIdx.z + blockIdx.z * blockDim.z;
+    const int32_t x_idx = threadIdx.x + blockIdx.x * blockDim.x;
+    const int32_t y_idx = threadIdx.y + blockIdx.y * blockDim.y;
+    const int32_t z_idx = threadIdx.z + blockIdx.z * blockDim.z;
 
     using src_type = typename SrcWrapper::ValueType;
     using dst_type = typename DstWrapper::ValueType;
@@ -87,9 +87,9 @@ __global__ void binary_inv_generic(SrcWrapper input, DstWrapper output, roccv::G
 template <typename SrcWrapper, typename DstWrapper>
 __global__ void trunc_generic(SrcWrapper input, DstWrapper output, roccv::GenericTensorWrapper<double> thresh) {
     using namespace roccv::detail;
-    const auto x_idx = threadIdx.x + blockIdx.x * blockDim.x;
-    const auto y_idx = threadIdx.y + blockIdx.y * blockDim.y;
-    const auto z_idx = threadIdx.z + blockIdx.z * blockDim.z;
+    const int32_t x_idx = threadIdx.x + blockIdx.x * blockDim.x;
+    const int32_t y_idx = threadIdx.y + blockIdx.y * blockDim.y;
+    const int32_t z_idx = threadIdx.z + blockIdx.z * blockDim.z;
 
     using src_type = typename SrcWrapper::ValueType;
     using dst_type = typename DstWrapper::ValueType;
@@ -111,9 +111,9 @@ __global__ void trunc_generic(SrcWrapper input, DstWrapper output, roccv::Generi
 template <typename SrcWrapper, typename DstWrapper>
 __global__ void tozero_generic(SrcWrapper input, DstWrapper output, roccv::GenericTensorWrapper<double> thresh) {
     using namespace roccv::detail;
-    const auto x_idx = threadIdx.x + blockIdx.x * blockDim.x;
-    const auto y_idx = threadIdx.y + blockIdx.y * blockDim.y;
-    const auto z_idx = threadIdx.z + blockIdx.z * blockDim.z;
+    const int32_t x_idx = threadIdx.x + blockIdx.x * blockDim.x;
+    const int32_t y_idx = threadIdx.y + blockIdx.y * blockDim.y;
+    const int32_t z_idx = threadIdx.z + blockIdx.z * blockDim.z;
 
     using src_type = typename SrcWrapper::ValueType;
     using dst_type = typename DstWrapper::ValueType;
@@ -135,9 +135,9 @@ __global__ void tozero_generic(SrcWrapper input, DstWrapper output, roccv::Gener
 template <typename SrcWrapper, typename DstWrapper>
 __global__ void tozeroinv_generic(SrcWrapper input, DstWrapper output, roccv::GenericTensorWrapper<double> thresh) {
     using namespace roccv::detail;
-    const auto x_idx = threadIdx.x + blockIdx.x * blockDim.x;
-    const auto y_idx = threadIdx.y + blockIdx.y * blockDim.y;
-    const auto z_idx = threadIdx.z + blockIdx.z * blockDim.z;
+    const int32_t x_idx = threadIdx.x + blockIdx.x * blockDim.x;
+    const int32_t y_idx = threadIdx.y + blockIdx.y * blockDim.y;
+    const int32_t z_idx = threadIdx.z + blockIdx.z * blockDim.z;
 
     using src_type = typename SrcWrapper::ValueType;
     using dst_type = typename DstWrapper::ValueType;

--- a/include/kernels/device/thresholding_device.hpp
+++ b/include/kernels/device/thresholding_device.hpp
@@ -36,9 +36,9 @@ template <typename SrcWrapper, typename DstWrapper>
 __global__ void binary_generic(SrcWrapper input, DstWrapper output, roccv::GenericTensorWrapper<double> thresh,
                                roccv::GenericTensorWrapper<double> maxVal) {
     using namespace roccv::detail;
-    const int32_t x_idx = threadIdx.x + blockIdx.x * blockDim.x;
-    const int32_t y_idx = threadIdx.y + blockIdx.y * blockDim.y;
-    const int32_t z_idx = threadIdx.z + blockIdx.z * blockDim.z;
+    const int x_idx = threadIdx.x + blockIdx.x * blockDim.x;
+    const int y_idx = threadIdx.y + blockIdx.y * blockDim.y;
+    const int z_idx = threadIdx.z + blockIdx.z * blockDim.z;
 
     using src_type = typename SrcWrapper::ValueType;
     using dst_type = typename DstWrapper::ValueType;

--- a/include/kernels/device/thresholding_device.hpp
+++ b/include/kernels/device/thresholding_device.hpp
@@ -62,9 +62,9 @@ template <typename SrcWrapper, typename DstWrapper>
 __global__ void binary_inv_generic(SrcWrapper input, DstWrapper output, roccv::GenericTensorWrapper<double> thresh,
                                    roccv::GenericTensorWrapper<double> maxVal) {
     using namespace roccv::detail;
-    const int32_t x_idx = threadIdx.x + blockIdx.x * blockDim.x;
-    const int32_t y_idx = threadIdx.y + blockIdx.y * blockDim.y;
-    const int32_t z_idx = threadIdx.z + blockIdx.z * blockDim.z;
+    const int x_idx = threadIdx.x + blockIdx.x * blockDim.x;
+    const int y_idx = threadIdx.y + blockIdx.y * blockDim.y;
+    const int z_idx = threadIdx.z + blockIdx.z * blockDim.z;
 
     using src_type = typename SrcWrapper::ValueType;
     using dst_type = typename DstWrapper::ValueType;
@@ -87,9 +87,9 @@ __global__ void binary_inv_generic(SrcWrapper input, DstWrapper output, roccv::G
 template <typename SrcWrapper, typename DstWrapper>
 __global__ void trunc_generic(SrcWrapper input, DstWrapper output, roccv::GenericTensorWrapper<double> thresh) {
     using namespace roccv::detail;
-    const int32_t x_idx = threadIdx.x + blockIdx.x * blockDim.x;
-    const int32_t y_idx = threadIdx.y + blockIdx.y * blockDim.y;
-    const int32_t z_idx = threadIdx.z + blockIdx.z * blockDim.z;
+    const int x_idx = threadIdx.x + blockIdx.x * blockDim.x;
+    const int y_idx = threadIdx.y + blockIdx.y * blockDim.y;
+    const int z_idx = threadIdx.z + blockIdx.z * blockDim.z;
 
     using src_type = typename SrcWrapper::ValueType;
     using dst_type = typename DstWrapper::ValueType;
@@ -111,9 +111,9 @@ __global__ void trunc_generic(SrcWrapper input, DstWrapper output, roccv::Generi
 template <typename SrcWrapper, typename DstWrapper>
 __global__ void tozero_generic(SrcWrapper input, DstWrapper output, roccv::GenericTensorWrapper<double> thresh) {
     using namespace roccv::detail;
-    const int32_t x_idx = threadIdx.x + blockIdx.x * blockDim.x;
-    const int32_t y_idx = threadIdx.y + blockIdx.y * blockDim.y;
-    const int32_t z_idx = threadIdx.z + blockIdx.z * blockDim.z;
+    const int x_idx = threadIdx.x + blockIdx.x * blockDim.x;
+    const int y_idx = threadIdx.y + blockIdx.y * blockDim.y;
+    const int z_idx = threadIdx.z + blockIdx.z * blockDim.z;
 
     using src_type = typename SrcWrapper::ValueType;
     using dst_type = typename DstWrapper::ValueType;
@@ -135,9 +135,9 @@ __global__ void tozero_generic(SrcWrapper input, DstWrapper output, roccv::Gener
 template <typename SrcWrapper, typename DstWrapper>
 __global__ void tozeroinv_generic(SrcWrapper input, DstWrapper output, roccv::GenericTensorWrapper<double> thresh) {
     using namespace roccv::detail;
-    const int32_t x_idx = threadIdx.x + blockIdx.x * blockDim.x;
-    const int32_t y_idx = threadIdx.y + blockIdx.y * blockDim.y;
-    const int32_t z_idx = threadIdx.z + blockIdx.z * blockDim.z;
+    const int x_idx = threadIdx.x + blockIdx.x * blockDim.x;
+    const int y_idx = threadIdx.y + blockIdx.y * blockDim.y;
+    const int z_idx = threadIdx.z + blockIdx.z * blockDim.z;
 
     using src_type = typename SrcWrapper::ValueType;
     using dst_type = typename DstWrapper::ValueType;

--- a/include/operator_types.h
+++ b/include/operator_types.h
@@ -108,40 +108,6 @@ typedef struct {
 namespace roccv {
 
 /**
- * @brief Check if a tensor requires int64_t for wrapper indexing based on batch byte stride.
- *
- * @param tensor The tensor to check.
- * @return True if the maximum addressable byte offset exceeds int32_t range, false otherwise.
- */
-inline bool needsInt64Wrapper(const Tensor &tensor) {
-    int batch_idx = tensor.layout().batch_index();
-    if (batch_idx == -1) {
-        // HWC/CHW layout - check height dimension instead
-        int h_idx = tensor.layout().height_index();
-        int64_t maxStride = tensor.stride(h_idx) * tensor.shape(h_idx);
-        return maxStride > std::numeric_limits<int32_t>::max();
-    }
-    // NHWC/NCHW layout - check batch dimension
-    int64_t maxStride = tensor.stride(batch_idx) * tensor.shape(batch_idx);
-    return maxStride > std::numeric_limits<int32_t>::max();
-}
-
-/**
- * @brief Check if any tensor dimension exceeds int32_t range.
- *
- * @param tensor The tensor to check.
- * @return True if any dimension value exceeds int32_t::max, false otherwise.
- */
-inline bool hasDimExceedingInt32(const Tensor &tensor) {
-    for (int i = 0; i < tensor.rank(); ++i) {
-        if (tensor.shape(i) > std::numeric_limits<int32_t>::max()) {
-            return true;
-        }
-    }
-    return false;
-}
-
-/**
  * @brief Describes the 2D dimensions of an image.
  *
  */

--- a/include/operator_types.h
+++ b/include/operator_types.h
@@ -113,7 +113,7 @@ namespace roccv {
  * @param tensor The tensor to check.
  * @return True if the maximum addressable byte offset exceeds int32_t range, false otherwise.
  */
-inline bool needsInt64Wrapper(const Tensor& tensor) {
+inline bool needsInt64Wrapper(const Tensor &tensor) {
     int batch_idx = tensor.layout().batch_index();
     if (batch_idx == -1) {
         // HWC/CHW layout - check height dimension instead
@@ -132,7 +132,7 @@ inline bool needsInt64Wrapper(const Tensor& tensor) {
  * @param tensor The tensor to check.
  * @return True if any dimension value exceeds int32_t::max, false otherwise.
  */
-inline bool hasDimExceedingInt32(const Tensor& tensor) {
+inline bool hasDimExceedingInt32(const Tensor &tensor) {
     for (int i = 0; i < tensor.rank(); ++i) {
         if (tensor.shape(i) > std::numeric_limits<int32_t>::max()) {
             return true;

--- a/include/operator_types.h
+++ b/include/operator_types.h
@@ -108,6 +108,40 @@ typedef struct {
 namespace roccv {
 
 /**
+ * @brief Check if a tensor requires int64_t for wrapper indexing based on batch byte stride.
+ *
+ * @param tensor The tensor to check.
+ * @return True if the maximum addressable byte offset exceeds int32_t range, false otherwise.
+ */
+inline bool needsInt64Wrapper(const Tensor& tensor) {
+    int batch_idx = tensor.layout().batch_index();
+    if (batch_idx == -1) {
+        // HWC/CHW layout - check height dimension instead
+        int h_idx = tensor.layout().height_index();
+        int64_t maxStride = tensor.stride(h_idx) * tensor.shape(h_idx);
+        return maxStride > std::numeric_limits<int32_t>::max();
+    }
+    // NHWC/NCHW layout - check batch dimension
+    int64_t maxStride = tensor.stride(batch_idx) * tensor.shape(batch_idx);
+    return maxStride > std::numeric_limits<int32_t>::max();
+}
+
+/**
+ * @brief Check if any tensor dimension exceeds int32_t range.
+ *
+ * @param tensor The tensor to check.
+ * @return True if any dimension value exceeds int32_t::max, false otherwise.
+ */
+inline bool hasDimExceedingInt32(const Tensor& tensor) {
+    for (int i = 0; i < tensor.rank(); ++i) {
+        if (tensor.shape(i) > std::numeric_limits<int32_t>::max()) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/**
  * @brief Describes the 2D dimensions of an image.
  *
  */

--- a/src/core/tensor.cpp
+++ b/src/core/tensor.cpp
@@ -83,6 +83,8 @@ DataType Tensor::dtype() const { return DataType(m_requirements.dtype); }
 
 TensorLayout Tensor::layout() const { return TensorLayout(m_requirements.layout); }
 
+int64_t Tensor::stride(int d) const { return m_requirements.strides[d]; }
+
 TensorData Tensor::exportData() const {
     TensorBufferStrided buffer;
     buffer.basePtr = m_data->data();

--- a/src/op_adv_cvt_color.cpp
+++ b/src/op_adv_cvt_color.cpp
@@ -40,25 +40,21 @@ inline int64_t GetBatch(const Tensor &tensor) {
     return batchIdx < 0 ? 1 : tensor.shape(batchIdx);
 }
 
-inline int64_t GetHeight(const Tensor &tensor) {
-    return tensor.shape(tensor.layout().height_index());
-}
+inline int64_t GetHeight(const Tensor &tensor) { return tensor.shape(tensor.layout().height_index()); }
 
-inline int64_t GetWidth(const Tensor &tensor) {
-    return tensor.shape(tensor.layout().width_index());
-}
+inline int64_t GetWidth(const Tensor &tensor) { return tensor.shape(tensor.layout().width_index()); }
 
-inline int64_t GetChannels(const Tensor &tensor) {
-    return tensor.shape(tensor.layout().channels_index());
-}
+inline int64_t GetChannels(const Tensor &tensor) { return tensor.shape(tensor.layout().channels_index()); }
 
 inline bool IsSemiPlanarToInterleaved(eColorConversionCode code) {
     switch (code) {
         case COLOR_YUV2RGB_NV12:
         case COLOR_YUV2BGR_NV12:
         case COLOR_YUV2RGB_NV21:
-        case COLOR_YUV2BGR_NV21: return true;
-        default: return false;
+        case COLOR_YUV2BGR_NV21:
+            return true;
+        default:
+            return false;
     }
 }
 
@@ -67,8 +63,10 @@ inline bool IsInterleavedToSemiPlanar(eColorConversionCode code) {
         case COLOR_RGB2YUV_NV12:
         case COLOR_BGR2YUV_NV12:
         case COLOR_RGB2YUV_NV21:
-        case COLOR_BGR2YUV_NV21: return true;
-        default: return false;
+        case COLOR_BGR2YUV_NV21:
+            return true;
+        default:
+            return false;
     }
 }
 
@@ -77,8 +75,10 @@ inline bool IsInterleaved444(eColorConversionCode code) {
         case COLOR_RGB2YUV:
         case COLOR_BGR2YUV:
         case COLOR_YUV2RGB:
-        case COLOR_YUV2BGR: return true;
-        default: return false;
+        case COLOR_YUV2BGR:
+            return true;
+        default:
+            return false;
     }
 }
 
@@ -93,8 +93,10 @@ inline bool IsBGRCode(eColorConversionCode code) {
         case COLOR_YUV2BGR_NV12:
         case COLOR_YUV2BGR_NV21:
         case COLOR_BGR2YUV_NV12:
-        case COLOR_BGR2YUV_NV21: return true;
-        default: return false;
+        case COLOR_BGR2YUV_NV21:
+            return true;
+        default:
+            return false;
     }
 }
 
@@ -103,8 +105,10 @@ inline bool IsNV12Code(eColorConversionCode code) {
         case COLOR_YUV2RGB_NV12:
         case COLOR_YUV2BGR_NV12:
         case COLOR_RGB2YUV_NV12:
-        case COLOR_BGR2YUV_NV12: return true;
-        default: return false;
+        case COLOR_BGR2YUV_NV12:
+            return true;
+        default:
+            return false;
     }
 }
 
@@ -121,9 +125,7 @@ inline Kernels::AdvCvtColorCoefficients GetCoefficients(eColorSpec spec) {
     }
 }
 
-inline int DivUp(int n, int d) {
-    return (n + d - 1) / d;
-}
+inline int DivUp(int n, int d) { return (n + d - 1) / d; }
 
 }  // namespace
 
@@ -131,8 +133,8 @@ AdvCvtColor::AdvCvtColor() {}
 
 AdvCvtColor::~AdvCvtColor() {}
 
-void AdvCvtColor::operator()(hipStream_t stream, const Tensor &input, Tensor &output, eColorConversionCode conversionCode,
-                             eColorSpec colorSpec, eDeviceType device) {
+void AdvCvtColor::operator()(hipStream_t stream, const Tensor &input, Tensor &output,
+                             eColorConversionCode conversionCode, eColorSpec colorSpec, eDeviceType device) {
     CHECK_TENSOR_DEVICE(input, device);
     CHECK_TENSOR_DEVICE(output, device);
 
@@ -186,59 +188,56 @@ void AdvCvtColor::operator()(hipStream_t stream, const Tensor &input, Tensor &ou
         dim3 blockSize(32, 16);
 
         if (IsInterleaved444(conversionCode)) {
-            dim3 gridSize(DivUp(static_cast<int>(outWidth), blockSize.x), DivUp(static_cast<int>(outHeight), blockSize.y),
-                          static_cast<unsigned int>(outBatch));
+            dim3 gridSize(DivUp(static_cast<int>(outWidth), blockSize.x),
+                          DivUp(static_cast<int>(outHeight), blockSize.y), static_cast<unsigned int>(outBatch));
 
             switch (conversionCode) {
                 case COLOR_BGR2YUV:
-                    Kernels::Device::rgb_or_bgr_to_yuv_adv<uchar3, eSwizzle::ZYXW>
-                        <<<gridSize, blockSize, 0, stream>>>(ImageWrapper<uchar3>(input), ImageWrapper<uchar3>(output),
-                                                              coeff, kDelta);
+                    Kernels::Device::rgb_or_bgr_to_yuv_adv<uchar3, eSwizzle::ZYXW><<<gridSize, blockSize, 0, stream>>>(
+                        ImageWrapper<uchar3>(input), ImageWrapper<uchar3>(output), coeff, kDelta);
                     break;
                 case COLOR_RGB2YUV:
-                    Kernels::Device::rgb_or_bgr_to_yuv_adv<uchar3, eSwizzle::XYZW>
-                        <<<gridSize, blockSize, 0, stream>>>(ImageWrapper<uchar3>(input), ImageWrapper<uchar3>(output),
-                                                              coeff, kDelta);
+                    Kernels::Device::rgb_or_bgr_to_yuv_adv<uchar3, eSwizzle::XYZW><<<gridSize, blockSize, 0, stream>>>(
+                        ImageWrapper<uchar3>(input), ImageWrapper<uchar3>(output), coeff, kDelta);
                     break;
                 case COLOR_YUV2BGR:
-                    Kernels::Device::yuv_to_rgb_or_bgr_adv<uchar3, eSwizzle::ZYXW>
-                        <<<gridSize, blockSize, 0, stream>>>(ImageWrapper<uchar3>(input), ImageWrapper<uchar3>(output),
-                                                              coeff, kDelta);
+                    Kernels::Device::yuv_to_rgb_or_bgr_adv<uchar3, eSwizzle::ZYXW><<<gridSize, blockSize, 0, stream>>>(
+                        ImageWrapper<uchar3>(input), ImageWrapper<uchar3>(output), coeff, kDelta);
                     break;
                 case COLOR_YUV2RGB:
-                    Kernels::Device::yuv_to_rgb_or_bgr_adv<uchar3, eSwizzle::XYZW>
-                        <<<gridSize, blockSize, 0, stream>>>(ImageWrapper<uchar3>(input), ImageWrapper<uchar3>(output),
-                                                              coeff, kDelta);
+                    Kernels::Device::yuv_to_rgb_or_bgr_adv<uchar3, eSwizzle::XYZW><<<gridSize, blockSize, 0, stream>>>(
+                        ImageWrapper<uchar3>(input), ImageWrapper<uchar3>(output), coeff, kDelta);
                     break;
-                default: throw Exception("Unsupported conversion code.", eStatusType::INVALID_COMBINATION);
+                default:
+                    throw Exception("Unsupported conversion code.", eStatusType::INVALID_COMBINATION);
             }
         } else if (IsSemiPlanarToInterleaved(conversionCode)) {
-            dim3 gridSize(DivUp(static_cast<int>(outWidth), blockSize.x), DivUp(static_cast<int>(outHeight), blockSize.y),
-                          static_cast<unsigned int>(outBatch));
+            dim3 gridSize(DivUp(static_cast<int>(outWidth), blockSize.x),
+                          DivUp(static_cast<int>(outHeight), blockSize.y), static_cast<unsigned int>(outBatch));
 
             if (outChannels == 3) {
                 if (bgr) {
                     Kernels::Device::nv12_or_nv21_to_rgb_or_bgr_adv<eSwizzle::ZYXW, ImageWrapper<uchar1>,
-                                                                     ImageWrapper<uchar3>, uchar3>
+                                                                    ImageWrapper<uchar3>, uchar3>
                         <<<gridSize, blockSize, 0, stream>>>(ImageWrapper<uchar1>(input), ImageWrapper<uchar3>(output),
-                                                              coeff, kDelta, uidx);
+                                                             coeff, kDelta, uidx);
                 } else {
                     Kernels::Device::nv12_or_nv21_to_rgb_or_bgr_adv<eSwizzle::XYZW, ImageWrapper<uchar1>,
-                                                                     ImageWrapper<uchar3>, uchar3>
+                                                                    ImageWrapper<uchar3>, uchar3>
                         <<<gridSize, blockSize, 0, stream>>>(ImageWrapper<uchar1>(input), ImageWrapper<uchar3>(output),
-                                                              coeff, kDelta, uidx);
+                                                             coeff, kDelta, uidx);
                 }
             } else {
                 if (bgr) {
                     Kernels::Device::nv12_or_nv21_to_rgb_or_bgr_adv<eSwizzle::ZYXW, ImageWrapper<uchar1>,
-                                                                     ImageWrapper<uchar4>, uchar4>
+                                                                    ImageWrapper<uchar4>, uchar4>
                         <<<gridSize, blockSize, 0, stream>>>(ImageWrapper<uchar1>(input), ImageWrapper<uchar4>(output),
-                                                              coeff, kDelta, uidx);
+                                                             coeff, kDelta, uidx);
                 } else {
                     Kernels::Device::nv12_or_nv21_to_rgb_or_bgr_adv<eSwizzle::XYZW, ImageWrapper<uchar1>,
-                                                                     ImageWrapper<uchar4>, uchar4>
+                                                                    ImageWrapper<uchar4>, uchar4>
                         <<<gridSize, blockSize, 0, stream>>>(ImageWrapper<uchar1>(input), ImageWrapper<uchar4>(output),
-                                                              coeff, kDelta, uidx);
+                                                             coeff, kDelta, uidx);
                 }
             }
         } else {
@@ -249,21 +248,21 @@ void AdvCvtColor::operator()(hipStream_t stream, const Tensor &input, Tensor &ou
                 if (bgr) {
                     Kernels::Device::rgb_or_bgr_to_nv12_or_nv21_adv<uchar3, eSwizzle::ZYXW>
                         <<<gridSize, blockSize, 0, stream>>>(ImageWrapper<uchar3>(input), ImageWrapper<uchar1>(output),
-                                                              coeff, kDelta, uidx);
+                                                             coeff, kDelta, uidx);
                 } else {
                     Kernels::Device::rgb_or_bgr_to_nv12_or_nv21_adv<uchar3, eSwizzle::XYZW>
                         <<<gridSize, blockSize, 0, stream>>>(ImageWrapper<uchar3>(input), ImageWrapper<uchar1>(output),
-                                                              coeff, kDelta, uidx);
+                                                             coeff, kDelta, uidx);
                 }
             } else {
                 if (bgr) {
                     Kernels::Device::rgb_or_bgr_to_nv12_or_nv21_adv<uchar4, eSwizzle::ZYXW>
                         <<<gridSize, blockSize, 0, stream>>>(ImageWrapper<uchar4>(input), ImageWrapper<uchar1>(output),
-                                                              coeff, kDelta, uidx);
+                                                             coeff, kDelta, uidx);
                 } else {
                     Kernels::Device::rgb_or_bgr_to_nv12_or_nv21_adv<uchar4, eSwizzle::XYZW>
                         <<<gridSize, blockSize, 0, stream>>>(ImageWrapper<uchar4>(input), ImageWrapper<uchar1>(output),
-                                                              coeff, kDelta, uidx);
+                                                             coeff, kDelta, uidx);
                 }
             }
         }
@@ -271,46 +270,43 @@ void AdvCvtColor::operator()(hipStream_t stream, const Tensor &input, Tensor &ou
         if (IsInterleaved444(conversionCode)) {
             switch (conversionCode) {
                 case COLOR_BGR2YUV:
-                    Kernels::Host::rgb_or_bgr_to_yuv_adv<uchar3, eSwizzle::ZYXW>(ImageWrapper<uchar3>(input),
-                                                                                  ImageWrapper<uchar3>(output), coeff,
-                                                                                  kDelta);
+                    Kernels::Host::rgb_or_bgr_to_yuv_adv<uchar3, eSwizzle::ZYXW>(
+                        ImageWrapper<uchar3>(input), ImageWrapper<uchar3>(output), coeff, kDelta);
                     break;
                 case COLOR_RGB2YUV:
-                    Kernels::Host::rgb_or_bgr_to_yuv_adv<uchar3, eSwizzle::XYZW>(ImageWrapper<uchar3>(input),
-                                                                                  ImageWrapper<uchar3>(output), coeff,
-                                                                                  kDelta);
+                    Kernels::Host::rgb_or_bgr_to_yuv_adv<uchar3, eSwizzle::XYZW>(
+                        ImageWrapper<uchar3>(input), ImageWrapper<uchar3>(output), coeff, kDelta);
                     break;
                 case COLOR_YUV2BGR:
-                    Kernels::Host::yuv_to_rgb_or_bgr_adv<uchar3, eSwizzle::ZYXW>(ImageWrapper<uchar3>(input),
-                                                                                  ImageWrapper<uchar3>(output), coeff,
-                                                                                  kDelta);
+                    Kernels::Host::yuv_to_rgb_or_bgr_adv<uchar3, eSwizzle::ZYXW>(
+                        ImageWrapper<uchar3>(input), ImageWrapper<uchar3>(output), coeff, kDelta);
                     break;
                 case COLOR_YUV2RGB:
-                    Kernels::Host::yuv_to_rgb_or_bgr_adv<uchar3, eSwizzle::XYZW>(ImageWrapper<uchar3>(input),
-                                                                                  ImageWrapper<uchar3>(output), coeff,
-                                                                                  kDelta);
+                    Kernels::Host::yuv_to_rgb_or_bgr_adv<uchar3, eSwizzle::XYZW>(
+                        ImageWrapper<uchar3>(input), ImageWrapper<uchar3>(output), coeff, kDelta);
                     break;
-                default: throw Exception("Unsupported conversion code.", eStatusType::INVALID_COMBINATION);
+                default:
+                    throw Exception("Unsupported conversion code.", eStatusType::INVALID_COMBINATION);
             }
         } else if (IsSemiPlanarToInterleaved(conversionCode)) {
             if (outChannels == 3) {
                 if (bgr) {
                     Kernels::Host::nv12_or_nv21_to_rgb_or_bgr_adv<eSwizzle::ZYXW, ImageWrapper<uchar1>,
-                                                                   ImageWrapper<uchar3>, uchar3>(
+                                                                  ImageWrapper<uchar3>, uchar3>(
                         ImageWrapper<uchar1>(input), ImageWrapper<uchar3>(output), coeff, kDelta, uidx);
                 } else {
                     Kernels::Host::nv12_or_nv21_to_rgb_or_bgr_adv<eSwizzle::XYZW, ImageWrapper<uchar1>,
-                                                                   ImageWrapper<uchar3>, uchar3>(
+                                                                  ImageWrapper<uchar3>, uchar3>(
                         ImageWrapper<uchar1>(input), ImageWrapper<uchar3>(output), coeff, kDelta, uidx);
                 }
             } else {
                 if (bgr) {
                     Kernels::Host::nv12_or_nv21_to_rgb_or_bgr_adv<eSwizzle::ZYXW, ImageWrapper<uchar1>,
-                                                                   ImageWrapper<uchar4>, uchar4>(
+                                                                  ImageWrapper<uchar4>, uchar4>(
                         ImageWrapper<uchar1>(input), ImageWrapper<uchar4>(output), coeff, kDelta, uidx);
                 } else {
                     Kernels::Host::nv12_or_nv21_to_rgb_or_bgr_adv<eSwizzle::XYZW, ImageWrapper<uchar1>,
-                                                                   ImageWrapper<uchar4>, uchar4>(
+                                                                  ImageWrapper<uchar4>, uchar4>(
                         ImageWrapper<uchar1>(input), ImageWrapper<uchar4>(output), coeff, kDelta, uidx);
                 }
             }

--- a/src/op_adv_cvt_color.cpp
+++ b/src/op_adv_cvt_color.cpp
@@ -28,7 +28,6 @@ THE SOFTWARE.
 #include "core/tensor.hpp"
 #include "core/wrappers/image_wrapper.hpp"
 #include "kernels/common/adv_cvt_color_coefficients.hpp"
-#include "operator_types.h"
 #include "kernels/device/adv_cvt_color_device.hpp"
 #include "kernels/host/adv_cvt_color_host.hpp"
 
@@ -176,9 +175,8 @@ void AdvCvtColor::operator()(hipStream_t stream, const Tensor &input, Tensor &ou
         CHECK_TENSOR_COMPARISON(outHeight == (inHeight * 3) / 2);
     }
 
-    if (needsInt64Wrapper(input) || needsInt64Wrapper(output)) {
-        throw Exception("Input or output tensor is too large for int32 indexing", eStatusType::INVALID_OPERATION);
-    }
+    CHECK_TENSOR_INT32_INDEXING(input);
+    CHECK_TENSOR_INT32_INDEXING(output);
 
     Kernels::AdvCvtColorCoefficients coeff = GetCoefficients(colorSpec);
     const bool bgr = IsBGRCode(conversionCode);

--- a/src/op_adv_cvt_color.cpp
+++ b/src/op_adv_cvt_color.cpp
@@ -28,6 +28,7 @@ THE SOFTWARE.
 #include "core/tensor.hpp"
 #include "core/wrappers/image_wrapper.hpp"
 #include "kernels/common/adv_cvt_color_coefficients.hpp"
+#include "operator_types.h"
 #include "kernels/device/adv_cvt_color_device.hpp"
 #include "kernels/host/adv_cvt_color_host.hpp"
 
@@ -173,6 +174,10 @@ void AdvCvtColor::operator()(hipStream_t stream, const Tensor &input, Tensor &ou
         CHECK_TENSOR_COMPARISON(inWidth % 2 == 0);
         CHECK_TENSOR_COMPARISON(inHeight % 2 == 0);
         CHECK_TENSOR_COMPARISON(outHeight == (inHeight * 3) / 2);
+    }
+
+    if (needsInt64Wrapper(input) || needsInt64Wrapper(output)) {
+        throw Exception("Input or output tensor is too large for int32 indexing", eStatusType::INVALID_OPERATION);
     }
 
     Kernels::AdvCvtColorCoefficients coeff = GetCoefficients(colorSpec);

--- a/src/op_bilateral_filter.cpp
+++ b/src/op_bilateral_filter.cpp
@@ -34,6 +34,7 @@ THE SOFTWARE.
 #include "core/wrappers/image_wrapper.hpp"
 #include "kernels/device/bilateral_filter_device.hpp"
 #include "kernels/host/bilateral_filter_host.hpp"
+#include "operator_types.h"
 
 namespace roccv {
 BilateralFilter::BilateralFilter() {}
@@ -156,6 +157,10 @@ void BilateralFilter::operator()(hipStream_t stream, const roccv::Tensor &input,
     CHECK_TENSOR_COMPARISON(input.layout() == output.layout());
     CHECK_TENSOR_COMPARISON(input.shape() == output.shape());
 
+    if (needsInt64Wrapper(input) || needsInt64Wrapper(output)) {
+        throw Exception("Input or output tensor is too large for int32 indexing", eStatusType::INVALID_OPERATION);
+    }
+    
     // Select kernel dispatcher based on number of channels and a base datatype.
     // clang-format off
     static const std::unordered_map<

--- a/src/op_bilateral_filter.cpp
+++ b/src/op_bilateral_filter.cpp
@@ -61,8 +61,7 @@ void dispatch_bilateral_filter_border_mode(hipStream_t stream, const Tensor &inp
         sigmaSpace = 1.0f;
     }
 
-    const int radius =
-        (diameter <= 0) ? static_cast<int>(std::roundf(sigmaSpace * 1.5f)) : (diameter >> 1);
+    const int radius = (diameter <= 0) ? static_cast<int>(std::roundf(sigmaSpace * 1.5f)) : (diameter >> 1);
 
     float spaceCoeff = -1 / (2 * sigmaSpace * sigmaSpace);
     float colorCoeff = -1 / (2 * sigmaColor * sigmaColor);
@@ -158,7 +157,7 @@ void BilateralFilter::operator()(hipStream_t stream, const roccv::Tensor &input,
 
     CHECK_TENSOR_INT32_INDEXING(input);
     CHECK_TENSOR_INT32_INDEXING(output);
-    
+
     // Select kernel dispatcher based on number of channels and a base datatype.
     // clang-format off
     static const std::unordered_map<

--- a/src/op_bilateral_filter.cpp
+++ b/src/op_bilateral_filter.cpp
@@ -34,7 +34,6 @@ THE SOFTWARE.
 #include "core/wrappers/image_wrapper.hpp"
 #include "kernels/device/bilateral_filter_device.hpp"
 #include "kernels/host/bilateral_filter_host.hpp"
-#include "operator_types.h"
 
 namespace roccv {
 BilateralFilter::BilateralFilter() {}
@@ -157,9 +156,8 @@ void BilateralFilter::operator()(hipStream_t stream, const roccv::Tensor &input,
     CHECK_TENSOR_COMPARISON(input.layout() == output.layout());
     CHECK_TENSOR_COMPARISON(input.shape() == output.shape());
 
-    if (needsInt64Wrapper(input) || needsInt64Wrapper(output)) {
-        throw Exception("Input or output tensor is too large for int32 indexing", eStatusType::INVALID_OPERATION);
-    }
+    CHECK_TENSOR_INT32_INDEXING(input);
+    CHECK_TENSOR_INT32_INDEXING(output);
     
     // Select kernel dispatcher based on number of channels and a base datatype.
     // clang-format off

--- a/src/op_bnd_box.cpp
+++ b/src/op_bnd_box.cpp
@@ -108,7 +108,7 @@ void BndBox::operator()(hipStream_t stream, const Tensor &input, const Tensor &o
 
     CHECK_TENSOR_INT32_INDEXING(input);
     CHECK_TENSOR_INT32_INDEXING(output);
-    
+
     const auto height = input.shape()[input.shape().layout().height_index()];
     const auto width = input.shape()[input.shape().layout().width_index()];
 

--- a/src/op_bnd_box.cpp
+++ b/src/op_bnd_box.cpp
@@ -35,6 +35,7 @@ THE SOFTWARE.
 #include "core/wrappers/image_wrapper.hpp"
 #include "kernels/device/bnd_box_device.hpp"
 #include "kernels/host/bnd_box_host.hpp"
+#include "operator_types.h"
 
 namespace roccv {
 BndBox::BndBox() {}
@@ -106,6 +107,10 @@ void BndBox::operator()(hipStream_t stream, const Tensor &input, const Tensor &o
     CHECK_TENSOR_COMPARISON(input.layout() == output.layout());
     CHECK_TENSOR_COMPARISON(input.shape() == output.shape());
 
+    if (needsInt64Wrapper(input) || needsInt64Wrapper(output)) {
+        throw Exception("Input or output tensor is too large for int32 indexing", eStatusType::INVALID_OPERATION);
+    }
+    
     const auto height = input.shape()[input.shape().layout().height_index()];
     const auto width = input.shape()[input.shape().layout().width_index()];
 

--- a/src/op_bnd_box.cpp
+++ b/src/op_bnd_box.cpp
@@ -35,7 +35,6 @@ THE SOFTWARE.
 #include "core/wrappers/image_wrapper.hpp"
 #include "kernels/device/bnd_box_device.hpp"
 #include "kernels/host/bnd_box_host.hpp"
-#include "operator_types.h"
 
 namespace roccv {
 BndBox::BndBox() {}
@@ -107,9 +106,8 @@ void BndBox::operator()(hipStream_t stream, const Tensor &input, const Tensor &o
     CHECK_TENSOR_COMPARISON(input.layout() == output.layout());
     CHECK_TENSOR_COMPARISON(input.shape() == output.shape());
 
-    if (needsInt64Wrapper(input) || needsInt64Wrapper(output)) {
-        throw Exception("Input or output tensor is too large for int32 indexing", eStatusType::INVALID_OPERATION);
-    }
+    CHECK_TENSOR_INT32_INDEXING(input);
+    CHECK_TENSOR_INT32_INDEXING(output);
     
     const auto height = input.shape()[input.shape().layout().height_index()];
     const auto width = input.shape()[input.shape().layout().width_index()];

--- a/src/op_brightness_contrast.cpp
+++ b/src/op_brightness_contrast.cpp
@@ -31,7 +31,6 @@ THE SOFTWARE.
 #include "core/wrappers/image_wrapper.hpp"
 #include "kernels/device/brightness_contrast_device.hpp"
 #include "kernels/host/brightness_contrast_host.hpp"
-#include "operator_types.h"
 
 namespace {
 using namespace roccv;
@@ -336,9 +335,8 @@ void BrightnessContrast::operator()(hipStream_t stream, const roccv::Tensor &inp
     CHECK_TENSOR_COMPARISON(input.device() == output.device());
     CHECK_TENSOR_COMPARISON(input.shape() == output.shape());
 
-    if (needsInt64Wrapper(input) || needsInt64Wrapper(output)) {
-        throw Exception("Input or output tensor is too large for int32 indexing", eStatusType::INVALID_OPERATION);
-    }
+    CHECK_TENSOR_INT32_INDEXING(input);
+    CHECK_TENSOR_INT32_INDEXING(output);
 
     // Validate brightness/contrast params
     eDataType input_dtype = input.dtype().etype();

--- a/src/op_brightness_contrast.cpp
+++ b/src/op_brightness_contrast.cpp
@@ -31,6 +31,7 @@ THE SOFTWARE.
 #include "core/wrappers/image_wrapper.hpp"
 #include "kernels/device/brightness_contrast_device.hpp"
 #include "kernels/host/brightness_contrast_host.hpp"
+#include "operator_types.h"
 
 namespace {
 using namespace roccv;
@@ -334,6 +335,10 @@ void BrightnessContrast::operator()(hipStream_t stream, const roccv::Tensor &inp
     CHECK_TENSOR_DATATYPES(output, DATA_TYPE_U8, DATA_TYPE_U16, DATA_TYPE_S16, DATA_TYPE_S32, DATA_TYPE_F32);
     CHECK_TENSOR_COMPARISON(input.device() == output.device());
     CHECK_TENSOR_COMPARISON(input.shape() == output.shape());
+
+    if (needsInt64Wrapper(input) || needsInt64Wrapper(output)) {
+        throw Exception("Input or output tensor is too large for int32 indexing", eStatusType::INVALID_OPERATION);
+    }
 
     // Validate brightness/contrast params
     eDataType input_dtype = input.dtype().etype();

--- a/src/op_center_crop.cpp
+++ b/src/op_center_crop.cpp
@@ -23,6 +23,7 @@ THE SOFTWARE.
 
 #include "common/validation_helpers.hpp"
 #include "op_custom_crop.hpp"
+#include "operator_types.h"
 
 namespace roccv {
 void CenterCrop::operator()(hipStream_t stream, const Tensor& input, const Tensor& output, Size2D cropSize,

--- a/src/op_center_crop.cpp
+++ b/src/op_center_crop.cpp
@@ -27,6 +27,10 @@ THE SOFTWARE.
 namespace roccv {
 void CenterCrop::operator()(hipStream_t stream, const Tensor& input, const Tensor& output, Size2D cropSize,
                             eDeviceType device) const {
+    if (needsInt64Wrapper(input) || needsInt64Wrapper(output)) {
+        throw Exception("Input or output tensor is too large for int32 indexing", eStatusType::INVALID_OPERATION);
+    }
+
     auto i_height = input.shape()[input.shape().layout().height_index()];
     auto i_width = input.shape()[input.shape().layout().width_index()];
 

--- a/src/op_center_crop.cpp
+++ b/src/op_center_crop.cpp
@@ -21,15 +21,14 @@ THE SOFTWARE.
 */
 #include "op_center_crop.hpp"
 
+#include "common/validation_helpers.hpp"
 #include "op_custom_crop.hpp"
-#include "operator_types.h"
 
 namespace roccv {
 void CenterCrop::operator()(hipStream_t stream, const Tensor& input, const Tensor& output, Size2D cropSize,
                             eDeviceType device) const {
-    if (needsInt64Wrapper(input) || needsInt64Wrapper(output)) {
-        throw Exception("Input or output tensor is too large for int32 indexing", eStatusType::INVALID_OPERATION);
-    }
+    CHECK_TENSOR_INT32_INDEXING(input);
+    CHECK_TENSOR_INT32_INDEXING(output);
 
     auto i_height = input.shape()[input.shape().layout().height_index()];
     auto i_width = input.shape()[input.shape().layout().width_index()];

--- a/src/op_composite.cpp
+++ b/src/op_composite.cpp
@@ -27,7 +27,6 @@
 #include "core/wrappers/image_wrapper.hpp"
 #include "kernels/device/composite_device.hpp"
 #include "kernels/host/composite_host.hpp"
-#include "operator_types.h"
 
 namespace roccv {
 
@@ -144,10 +143,10 @@ void Composite::operator()(hipStream_t stream, const Tensor& foreground, const T
 
     CHECK_TENSOR_CHANNELS(output, 3, 4);
 
-    if (needsInt64Wrapper(foreground) || needsInt64Wrapper(background) || needsInt64Wrapper(mask) ||
-        needsInt64Wrapper(output)) {
-        throw Exception("Input or output tensor is too large for int32 indexing", eStatusType::INVALID_OPERATION);
-    }
+    CHECK_TENSOR_INT32_INDEXING(foreground);
+    CHECK_TENSOR_INT32_INDEXING(background);
+    CHECK_TENSOR_INT32_INDEXING(mask);
+    CHECK_TENSOR_INT32_INDEXING(output);
     // clang-format off
     static const std::unordered_map<eDataType, std::array<std::function<void(hipStream_t, const Tensor&, const Tensor&, const Tensor&, const Tensor&, eDeviceType)>, 4>>
         funcs = {

--- a/src/op_composite.cpp
+++ b/src/op_composite.cpp
@@ -27,6 +27,7 @@
 #include "core/wrappers/image_wrapper.hpp"
 #include "kernels/device/composite_device.hpp"
 #include "kernels/host/composite_host.hpp"
+#include "operator_types.h"
 
 namespace roccv {
 
@@ -143,6 +144,10 @@ void Composite::operator()(hipStream_t stream, const Tensor& foreground, const T
 
     CHECK_TENSOR_CHANNELS(output, 3, 4);
 
+    if (needsInt64Wrapper(foreground) || needsInt64Wrapper(background) || needsInt64Wrapper(mask) ||
+        needsInt64Wrapper(output)) {
+        throw Exception("Input or output tensor is too large for int32 indexing", eStatusType::INVALID_OPERATION);
+    }
     // clang-format off
     static const std::unordered_map<eDataType, std::array<std::function<void(hipStream_t, const Tensor&, const Tensor&, const Tensor&, const Tensor&, eDeviceType)>, 4>>
         funcs = {

--- a/src/op_convert_to.cpp
+++ b/src/op_convert_to.cpp
@@ -30,7 +30,6 @@ THE SOFTWARE.
 #include "core/detail/type_traits.hpp"
 #include "kernels/device/convert_to_device.hpp"
 #include "kernels/host/convert_to_host.hpp"
-#include "operator_types.h"
 
 namespace roccv {
 
@@ -128,9 +127,8 @@ void ConvertTo::operator()(hipStream_t stream, const Tensor &input, const Tensor
     CHECK_TENSOR_COMPARISON(input.device() == output.device());
     CHECK_TENSOR_COMPARISON(input.shape() == output.shape());
 
-    if (needsInt64Wrapper(input) || needsInt64Wrapper(output)) {
-        throw Exception("Input or output tensor is too large for int32 indexing", eStatusType::INVALID_OPERATION);
-    }
+    CHECK_TENSOR_INT32_INDEXING(input);
+    CHECK_TENSOR_INT32_INDEXING(output);
     
     // Select kernel dispatcher based on a base input datatype.
     // clang-format off

--- a/src/op_convert_to.cpp
+++ b/src/op_convert_to.cpp
@@ -30,6 +30,7 @@ THE SOFTWARE.
 #include "core/detail/type_traits.hpp"
 #include "kernels/device/convert_to_device.hpp"
 #include "kernels/host/convert_to_host.hpp"
+#include "operator_types.h"
 
 namespace roccv {
 
@@ -127,6 +128,10 @@ void ConvertTo::operator()(hipStream_t stream, const Tensor &input, const Tensor
     CHECK_TENSOR_COMPARISON(input.device() == output.device());
     CHECK_TENSOR_COMPARISON(input.shape() == output.shape());
 
+    if (needsInt64Wrapper(input) || needsInt64Wrapper(output)) {
+        throw Exception("Input or output tensor is too large for int32 indexing", eStatusType::INVALID_OPERATION);
+    }
+    
     // Select kernel dispatcher based on a base input datatype.
     // clang-format off
     static const std::unordered_map<eDataType, std::function<void(hipStream_t, const Tensor &, const Tensor &, double, double, eDeviceType)>>

--- a/src/op_convert_to.cpp
+++ b/src/op_convert_to.cpp
@@ -21,22 +21,22 @@ THE SOFTWARE.
 */
 #include "op_convert_to.hpp"
 
+#include <hip/hip_runtime.h>
+
 #include <functional>
 
-#include <hip/hip_runtime.h>
-#include "core/wrappers/image_wrapper.hpp"
 #include "common/validation_helpers.hpp"
 #include "core/detail/casting.hpp"
 #include "core/detail/type_traits.hpp"
+#include "core/wrappers/image_wrapper.hpp"
 #include "kernels/device/convert_to_device.hpp"
 #include "kernels/host/convert_to_host.hpp"
 
 namespace roccv {
 
 template <typename SRC_DT, typename DST_DT, int NC>
-void dispatch_convert_to_channels(hipStream_t stream, const Tensor &input, const Tensor &output,
-                                       double alpha, double beta, eDeviceType device) {
-    
+void dispatch_convert_to_channels(hipStream_t stream, const Tensor &input, const Tensor &output, double alpha,
+                                  double beta, eDeviceType device) {
     using SRC_DT_NC = detail::MakeType<SRC_DT, NC>;
     using DST_DT_NC = detail::MakeType<DST_DT, NC>;
 
@@ -47,7 +47,7 @@ void dispatch_convert_to_channels(hipStream_t stream, const Tensor &input, const
     using DST_BT = detail::BaseType<DST_DT>;
 
     using DT_AB = decltype(float() * SRC_BT() * DST_BT());
-    
+
     DT_AB alpha_ab = detail::SaturateCast<DT_AB>(alpha);
     DT_AB beta_ab = detail::SaturateCast<DT_AB>(beta);
 
@@ -68,16 +68,14 @@ void dispatch_convert_to_channels(hipStream_t stream, const Tensor &input, const
 }
 
 template <typename SRC_DT, typename DST_DT>
-void dispatch_convert_to_output_dtype(hipStream_t stream, const Tensor &input, const Tensor &output,
-                                       double alpha, double beta, eDeviceType device) {
-
+void dispatch_convert_to_output_dtype(hipStream_t stream, const Tensor &input, const Tensor &output, double alpha,
+                                      double beta, eDeviceType device) {
     int64_t channels = output.shape(output.layout().channels_index());
     // Select kernel dispatcher based on number of channels.
     // clang-format off
     static const std::array<std::function<void(hipStream_t, const Tensor &, const Tensor &, double, double, eDeviceType)>, 4>
         funcs = {dispatch_convert_to_channels<SRC_DT, DST_DT, 1>, dispatch_convert_to_channels<SRC_DT, DST_DT, 2>, dispatch_convert_to_channels<SRC_DT, DST_DT, 3>, dispatch_convert_to_channels<SRC_DT, DST_DT, 4>};
-        
-            
+
     // clang-format on
 
     auto func = funcs.at(channels - 1);
@@ -86,11 +84,10 @@ void dispatch_convert_to_output_dtype(hipStream_t stream, const Tensor &input, c
 }
 
 template <typename SRC_DT>
-void dispatch_convert_to_input_dtype(hipStream_t stream, const Tensor &input, const Tensor &output,
-                                       double alpha, double beta, eDeviceType device) {
-    
+void dispatch_convert_to_input_dtype(hipStream_t stream, const Tensor &input, const Tensor &output, double alpha,
+                                     double beta, eDeviceType device) {
     eDataType output_dtype = output.dtype().etype();
-    
+
     // Select kernel dispatcher based on a base input datatype.
     // clang-format off
     static const std::unordered_map<eDataType, std::function<void(hipStream_t, const Tensor &, const Tensor &, double, double, eDeviceType)>>

--- a/src/op_copy_make_border.cpp
+++ b/src/op_copy_make_border.cpp
@@ -29,6 +29,7 @@
 #include "core/wrappers/interpolation_wrapper.hpp"
 #include "kernels/device/copy_make_border_device.hpp"
 #include "kernels/host/copy_make_border_host.hpp"
+
 namespace roccv {
 
 /**

--- a/src/op_copy_make_border.cpp
+++ b/src/op_copy_make_border.cpp
@@ -29,8 +29,6 @@
 #include "core/wrappers/interpolation_wrapper.hpp"
 #include "kernels/device/copy_make_border_device.hpp"
 #include "kernels/host/copy_make_border_host.hpp"
-#include "operator_types.h"
-
 namespace roccv {
 
 /**
@@ -105,9 +103,8 @@ void CopyMakeBorder::operator()(hipStream_t stream, const Tensor& input, const T
     CHECK_TENSOR_COMPARISON(output.shape(output.layout().channels_index()) ==
                             input.shape(input.layout().channels_index()));
 
-    if (needsInt64Wrapper(input) || needsInt64Wrapper(output)) {
-        throw Exception("Input or output tensor is too large for int32 indexing", eStatusType::INVALID_OPERATION);
-    }
+    CHECK_TENSOR_INT32_INDEXING(input);
+    CHECK_TENSOR_INT32_INDEXING(output);
 
     // clang-format off
     // Maps kernel dispatchers according to the underlying data type and number of channels.

--- a/src/op_copy_make_border.cpp
+++ b/src/op_copy_make_border.cpp
@@ -83,8 +83,7 @@ void dispatch_copy_make_border(hipStream_t stream, const Tensor& input, const Te
 }
 
 void CopyMakeBorder::operator()(hipStream_t stream, const Tensor& input, const Tensor& output, int32_t top,
-                                int32_t left, eBorderType border_mode, float4 border_value,
-                                eDeviceType device) const {
+                                int32_t left, eBorderType border_mode, float4 border_value, eDeviceType device) const {
     CHECK_TENSOR_DEVICE(input, device);
     CHECK_TENSOR_LAYOUT(input, eTensorLayout::TENSOR_LAYOUT_NHWC, eTensorLayout::TENSOR_LAYOUT_HWC);
     CHECK_TENSOR_DATATYPES(input, eDataType::DATA_TYPE_U8, eDataType::DATA_TYPE_S8, eDataType::DATA_TYPE_U16,

--- a/src/op_copy_make_border.cpp
+++ b/src/op_copy_make_border.cpp
@@ -29,6 +29,7 @@
 #include "core/wrappers/interpolation_wrapper.hpp"
 #include "kernels/device/copy_make_border_device.hpp"
 #include "kernels/host/copy_make_border_host.hpp"
+#include "operator_types.h"
 
 namespace roccv {
 
@@ -103,6 +104,10 @@ void CopyMakeBorder::operator()(hipStream_t stream, const Tensor& input, const T
     }
     CHECK_TENSOR_COMPARISON(output.shape(output.layout().channels_index()) ==
                             input.shape(input.layout().channels_index()));
+
+    if (needsInt64Wrapper(input) || needsInt64Wrapper(output)) {
+        throw Exception("Input or output tensor is too large for int32 indexing", eStatusType::INVALID_OPERATION);
+    }
 
     // clang-format off
     // Maps kernel dispatchers according to the underlying data type and number of channels.

--- a/src/op_custom_crop.cpp
+++ b/src/op_custom_crop.cpp
@@ -29,6 +29,7 @@ THE SOFTWARE.
 #include "core/wrappers/image_wrapper.hpp"
 #include "kernels/device/custom_crop_device.hpp"
 #include "kernels/host/custom_crop_host.hpp"
+#include "operator_types.h"
 
 namespace roccv {
 
@@ -77,6 +78,10 @@ void CustomCrop::operator()(hipStream_t stream, const Tensor& input, const Tenso
     CHECK_TENSOR_COMPARISON(input.shape(input.layout().width_index()) >= (cropRect.x + cropRect.width));
     CHECK_TENSOR_COMPARISON(input.shape(input.layout().height_index()) >= (cropRect.y + cropRect.height));
 
+    if (needsInt64Wrapper(input) || needsInt64Wrapper(output)) {
+        throw Exception("Input or output tensor is too large for int32 indexing", eStatusType::INVALID_OPERATION);
+    }
+    
     // Select kernel dispatcher based on number of channels and a base datatype.
     // clang-format off
     static const std::unordered_map<

--- a/src/op_custom_crop.cpp
+++ b/src/op_custom_crop.cpp
@@ -29,7 +29,6 @@ THE SOFTWARE.
 #include "core/wrappers/image_wrapper.hpp"
 #include "kernels/device/custom_crop_device.hpp"
 #include "kernels/host/custom_crop_host.hpp"
-#include "operator_types.h"
 
 namespace roccv {
 
@@ -78,9 +77,8 @@ void CustomCrop::operator()(hipStream_t stream, const Tensor& input, const Tenso
     CHECK_TENSOR_COMPARISON(input.shape(input.layout().width_index()) >= (cropRect.x + cropRect.width));
     CHECK_TENSOR_COMPARISON(input.shape(input.layout().height_index()) >= (cropRect.y + cropRect.height));
 
-    if (needsInt64Wrapper(input) || needsInt64Wrapper(output)) {
-        throw Exception("Input or output tensor is too large for int32 indexing", eStatusType::INVALID_OPERATION);
-    }
+    CHECK_TENSOR_INT32_INDEXING(input);
+    CHECK_TENSOR_INT32_INDEXING(output);
     
     // Select kernel dispatcher based on number of channels and a base datatype.
     // clang-format off

--- a/src/op_custom_crop.cpp
+++ b/src/op_custom_crop.cpp
@@ -79,7 +79,7 @@ void CustomCrop::operator()(hipStream_t stream, const Tensor& input, const Tenso
 
     CHECK_TENSOR_INT32_INDEXING(input);
     CHECK_TENSOR_INT32_INDEXING(output);
-    
+
     // Select kernel dispatcher based on number of channels and a base datatype.
     // clang-format off
     static const std::unordered_map<

--- a/src/op_cvt_color.cpp
+++ b/src/op_cvt_color.cpp
@@ -37,8 +37,8 @@ CvtColor::CvtColor() {}
 CvtColor::~CvtColor() {}
 
 template <typename IndexT>
-void dispatch_cvt_color_itype(hipStream_t stream, const Tensor &input, Tensor &output, eColorConversionCode conversionCode,
-                          eDeviceType device) {
+void dispatch_cvt_color_itype(hipStream_t stream, const Tensor &input, Tensor &output,
+                              eColorConversionCode conversionCode, eDeviceType device) {
     // Launch kernel
 
     int64_t width = input.shape(input.layout().width_index());
@@ -53,19 +53,19 @@ void dispatch_cvt_color_itype(hipStream_t stream, const Tensor &input, Tensor &o
 
         switch (conversionCode) {
             case eColorConversionCode::COLOR_BGR2GRAY:
-                Kernels::Device::rgb_or_bgr_to_grayscale<uchar3, eSwizzle::ZYXW>
-                    <<<gridSize, blockSize, 0, stream>>>(ImageWrapper<uchar3, IndexT>(input), ImageWrapper<uchar1, IndexT>(output));
+                Kernels::Device::rgb_or_bgr_to_grayscale<uchar3, eSwizzle::ZYXW><<<gridSize, blockSize, 0, stream>>>(
+                    ImageWrapper<uchar3, IndexT>(input), ImageWrapper<uchar1, IndexT>(output));
                 break;
 
             case eColorConversionCode::COLOR_RGB2GRAY:
-                Kernels::Device::rgb_or_bgr_to_grayscale<uchar3, eSwizzle::XYZW>
-                    <<<gridSize, blockSize, 0, stream>>>(ImageWrapper<uchar3, IndexT>(input), ImageWrapper<uchar1, IndexT>(output));
+                Kernels::Device::rgb_or_bgr_to_grayscale<uchar3, eSwizzle::XYZW><<<gridSize, blockSize, 0, stream>>>(
+                    ImageWrapper<uchar3, IndexT>(input), ImageWrapper<uchar1, IndexT>(output));
                 break;
 
             case eColorConversionCode::COLOR_BGR2RGB:
             case eColorConversionCode::COLOR_RGB2BGR:
-                Kernels::Device::reorder<uchar3, eSwizzle::ZYXW>
-                    <<<gridSize, blockSize, 0, stream>>>(ImageWrapper<uchar3, IndexT>(input), ImageWrapper<uchar3, IndexT>(output));
+                Kernels::Device::reorder<uchar3, eSwizzle::ZYXW><<<gridSize, blockSize, 0, stream>>>(
+                    ImageWrapper<uchar3, IndexT>(input), ImageWrapper<uchar3, IndexT>(output));
                 break;
 
             case eColorConversionCode::COLOR_BGR2YUV:

--- a/src/op_cvt_color.cpp
+++ b/src/op_cvt_color.cpp
@@ -30,6 +30,7 @@ THE SOFTWARE.
 #include "core/wrappers/image_wrapper.hpp"
 #include "kernels/device/cvt_color_device.hpp"
 #include "kernels/host/cvt_color_host.hpp"
+#include "operator_types.h"
 
 namespace roccv {
 CvtColor::CvtColor() {}
@@ -72,6 +73,10 @@ void CvtColor::operator()(hipStream_t stream, const Tensor &input, Tensor &outpu
         CHECK_TENSOR_CHANNELS(output, 3);
     }
 
+    if (needsInt64Wrapper(input) || needsInt64Wrapper(output)) {
+        throw Exception("Input or output tensor is too large for int32 indexing", eStatusType::INVALID_OPERATION);
+    }
+    
     // Launch kernel
 
     int64_t width = input.shape(input.layout().width_index());

--- a/src/op_cvt_color.cpp
+++ b/src/op_cvt_color.cpp
@@ -30,12 +30,112 @@ THE SOFTWARE.
 #include "core/wrappers/image_wrapper.hpp"
 #include "kernels/device/cvt_color_device.hpp"
 #include "kernels/host/cvt_color_host.hpp"
-#include "operator_types.h"
 
 namespace roccv {
 CvtColor::CvtColor() {}
 
 CvtColor::~CvtColor() {}
+
+template <typename IndexT>
+void dispatch_cvt_color_itype(hipStream_t stream, const Tensor &input, Tensor &output, eColorConversionCode conversionCode,
+                          eDeviceType device) {
+    // Launch kernel
+
+    int64_t width = input.shape(input.layout().width_index());
+    int64_t height = input.shape(input.layout().height_index());
+    int64_t samples = input.shape(input.layout().batch_index());
+
+    if (device == eDeviceType::GPU) {
+        // Dispatch appropriate device kernel based on given conversion code
+
+        dim3 blockSize(32, 16);
+        dim3 gridSize((width + blockSize.x - 1) / blockSize.x, (height + blockSize.y - 1) / blockSize.y, samples);
+
+        switch (conversionCode) {
+            case eColorConversionCode::COLOR_BGR2GRAY:
+                Kernels::Device::rgb_or_bgr_to_grayscale<uchar3, eSwizzle::ZYXW>
+                    <<<gridSize, blockSize, 0, stream>>>(ImageWrapper<uchar3, IndexT>(input), ImageWrapper<uchar1, IndexT>(output));
+                break;
+
+            case eColorConversionCode::COLOR_RGB2GRAY:
+                Kernels::Device::rgb_or_bgr_to_grayscale<uchar3, eSwizzle::XYZW>
+                    <<<gridSize, blockSize, 0, stream>>>(ImageWrapper<uchar3, IndexT>(input), ImageWrapper<uchar1, IndexT>(output));
+                break;
+
+            case eColorConversionCode::COLOR_BGR2RGB:
+            case eColorConversionCode::COLOR_RGB2BGR:
+                Kernels::Device::reorder<uchar3, eSwizzle::ZYXW>
+                    <<<gridSize, blockSize, 0, stream>>>(ImageWrapper<uchar3, IndexT>(input), ImageWrapper<uchar3, IndexT>(output));
+                break;
+
+            case eColorConversionCode::COLOR_BGR2YUV:
+                Kernels::Device::rgb_or_bgr_to_yuv<uchar3, eSwizzle::ZYXW><<<gridSize, blockSize, 0, stream>>>(
+                    ImageWrapper<uchar3, IndexT>(input), ImageWrapper<uchar3, IndexT>(output), 128.0f);
+                break;
+
+            case eColorConversionCode::COLOR_RGB2YUV:
+                Kernels::Device::rgb_or_bgr_to_yuv<uchar3, eSwizzle::XYZW><<<gridSize, blockSize, 0, stream>>>(
+                    ImageWrapper<uchar3, IndexT>(input), ImageWrapper<uchar3, IndexT>(output), 128.0f);
+                break;
+
+            case eColorConversionCode::COLOR_YUV2BGR:
+                Kernels::Device::yuv_to_rgb_or_bgr<uchar3, eSwizzle::ZYXW><<<gridSize, blockSize, 0, stream>>>(
+                    ImageWrapper<uchar3, IndexT>(input), ImageWrapper<uchar3, IndexT>(output), 128.0f);
+                break;
+
+            case eColorConversionCode::COLOR_YUV2RGB:
+                Kernels::Device::yuv_to_rgb_or_bgr<uchar3, eSwizzle::XYZW><<<gridSize, blockSize, 0, stream>>>(
+                    ImageWrapper<uchar3, IndexT>(input), ImageWrapper<uchar3, IndexT>(output), 128.0f);
+                break;
+
+            default:
+                throw Exception("Not implemented", eStatusType::NOT_IMPLEMENTED);
+        }
+    } else {
+        // Dispatch appropriate host kernel based on conversion code
+
+        switch (conversionCode) {
+            case eColorConversionCode::COLOR_BGR2GRAY:
+                Kernels::Host::rgb_or_bgr_to_grayscale<uchar3, eSwizzle::ZYXW>(ImageWrapper<uchar3, IndexT>(input),
+                                                                               ImageWrapper<uchar1, IndexT>(output));
+                break;
+
+            case eColorConversionCode::COLOR_RGB2GRAY:
+                Kernels::Host::rgb_or_bgr_to_grayscale<uchar3, eSwizzle::XYZW>(ImageWrapper<uchar3, IndexT>(input),
+                                                                               ImageWrapper<uchar1, IndexT>(output));
+                break;
+
+            case eColorConversionCode::COLOR_BGR2RGB:
+            case eColorConversionCode::COLOR_RGB2BGR:
+                Kernels::Host::reorder<uchar3, eSwizzle::ZYXW>(ImageWrapper<uchar3, IndexT>(input),
+                                                               ImageWrapper<uchar3, IndexT>(output));
+                break;
+
+            case eColorConversionCode::COLOR_BGR2YUV:
+                Kernels::Host::rgb_or_bgr_to_yuv<uchar3, eSwizzle::ZYXW>(ImageWrapper<uchar3, IndexT>(input),
+                                                                         ImageWrapper<uchar3, IndexT>(output), 128.0f);
+                break;
+
+            case eColorConversionCode::COLOR_RGB2YUV:
+                Kernels::Host::rgb_or_bgr_to_yuv<uchar3, eSwizzle::XYZW>(ImageWrapper<uchar3, IndexT>(input),
+                                                                         ImageWrapper<uchar3, IndexT>(output), 128.0f);
+                break;
+
+            case eColorConversionCode::COLOR_YUV2BGR:
+                Kernels::Host::yuv_to_rgb_or_bgr<uchar3, eSwizzle::ZYXW>(ImageWrapper<uchar3, IndexT>(input),
+                                                                         ImageWrapper<uchar3>(output), 128.0f);
+                break;
+
+            case eColorConversionCode::COLOR_YUV2RGB:
+                Kernels::Host::yuv_to_rgb_or_bgr<uchar3, eSwizzle::XYZW>(ImageWrapper<uchar3, IndexT>(input),
+                                                                         ImageWrapper<uchar3, IndexT>(output), 128.0f);
+                break;
+
+            default:
+                throw Exception("Not implemented", eStatusType::NOT_IMPLEMENTED);
+        }
+    }
+}
 
 void CvtColor::operator()(hipStream_t stream, const Tensor &input, Tensor &output, eColorConversionCode conversionCode,
                           eDeviceType device) {
@@ -73,105 +173,11 @@ void CvtColor::operator()(hipStream_t stream, const Tensor &input, Tensor &outpu
         CHECK_TENSOR_CHANNELS(output, 3);
     }
 
+    // Check if tensors need int64 indexing (adaptive)
     if (needsInt64Wrapper(input) || needsInt64Wrapper(output)) {
-        throw Exception("Input or output tensor is too large for int32 indexing", eStatusType::INVALID_OPERATION);
-    }
-    
-    // Launch kernel
-
-    int64_t width = input.shape(input.layout().width_index());
-    int64_t height = input.shape(input.layout().height_index());
-    int64_t samples = input.shape(input.layout().batch_index());
-
-    if (device == eDeviceType::GPU) {
-        // Dispatch appropriate device kernel based on given conversion code
-
-        dim3 blockSize(32, 16);
-        dim3 gridSize((width + blockSize.x - 1) / blockSize.x, (height + blockSize.y - 1) / blockSize.y, samples);
-
-        switch (conversionCode) {
-            case eColorConversionCode::COLOR_BGR2GRAY:
-                Kernels::Device::rgb_or_bgr_to_grayscale<uchar3, eSwizzle::ZYXW>
-                    <<<gridSize, blockSize, 0, stream>>>(ImageWrapper<uchar3>(input), ImageWrapper<uchar1>(output));
-                break;
-
-            case eColorConversionCode::COLOR_RGB2GRAY:
-                Kernels::Device::rgb_or_bgr_to_grayscale<uchar3, eSwizzle::XYZW>
-                    <<<gridSize, blockSize, 0, stream>>>(ImageWrapper<uchar3>(input), ImageWrapper<uchar1>(output));
-                break;
-
-            case eColorConversionCode::COLOR_BGR2RGB:
-            case eColorConversionCode::COLOR_RGB2BGR:
-                Kernels::Device::reorder<uchar3, eSwizzle::ZYXW>
-                    <<<gridSize, blockSize, 0, stream>>>(ImageWrapper<uchar3>(input), ImageWrapper<uchar3>(output));
-                break;
-
-            case eColorConversionCode::COLOR_BGR2YUV:
-                Kernels::Device::rgb_or_bgr_to_yuv<uchar3, eSwizzle::ZYXW><<<gridSize, blockSize, 0, stream>>>(
-                    ImageWrapper<uchar3>(input), ImageWrapper<uchar3>(output), 128.0f);
-                break;
-
-            case eColorConversionCode::COLOR_RGB2YUV:
-                Kernels::Device::rgb_or_bgr_to_yuv<uchar3, eSwizzle::XYZW><<<gridSize, blockSize, 0, stream>>>(
-                    ImageWrapper<uchar3>(input), ImageWrapper<uchar3>(output), 128.0f);
-                break;
-
-            case eColorConversionCode::COLOR_YUV2BGR:
-                Kernels::Device::yuv_to_rgb_or_bgr<uchar3, eSwizzle::ZYXW><<<gridSize, blockSize, 0, stream>>>(
-                    ImageWrapper<uchar3>(input), ImageWrapper<uchar3>(output), 128.0f);
-                break;
-
-            case eColorConversionCode::COLOR_YUV2RGB:
-                Kernels::Device::yuv_to_rgb_or_bgr<uchar3, eSwizzle::XYZW><<<gridSize, blockSize, 0, stream>>>(
-                    ImageWrapper<uchar3>(input), ImageWrapper<uchar3>(output), 128.0f);
-                break;
-
-            default:
-                throw Exception("Not implemented", eStatusType::NOT_IMPLEMENTED);
-        }
+        dispatch_cvt_color_itype<int64_t>(stream, input, output, conversionCode, device);
     } else {
-        // Dispatch appropriate host kernel based on conversion code
-
-        switch (conversionCode) {
-            case eColorConversionCode::COLOR_BGR2GRAY:
-                Kernels::Host::rgb_or_bgr_to_grayscale<uchar3, eSwizzle::ZYXW>(ImageWrapper<uchar3>(input),
-                                                                               ImageWrapper<uchar1>(output));
-                break;
-
-            case eColorConversionCode::COLOR_RGB2GRAY:
-                Kernels::Host::rgb_or_bgr_to_grayscale<uchar3, eSwizzle::XYZW>(ImageWrapper<uchar3>(input),
-                                                                               ImageWrapper<uchar1>(output));
-                break;
-
-            case eColorConversionCode::COLOR_BGR2RGB:
-            case eColorConversionCode::COLOR_RGB2BGR:
-                Kernels::Host::reorder<uchar3, eSwizzle::ZYXW>(ImageWrapper<uchar3>(input),
-                                                               ImageWrapper<uchar3>(output));
-                break;
-
-            case eColorConversionCode::COLOR_BGR2YUV:
-                Kernels::Host::rgb_or_bgr_to_yuv<uchar3, eSwizzle::ZYXW>(ImageWrapper<uchar3>(input),
-                                                                         ImageWrapper<uchar3>(output), 128.0f);
-                break;
-
-            case eColorConversionCode::COLOR_RGB2YUV:
-                Kernels::Host::rgb_or_bgr_to_yuv<uchar3, eSwizzle::XYZW>(ImageWrapper<uchar3>(input),
-                                                                         ImageWrapper<uchar3>(output), 128.0f);
-                break;
-
-            case eColorConversionCode::COLOR_YUV2BGR:
-                Kernels::Host::yuv_to_rgb_or_bgr<uchar3, eSwizzle::ZYXW>(ImageWrapper<uchar3>(input),
-                                                                         ImageWrapper<uchar3>(output), 128.0f);
-                break;
-
-            case eColorConversionCode::COLOR_YUV2RGB:
-                Kernels::Host::yuv_to_rgb_or_bgr<uchar3, eSwizzle::XYZW>(ImageWrapper<uchar3>(input),
-                                                                         ImageWrapper<uchar3>(output), 128.0f);
-                break;
-
-            default:
-                throw Exception("Not implemented", eStatusType::NOT_IMPLEMENTED);
-        }
+        dispatch_cvt_color_itype<int32_t>(stream, input, output, conversionCode, device);
     }
 }
 

--- a/src/op_flip.cpp
+++ b/src/op_flip.cpp
@@ -32,7 +32,6 @@ THE SOFTWARE.
 #include "core/wrappers/image_wrapper.hpp"
 #include "kernels/device/flip_device.hpp"
 #include "kernels/host/flip_host.hpp"
-#include "operator_types.h"
 
 namespace roccv {
 
@@ -94,9 +93,8 @@ void Flip::operator()(hipStream_t stream, const Tensor& input, const Tensor& out
     CHECK_TENSOR_COMPARISON(input.dtype() == output.dtype());
     CHECK_TENSOR_COMPARISON(input.shape() == output.shape());
 
-    if (needsInt64Wrapper(input) || needsInt64Wrapper(output)) {
-        throw Exception("Input or output tensor is too large for int32 indexing", eStatusType::INVALID_OPERATION);
-    }
+    CHECK_TENSOR_INT32_INDEXING(input);
+    CHECK_TENSOR_INT32_INDEXING(output);
 
     // clang-format off
     static const std::unordered_map<

--- a/src/op_flip.cpp
+++ b/src/op_flip.cpp
@@ -32,6 +32,7 @@ THE SOFTWARE.
 #include "core/wrappers/image_wrapper.hpp"
 #include "kernels/device/flip_device.hpp"
 #include "kernels/host/flip_host.hpp"
+#include "operator_types.h"
 
 namespace roccv {
 
@@ -92,6 +93,10 @@ void Flip::operator()(hipStream_t stream, const Tensor& input, const Tensor& out
     CHECK_TENSOR_COMPARISON(input.layout() == output.layout());
     CHECK_TENSOR_COMPARISON(input.dtype() == output.dtype());
     CHECK_TENSOR_COMPARISON(input.shape() == output.shape());
+
+    if (needsInt64Wrapper(input) || needsInt64Wrapper(output)) {
+        throw Exception("Input or output tensor is too large for int32 indexing", eStatusType::INVALID_OPERATION);
+    }
 
     // clang-format off
     static const std::unordered_map<

--- a/src/op_flip.cpp
+++ b/src/op_flip.cpp
@@ -70,8 +70,8 @@ void dispatch_flip_dtype(hipStream_t stream, const Tensor& input, const Tensor& 
     }
 
     // Dispatch proper kernel based on provided flip type.
-    std::unordered_map<eAxis, std::function<void(hipStream_t stream, const Tensor& input, const Tensor& output,
-                                                 eDeviceType device)>>
+    std::unordered_map<
+        eAxis, std::function<void(hipStream_t stream, const Tensor& input, const Tensor& output, eDeviceType device)>>
         funcs = {{eAxis::X, dispatch_flip_axis<T, eAxis::X>},
                  {eAxis::Y, dispatch_flip_axis<T, eAxis::Y>},
                  {eAxis::BOTH, dispatch_flip_axis<T, eAxis::BOTH>}};

--- a/src/op_gamma_contrast.cpp
+++ b/src/op_gamma_contrast.cpp
@@ -37,7 +37,6 @@ THE SOFTWARE.
 #include "core/wrappers/image_wrapper.hpp"
 #include "kernels/device/gamma_contrast_device.hpp"
 #include "kernels/host/gamma_contrast_host.hpp"
-#include "operator_types.h"
 
 namespace roccv {
 
@@ -82,9 +81,8 @@ void GammaContrast::operator()(hipStream_t stream, const Tensor &input, const Te
     CHECK_TENSOR_COMPARISON(output.shape(output.layout().height_index()) == input.shape(input.layout().height_index()));
     CHECK_TENSOR_COMPARISON(output.shape(output.layout().batch_index()) == input.shape(input.layout().batch_index()));
 
-    if (needsInt64Wrapper(input) || needsInt64Wrapper(output)) {
-        throw Exception("Input or output tensor is too large for int32 indexing", eStatusType::INVALID_OPERATION);
-    }
+    CHECK_TENSOR_INT32_INDEXING(input);
+    CHECK_TENSOR_INT32_INDEXING(output);
 
     // Select kernel dispatcher based on number of channels and a base datatype.
     // clang-format off

--- a/src/op_gamma_contrast.cpp
+++ b/src/op_gamma_contrast.cpp
@@ -37,6 +37,7 @@ THE SOFTWARE.
 #include "core/wrappers/image_wrapper.hpp"
 #include "kernels/device/gamma_contrast_device.hpp"
 #include "kernels/host/gamma_contrast_host.hpp"
+#include "operator_types.h"
 
 namespace roccv {
 
@@ -80,6 +81,10 @@ void GammaContrast::operator()(hipStream_t stream, const Tensor &input, const Te
     CHECK_TENSOR_COMPARISON(output.shape(output.layout().width_index()) == input.shape(input.layout().width_index()));
     CHECK_TENSOR_COMPARISON(output.shape(output.layout().height_index()) == input.shape(input.layout().height_index()));
     CHECK_TENSOR_COMPARISON(output.shape(output.layout().batch_index()) == input.shape(input.layout().batch_index()));
+
+    if (needsInt64Wrapper(input) || needsInt64Wrapper(output)) {
+        throw Exception("Input or output tensor is too large for int32 indexing", eStatusType::INVALID_OPERATION);
+    }
 
     // Select kernel dispatcher based on number of channels and a base datatype.
     // clang-format off

--- a/src/op_histogram.cpp
+++ b/src/op_histogram.cpp
@@ -34,6 +34,7 @@ THE SOFTWARE.
 #include "core/wrappers/image_wrapper.hpp"
 #include "kernels/device/histogram_device.hpp"
 #include "kernels/host/histogram_host.hpp"
+#include "operator_types.h"
 
 namespace roccv {
 Histogram::Histogram() {}
@@ -139,6 +140,10 @@ void Histogram::operator()(hipStream_t stream, const Tensor& input,
     // Ensure all tensors are using supported layouts.
     CHECK_TENSOR_LAYOUT(input, eTensorLayout::TENSOR_LAYOUT_NHWC, eTensorLayout::TENSOR_LAYOUT_HWC);
     CHECK_TENSOR_LAYOUT(histogram, eTensorLayout::TENSOR_LAYOUT_HWC);
+
+    if (needsInt64Wrapper(input) || needsInt64Wrapper(histogram)) {
+        throw Exception("Input or histogram tensor is too large for int32 indexing", eStatusType::INVALID_OPERATION);
+    }
 
     // Create kernel dispatching table based on histogram datatype.
     // clang-format off

--- a/src/op_histogram.cpp
+++ b/src/op_histogram.cpp
@@ -34,7 +34,6 @@ THE SOFTWARE.
 #include "core/wrappers/image_wrapper.hpp"
 #include "kernels/device/histogram_device.hpp"
 #include "kernels/host/histogram_host.hpp"
-#include "operator_types.h"
 
 namespace roccv {
 Histogram::Histogram() {}
@@ -141,9 +140,8 @@ void Histogram::operator()(hipStream_t stream, const Tensor& input,
     CHECK_TENSOR_LAYOUT(input, eTensorLayout::TENSOR_LAYOUT_NHWC, eTensorLayout::TENSOR_LAYOUT_HWC);
     CHECK_TENSOR_LAYOUT(histogram, eTensorLayout::TENSOR_LAYOUT_HWC);
 
-    if (needsInt64Wrapper(input) || needsInt64Wrapper(histogram)) {
-        throw Exception("Input or histogram tensor is too large for int32 indexing", eStatusType::INVALID_OPERATION);
-    }
+    CHECK_TENSOR_INT32_INDEXING(input);
+    CHECK_TENSOR_INT32_INDEXING(histogram);
 
     // Create kernel dispatching table based on histogram datatype.
     // clang-format off

--- a/src/op_non_max_suppression.cpp
+++ b/src/op_non_max_suppression.cpp
@@ -92,7 +92,7 @@ void NonMaximumSuppression::operator()(hipStream_t stream, const Tensor& input, 
 
     CHECK_TENSOR_COMPARISON(scores.shape(1) == numBoxes);
     CHECK_TENSOR_COMPARISON(scores.shape(0) == numBatches);
-    
+
     CHECK_TENSOR_INT32_INDEXING(input);
     CHECK_TENSOR_INT32_INDEXING(output);
 

--- a/src/op_non_max_suppression.cpp
+++ b/src/op_non_max_suppression.cpp
@@ -27,6 +27,7 @@ THE SOFTWARE.
 #include "core/hip_assert.h"
 #include "kernels/device/non_max_suppression_device.hpp"
 #include "kernels/host/non_max_suppression_host.hpp"
+#include "operator_types.h"
 
 namespace roccv {
 void NonMaximumSuppression::operator()(hipStream_t stream, const Tensor& input, const Tensor& output,
@@ -92,6 +93,10 @@ void NonMaximumSuppression::operator()(hipStream_t stream, const Tensor& input, 
 
     CHECK_TENSOR_COMPARISON(scores.shape(1) == numBoxes);
     CHECK_TENSOR_COMPARISON(scores.shape(0) == numBatches);
+    
+    if (needsInt64Wrapper(input) || needsInt64Wrapper(output)) {
+        throw Exception("Input or output tensor is too large for int32 indexing", eStatusType::INVALID_OPERATION);
+    }
 
     // Create tensor views to conform to the expected data types of the NMS kernel. These shapes should be validated,
     // but typically involve going from non-vectorized to vectorized shapes. These shapes should be validated

--- a/src/op_non_max_suppression.cpp
+++ b/src/op_non_max_suppression.cpp
@@ -27,7 +27,6 @@ THE SOFTWARE.
 #include "core/hip_assert.h"
 #include "kernels/device/non_max_suppression_device.hpp"
 #include "kernels/host/non_max_suppression_host.hpp"
-#include "operator_types.h"
 
 namespace roccv {
 void NonMaximumSuppression::operator()(hipStream_t stream, const Tensor& input, const Tensor& output,
@@ -94,9 +93,8 @@ void NonMaximumSuppression::operator()(hipStream_t stream, const Tensor& input, 
     CHECK_TENSOR_COMPARISON(scores.shape(1) == numBoxes);
     CHECK_TENSOR_COMPARISON(scores.shape(0) == numBatches);
     
-    if (needsInt64Wrapper(input) || needsInt64Wrapper(output)) {
-        throw Exception("Input or output tensor is too large for int32 indexing", eStatusType::INVALID_OPERATION);
-    }
+    CHECK_TENSOR_INT32_INDEXING(input);
+    CHECK_TENSOR_INT32_INDEXING(output);
 
     // Create tensor views to conform to the expected data types of the NMS kernel. These shapes should be validated,
     // but typically involve going from non-vectorized to vectorized shapes. These shapes should be validated

--- a/src/op_normalize.cpp
+++ b/src/op_normalize.cpp
@@ -31,7 +31,6 @@ THE SOFTWARE.
 #include "core/wrappers/image_wrapper.hpp"
 #include "kernels/device/normalize_device.hpp"
 #include "kernels/host/normalize_host.hpp"
-#include "operator_types.h"
 
 namespace roccv {
 
@@ -115,9 +114,8 @@ void Normalize::operator()(hipStream_t stream, const Tensor& input, const Tensor
     CHECK_TENSOR_COMPARISON(base.shape(base.layout().channels_index()) == input.shape(input.layout().channels_index()));
     CHECK_TENSOR_COMPARISON(scale.shape(scale.layout().channels_index()) == input.shape(input.layout().channels_index()));
 
-    if (needsInt64Wrapper(input) || needsInt64Wrapper(output)) {
-        throw Exception("Input or output tensor is too large for int32 indexing", eStatusType::INVALID_OPERATION);
-    }
+    CHECK_TENSOR_INT32_INDEXING(input);
+    CHECK_TENSOR_INT32_INDEXING(output);
     // Create kernel dispatching table based on input/output datatype and number of channels.
     // clang-format off
     static const std::unordered_map<eDataType, std::array<std::function<void(hipStream_t, const Tensor&, const Tensor&, const Tensor&, const Tensor&, float, float, float, uint32_t, eDeviceType)>, 4>>

--- a/src/op_normalize.cpp
+++ b/src/op_normalize.cpp
@@ -112,7 +112,8 @@ void Normalize::operator()(hipStream_t stream, const Tensor& input, const Tensor
     // TODO: Need to support scalar base/scale tensors at some point. Will require some extra handling on the kernel
     // level. Once in place, this check can be removed.
     CHECK_TENSOR_COMPARISON(base.shape(base.layout().channels_index()) == input.shape(input.layout().channels_index()));
-    CHECK_TENSOR_COMPARISON(scale.shape(scale.layout().channels_index()) == input.shape(input.layout().channels_index()));
+    CHECK_TENSOR_COMPARISON(scale.shape(scale.layout().channels_index()) ==
+                            input.shape(input.layout().channels_index()));
 
     CHECK_TENSOR_INT32_INDEXING(input);
     CHECK_TENSOR_INT32_INDEXING(output);

--- a/src/op_normalize.cpp
+++ b/src/op_normalize.cpp
@@ -31,6 +31,7 @@ THE SOFTWARE.
 #include "core/wrappers/image_wrapper.hpp"
 #include "kernels/device/normalize_device.hpp"
 #include "kernels/host/normalize_host.hpp"
+#include "operator_types.h"
 
 namespace roccv {
 
@@ -114,6 +115,9 @@ void Normalize::operator()(hipStream_t stream, const Tensor& input, const Tensor
     CHECK_TENSOR_COMPARISON(base.shape(base.layout().channels_index()) == input.shape(input.layout().channels_index()));
     CHECK_TENSOR_COMPARISON(scale.shape(scale.layout().channels_index()) == input.shape(input.layout().channels_index()));
 
+    if (needsInt64Wrapper(input) || needsInt64Wrapper(output)) {
+        throw Exception("Input or output tensor is too large for int32 indexing", eStatusType::INVALID_OPERATION);
+    }
     // Create kernel dispatching table based on input/output datatype and number of channels.
     // clang-format off
     static const std::unordered_map<eDataType, std::array<std::function<void(hipStream_t, const Tensor&, const Tensor&, const Tensor&, const Tensor&, float, float, float, uint32_t, eDeviceType)>, 4>>

--- a/src/op_reformat.cpp
+++ b/src/op_reformat.cpp
@@ -29,7 +29,6 @@ THE SOFTWARE.
 #include "core/wrappers/image_wrapper.hpp"
 #include "kernels/device/reformat_device.hpp"
 #include "kernels/host/reformat_host.hpp"
-#include "operator_types.h"
 
 namespace roccv {
 
@@ -108,9 +107,8 @@ void Reformat::operator()(hipStream_t stream, const Tensor& input, const Tensor&
     CHECK_TENSOR_COMPARISON(inputShape["W"] == outputShape["W"]);
     CHECK_TENSOR_COMPARISON(inputShape["H"] == outputShape["H"]);
 
-    if (needsInt64Wrapper(input) || needsInt64Wrapper(output)) {
-        throw Exception("Input or output tensor is too large for int32 indexing", eStatusType::INVALID_OPERATION);
-    }
+    CHECK_TENSOR_INT32_INDEXING(input);
+    CHECK_TENSOR_INT32_INDEXING(output);
 
     // Select kernel dispatcher based on the input and output datatypes.
     static const std::unordered_map<eDataType, std::function<void(hipStream_t stream, const Tensor& input, const Tensor& output,

--- a/src/op_reformat.cpp
+++ b/src/op_reformat.cpp
@@ -79,8 +79,7 @@ void DispatchReformatType(hipStream_t stream, const Tensor& input, const Tensor&
 }
 }  // namespace
 
-void Reformat::operator()(hipStream_t stream, const Tensor& input, const Tensor& output,
-                          eDeviceType device) const {
+void Reformat::operator()(hipStream_t stream, const Tensor& input, const Tensor& output, eDeviceType device) const {
     // clang-format off
 
     // Validate the input and output tensors

--- a/src/op_reformat.cpp
+++ b/src/op_reformat.cpp
@@ -29,6 +29,7 @@ THE SOFTWARE.
 #include "core/wrappers/image_wrapper.hpp"
 #include "kernels/device/reformat_device.hpp"
 #include "kernels/host/reformat_host.hpp"
+#include "operator_types.h"
 
 namespace roccv {
 
@@ -106,6 +107,10 @@ void Reformat::operator()(hipStream_t stream, const Tensor& input, const Tensor&
     CHECK_TENSOR_COMPARISON(inputShape["C"] == outputShape["C"]);
     CHECK_TENSOR_COMPARISON(inputShape["W"] == outputShape["W"]);
     CHECK_TENSOR_COMPARISON(inputShape["H"] == outputShape["H"]);
+
+    if (needsInt64Wrapper(input) || needsInt64Wrapper(output)) {
+        throw Exception("Input or output tensor is too large for int32 indexing", eStatusType::INVALID_OPERATION);
+    }
 
     // Select kernel dispatcher based on the input and output datatypes.
     static const std::unordered_map<eDataType, std::function<void(hipStream_t stream, const Tensor& input, const Tensor& output,

--- a/src/op_remap.cpp
+++ b/src/op_remap.cpp
@@ -33,6 +33,7 @@ THE SOFTWARE.
 #include "core/wrappers/interpolation_wrapper.hpp"
 #include "kernels/device/remap_device.hpp"
 #include "kernels/host/remap_host.hpp"
+#include "operator_types.h"
 
 using namespace roccv::detail;
 namespace roccv {
@@ -204,6 +205,10 @@ void Remap::operator()(hipStream_t stream, const Tensor &input, const Tensor &ou
 
     CHECK_TENSOR_CHANNELS(input, 1, 3, 4);
     CHECK_TENSOR_CHANNELS(map, 2);
+
+    if (needsInt64Wrapper(input) || needsInt64Wrapper(output)) {
+        throw Exception("Input or output tensor is too large for int32 indexing", eStatusType::INVALID_OPERATION);
+    }
 
     eDataType dtype = input.dtype().etype();
     int64_t channels = input.shape(input.layout().channels_index());

--- a/src/op_remap.cpp
+++ b/src/op_remap.cpp
@@ -33,7 +33,6 @@ THE SOFTWARE.
 #include "core/wrappers/interpolation_wrapper.hpp"
 #include "kernels/device/remap_device.hpp"
 #include "kernels/host/remap_host.hpp"
-#include "operator_types.h"
 
 using namespace roccv::detail;
 namespace roccv {
@@ -206,9 +205,8 @@ void Remap::operator()(hipStream_t stream, const Tensor &input, const Tensor &ou
     CHECK_TENSOR_CHANNELS(input, 1, 3, 4);
     CHECK_TENSOR_CHANNELS(map, 2);
 
-    if (needsInt64Wrapper(input) || needsInt64Wrapper(output)) {
-        throw Exception("Input or output tensor is too large for int32 indexing", eStatusType::INVALID_OPERATION);
-    }
+    CHECK_TENSOR_INT32_INDEXING(input);
+    CHECK_TENSOR_INT32_INDEXING(output);
 
     eDataType dtype = input.dtype().etype();
     int64_t channels = input.shape(input.layout().channels_index());

--- a/src/op_resize.cpp
+++ b/src/op_resize.cpp
@@ -97,8 +97,9 @@ void Resize::operator()(hipStream_t stream, const Tensor& input, const Tensor& o
                                 output.shape(output.layout().batch_index()));
     }
 
-    if (needsInt64Wrapper(input) || needsInt64Wrapper(output) ||
-                  hasDimExceedingInt32(input) || hasDimExceedingInt32(output)) {
+    CHECK_TENSOR_INT32_INDEXING(input);
+    CHECK_TENSOR_INT32_INDEXING(output);
+    if (hasDimExceedingInt32(input) || hasDimExceedingInt32(output)) {
         throw Exception("Input or output tensor is too large for int32 indexing", eStatusType::INVALID_OPERATION);
     }
 

--- a/src/op_resize.cpp
+++ b/src/op_resize.cpp
@@ -63,13 +63,13 @@ void dispatch_resize_interp(hipStream_t stream, const Tensor& input, const Tenso
 template <typename T>
 void dispatch_resize_dtype(hipStream_t stream, const Tensor& input, const Tensor& output,
                            eInterpolationType interpolation, eDeviceType device) {
-    static const std::unordered_map<
-        eInterpolationType,
-        std::function<void(hipStream_t stream, const Tensor& input, const Tensor& output, eDeviceType device)>>
-        funcs = {{eInterpolationType::INTERP_TYPE_NEAREST, dispatch_resize_interp<T, eInterpolationType::INTERP_TYPE_NEAREST>},
-                 {eInterpolationType::INTERP_TYPE_LINEAR, dispatch_resize_interp<T, eInterpolationType::INTERP_TYPE_LINEAR>},
-                 {eInterpolationType::INTERP_TYPE_CUBIC, dispatch_resize_interp<T, eInterpolationType::INTERP_TYPE_CUBIC>}
-                };
+    static const std::unordered_map<eInterpolationType, std::function<void(hipStream_t stream, const Tensor& input,
+                                                                           const Tensor& output, eDeviceType device)>>
+        funcs = {
+            {eInterpolationType::INTERP_TYPE_NEAREST,
+             dispatch_resize_interp<T, eInterpolationType::INTERP_TYPE_NEAREST>},
+            {eInterpolationType::INTERP_TYPE_LINEAR, dispatch_resize_interp<T, eInterpolationType::INTERP_TYPE_LINEAR>},
+            {eInterpolationType::INTERP_TYPE_CUBIC, dispatch_resize_interp<T, eInterpolationType::INTERP_TYPE_CUBIC>}};
 
     if (!funcs.contains(interpolation)) {
         throw Exception("Operation does not support the given interpolation mode.", eStatusType::NOT_IMPLEMENTED);
@@ -79,8 +79,8 @@ void dispatch_resize_dtype(hipStream_t stream, const Tensor& input, const Tensor
     func(stream, input, output, device);
 }
 
-void Resize::operator()(hipStream_t stream, const Tensor& input, const Tensor& output,
-                        eInterpolationType interpolation, eDeviceType device) const {
+void Resize::operator()(hipStream_t stream, const Tensor& input, const Tensor& output, eInterpolationType interpolation,
+                        eDeviceType device) const {
     CHECK_TENSOR_DEVICE(input, device);
     CHECK_TENSOR_DEVICE(output, device);
 

--- a/src/op_resize.cpp
+++ b/src/op_resize.cpp
@@ -31,6 +31,7 @@ THE SOFTWARE.
 #include "core/wrappers/interpolation_wrapper.hpp"
 #include "kernels/device/resize_device.hpp"
 #include "kernels/host/resize_host.hpp"
+#include "operator_types.h"
 
 namespace roccv {
 
@@ -94,6 +95,11 @@ void Resize::operator()(hipStream_t stream, const Tensor& input, const Tensor& o
     if (input.layout().batch_index() != -1) {
         CHECK_TENSOR_COMPARISON(input.shape(input.layout().batch_index()) ==
                                 output.shape(output.layout().batch_index()));
+    }
+
+    if (needsInt64Wrapper(input) || needsInt64Wrapper(output) ||
+                  hasDimExceedingInt32(input) || hasDimExceedingInt32(output)) {
+        throw Exception("Input or output tensor is too large for int32 indexing", eStatusType::INVALID_OPERATION);
     }
 
     // clang-format off

--- a/src/op_rotate.cpp
+++ b/src/op_rotate.cpp
@@ -29,7 +29,6 @@ THE SOFTWARE.
 #include "core/wrappers/interpolation_wrapper.hpp"
 #include "kernels/device/rotate_device.hpp"
 #include "kernels/host/rotate_host.hpp"
-#include "operator_types.h"
 
 namespace roccv {
 void GetRotationMatrix(double angleDeg, double2 shift, double *mat) {
@@ -108,9 +107,8 @@ void Rotate::operator()(hipStream_t stream, const Tensor &input, const Tensor &o
     CHECK_TENSOR_COMPARISON(input.dtype() == output.dtype());
     CHECK_TENSOR_COMPARISON(input.shape() == output.shape());
 
-    if (needsInt64Wrapper(input) || needsInt64Wrapper(output)) {
-        throw Exception("Input or output tensor is too large for int32 indexing", eStatusType::INVALID_OPERATION);
-    }
+    CHECK_TENSOR_INT32_INDEXING(input);
+    CHECK_TENSOR_INT32_INDEXING(output);
 
     // clang-format off
     static const std::unordered_map<

--- a/src/op_rotate.cpp
+++ b/src/op_rotate.cpp
@@ -108,6 +108,10 @@ void Rotate::operator()(hipStream_t stream, const Tensor &input, const Tensor &o
     CHECK_TENSOR_COMPARISON(input.dtype() == output.dtype());
     CHECK_TENSOR_COMPARISON(input.shape() == output.shape());
 
+    if (needsInt64Wrapper(input) || needsInt64Wrapper(output)) {
+        throw Exception("Input or output tensor is too large for int32 indexing", eStatusType::INVALID_OPERATION);
+    }
+
     // clang-format off
     static const std::unordered_map<
         eDataType, std::array<std::function<void(hipStream_t, const Tensor &, const Tensor &, double,

--- a/src/op_rotate.cpp
+++ b/src/op_rotate.cpp
@@ -29,6 +29,7 @@ THE SOFTWARE.
 #include "core/wrappers/interpolation_wrapper.hpp"
 #include "kernels/device/rotate_device.hpp"
 #include "kernels/host/rotate_host.hpp"
+#include "operator_types.h"
 
 namespace roccv {
 void GetRotationMatrix(double angleDeg, double2 shift, double *mat) {

--- a/src/op_rotate.cpp
+++ b/src/op_rotate.cpp
@@ -74,8 +74,8 @@ void dispatch_rotate_interp(hipStream_t stream, const Tensor &input, const Tenso
 }
 
 template <typename T>
-void dispatch_rotate_type(hipStream_t stream, const Tensor &input, const Tensor &output, double angleDeg,
-                          double2 shift, eInterpolationType interpolation, eDeviceType device) {
+void dispatch_rotate_type(hipStream_t stream, const Tensor &input, const Tensor &output, double angleDeg, double2 shift,
+                          eInterpolationType interpolation, eDeviceType device) {
     // clang-format off
     static const std::unordered_map<eInterpolationType,
                                     std::function<void(hipStream_t, const Tensor &, const Tensor &, double,
@@ -94,8 +94,8 @@ void dispatch_rotate_type(hipStream_t stream, const Tensor &input, const Tensor 
     func(stream, input, output, angleDeg, shift, device);
 }
 
-void Rotate::operator()(hipStream_t stream, const Tensor &input, const Tensor &output, double angleDeg,
-                        double2 shift, eInterpolationType interpolation, eDeviceType device) const {
+void Rotate::operator()(hipStream_t stream, const Tensor &input, const Tensor &output, double angleDeg, double2 shift,
+                        eInterpolationType interpolation, eDeviceType device) const {
     CHECK_TENSOR_DEVICE(input, device);
     CHECK_TENSOR_CHANNELS(input, 1, 3, 4);
     CHECK_TENSOR_DATATYPES(input, eDataType::DATA_TYPE_U8, eDataType::DATA_TYPE_S8, eDataType::DATA_TYPE_U16,

--- a/src/op_thresholding.cpp
+++ b/src/op_thresholding.cpp
@@ -30,7 +30,6 @@ THE SOFTWARE.
 #include "core/wrappers/image_wrapper.hpp"
 #include "kernels/device/thresholding_device.hpp"
 #include "kernels/host/thresholding_host.hpp"
-#include "operator_types.h"
 
 namespace roccv {
 Threshold::Threshold(eThresholdType threshType, int32_t maxBatchSize)
@@ -133,9 +132,8 @@ void Threshold::operator()(hipStream_t stream, const Tensor &input, const Tensor
     CHECK_TENSOR_COMPARISON(thresh.shape("N") == input.shape("N"));
     CHECK_TENSOR_COMPARISON(maxVal.shape("N") == input.shape("N"));
 
-    if (needsInt64Wrapper(input) || needsInt64Wrapper(output)) {
-        throw Exception("Input or output tensor is too large for int32 indexing", eStatusType::INVALID_OPERATION);
-    }
+    CHECK_TENSOR_INT32_INDEXING(input);
+    CHECK_TENSOR_INT32_INDEXING(output);
 
     // Select kernel dispatcher based on number of channels and a base datatype.
     // clang-format off

--- a/src/op_thresholding.cpp
+++ b/src/op_thresholding.cpp
@@ -30,6 +30,7 @@ THE SOFTWARE.
 #include "core/wrappers/image_wrapper.hpp"
 #include "kernels/device/thresholding_device.hpp"
 #include "kernels/host/thresholding_host.hpp"
+#include "operator_types.h"
 
 namespace roccv {
 Threshold::Threshold(eThresholdType threshType, int32_t maxBatchSize)
@@ -131,6 +132,10 @@ void Threshold::operator()(hipStream_t stream, const Tensor &input, const Tensor
     // Ensure the threshold and max value tensors have the same batch size as the input tensor.
     CHECK_TENSOR_COMPARISON(thresh.shape("N") == input.shape("N"));
     CHECK_TENSOR_COMPARISON(maxVal.shape("N") == input.shape("N"));
+
+    if (needsInt64Wrapper(input) || needsInt64Wrapper(output)) {
+        throw Exception("Input or output tensor is too large for int32 indexing", eStatusType::INVALID_OPERATION);
+    }
 
     // Select kernel dispatcher based on number of channels and a base datatype.
     // clang-format off

--- a/src/op_warp_affine.cpp
+++ b/src/op_warp_affine.cpp
@@ -29,6 +29,7 @@ THE SOFTWARE.
 #include "core/detail/math/math.hpp"
 #include "kernels/device/warp_affine_device.hpp"
 #include "kernels/host/warp_affine_host.hpp"
+#include "operator_types.h"
 
 namespace roccv {
 template <typename T, eBorderType B, eInterpolationType I>
@@ -117,6 +118,10 @@ void WarpAffine::operator()(hipStream_t stream, const Tensor &input, const Tenso
     if (output.layout().batch_index() != -1) {
         CHECK_TENSOR_COMPARISON(output.shape(output.layout().batch_index()) ==
                                 input.shape(input.layout().batch_index()));
+    }
+
+    if (needsInt64Wrapper(input) || needsInt64Wrapper(output)) {
+        throw Exception("Input or output tensor is too large for int32 indexing", eStatusType::INVALID_OPERATION);
     }
 
     PerspectiveTransform full{};

--- a/src/op_warp_affine.cpp
+++ b/src/op_warp_affine.cpp
@@ -29,7 +29,6 @@ THE SOFTWARE.
 #include "core/detail/math/math.hpp"
 #include "kernels/device/warp_affine_device.hpp"
 #include "kernels/host/warp_affine_host.hpp"
-#include "operator_types.h"
 
 namespace roccv {
 template <typename T, eBorderType B, eInterpolationType I>
@@ -120,9 +119,8 @@ void WarpAffine::operator()(hipStream_t stream, const Tensor &input, const Tenso
                                 input.shape(input.layout().batch_index()));
     }
 
-    if (needsInt64Wrapper(input) || needsInt64Wrapper(output)) {
-        throw Exception("Input or output tensor is too large for int32 indexing", eStatusType::INVALID_OPERATION);
-    }
+    CHECK_TENSOR_INT32_INDEXING(input);
+    CHECK_TENSOR_INT32_INDEXING(output);
 
     PerspectiveTransform full{};
 #pragma unroll

--- a/src/op_warp_perspective.cpp
+++ b/src/op_warp_perspective.cpp
@@ -35,7 +35,6 @@ namespace roccv {
 template <typename T, eBorderType B, eInterpolationType I>
 void dispatch_warp_perspective_interp(hipStream_t stream, const Tensor &input, const Tensor &output,
                                       const PerspectiveTransform transMatrix, T borderValue, eDeviceType device) {
-
     ArrayWrapper<float, 9> transform(transMatrix);
     ImageWrapper<T> outputWrapper(output);
     InterpolationWrapper<T, B, I> inputWrapper(input, borderValue);

--- a/src/op_warp_perspective.cpp
+++ b/src/op_warp_perspective.cpp
@@ -30,7 +30,6 @@ THE SOFTWARE.
 #include "core/detail/type_traits.hpp"
 #include "kernels/device/warp_perspective_device.hpp"
 #include "kernels/host/warp_perspective_host.hpp"
-#include "operator_types.h"
 
 namespace roccv {
 template <typename T, eBorderType B, eInterpolationType I>
@@ -127,9 +126,8 @@ void WarpPerspective::operator()(hipStream_t stream, const Tensor &input, const 
                                 input.shape(input.layout().batch_index()));
     }
 
-    if (needsInt64Wrapper(input) || needsInt64Wrapper(output)) {
-        throw Exception("Input or output tensor is too large for int32 indexing", eStatusType::INVALID_OPERATION);
-    }
+    CHECK_TENSOR_INT32_INDEXING(input);
+    CHECK_TENSOR_INT32_INDEXING(output);
 
     PerspectiveTransform invertedTransform;
 

--- a/src/op_warp_perspective.cpp
+++ b/src/op_warp_perspective.cpp
@@ -30,11 +30,13 @@ THE SOFTWARE.
 #include "core/detail/type_traits.hpp"
 #include "kernels/device/warp_perspective_device.hpp"
 #include "kernels/host/warp_perspective_host.hpp"
+#include "operator_types.h"
 
 namespace roccv {
 template <typename T, eBorderType B, eInterpolationType I>
 void dispatch_warp_perspective_interp(hipStream_t stream, const Tensor &input, const Tensor &output,
                                       const PerspectiveTransform transMatrix, T borderValue, eDeviceType device) {
+
     ArrayWrapper<float, 9> transform(transMatrix);
     ImageWrapper<T> outputWrapper(output);
     InterpolationWrapper<T, B, I> inputWrapper(input, borderValue);
@@ -123,6 +125,10 @@ void WarpPerspective::operator()(hipStream_t stream, const Tensor &input, const 
     if (output.layout().batch_index() != -1) {
         CHECK_TENSOR_COMPARISON(output.shape(output.layout().batch_index()) ==
                                 input.shape(input.layout().batch_index()));
+    }
+
+    if (needsInt64Wrapper(input) || needsInt64Wrapper(output)) {
+        throw Exception("Input or output tensor is too large for int32 indexing", eStatusType::INVALID_OPERATION);
     }
 
     PerspectiveTransform invertedTransform;


### PR DESCRIPTION
## Motivation

Operators can see a speedup when image indexing and stride calculations are done in int32 rather than int64.

## Technical Details

Templatized the ImageWrapper, BorderWrapper, and InterpolationWrapper classes so that the type they use for index/stride calculations can be controlled to be int32_t or int64_t. Currently all operators but CvtColor have a hard limit, checked with validation, that they must fit in int32 (they will not fall back to int64_t otherwise). CvtColor is adaptive: will choose int32 for the wrapper type if it can fit, and otherwise falls back to int64_t.

## Tests

Existing ctests all still pass.
Benchmark with batch size 128 on Resize throws an exception because it is too large to fit with int32.
