### PR TITLE
[Bugfix] Add missing Size2D include in merged ImageBatch headers

### DIFF
--- a/include/core/image.hpp
+++ b/include/core/image.hpp
@@ -32,6 +32,7 @@
 #include "core/image_buffer.hpp"
 #include "core/image_data.hpp"
 #include "core/image_format.hpp"
+#include "core/size.hpp"
 #include "core/util_enums.h"
 #include "operator_types.h"
 

--- a/include/core/image_batch_data.hpp
+++ b/include/core/image_batch_data.hpp
@@ -29,6 +29,7 @@
 
 #include "core/image_batch_buffer.hpp"
 #include "core/image_format.hpp"
+#include "core/size.hpp"
 #include "core/util_enums.h"
 #include "operator_types.h"
 

--- a/include/core/image_batch_var_shape.hpp
+++ b/include/core/image_batch_var_shape.hpp
@@ -34,6 +34,7 @@
 #include "core/image.hpp"
 #include "core/image_batch_data.hpp"
 #include "core/image_format.hpp"
+#include "core/size.hpp"
 #include "exception.hpp"
 #include "operator_types.h"
 

--- a/include/core/image_data.hpp
+++ b/include/core/image_data.hpp
@@ -29,6 +29,7 @@
 
 #include "core/image_buffer.hpp"
 #include "core/image_format.hpp"
+#include "core/size.hpp"
 #include "core/util_enums.h"
 #include "operator_types.h"
 

--- a/tests/roccv/cpp/include/image_test_helpers.hpp
+++ b/tests/roccv/cpp/include/image_test_helpers.hpp
@@ -61,7 +61,7 @@ class CountingAllocator : public IAllocator {
     mutable int pinnedFrees = 0;
     mutable size_t lastAllocBytes = 0;
 
-    void* allocHipMem(size_t size) const override {
+    void* allocHipMem(size_t size, int32_t /*alignment*/ = 0) const override {
         ++hipAllocs;
         lastAllocBytes = size;
         return std::malloc(size);


### PR DESCRIPTION
## Problem

The variable-shape ImageBatch merge (#151) introduced headers that reference `roccv::Size2D` (defined in `core/size.hpp`) without including it. It only compiled because `Size2D` leaked in transitively via include order; any translation unit that included these headers first hit `error: 'Size2D' could not be found`.

## Fix

Add `#include "core/size.hpp"` to the four headers that use `Size2D` directly (`image_data.hpp`, `image.hpp`, `image_batch_data.hpp`, `image_batch_var_shape.hpp`) following include-what-you-use.

Also fix a second fallout from the same merge: `CountingAllocator` in the test helpers was left abstract because `allocHipMem` didn't pick up the `int32_t alignment = 0` parameter that `IAllocator` gained in the alignment work (#136). Updated the signature so it overrides the pure virtual again.

## Verification

Full build (library + tests + Python bindings) is clean, and `test_image_batch_var_shape` passes.