### PR TITLE
[Bugfix]: Fix concurrency edge case in Gaussian

### DIFF
--- a/include/op_gaussian.hpp
+++ b/include/op_gaussian.hpp
@@ -55,7 +55,8 @@ class Gaussian final : public IOperator {
 
     /**
      * @brief Executes the Gaussian operation on the given HIP stream.
-     *
+     * Note that the Gaussian operator is stateful, and has concurrency control such that back-to-back calls on the same
+     * Gaussian operator object will be serialized.
      *
      * Limitations:
      *
@@ -78,6 +79,7 @@ class Gaussian final : public IOperator {
      *       kernelHeight: Must be odd and positive, or non-positive (<= 0) in which case it is inferred from sigmaY.
      *                     Inferred kernel size is calculated as: round(sigmaY × (U8 ? 6 : 8) + 1) | 1
      *                     Must not exceed m_maxKernelHeight after inference.
+     *
      *
      * Input/Output dependency:
      *

--- a/include/op_gaussian.hpp
+++ b/include/op_gaussian.hpp
@@ -80,7 +80,6 @@ class Gaussian final : public IOperator {
      *                     Inferred kernel size is calculated as: round(sigmaY × (U8 ? 6 : 8) + 1) | 1
      *                     Must not exceed m_maxKernelHeight after inference.
      *
-     *
      * Input/Output dependency:
      *
      *       Property      |  Input == Output

--- a/src/op_gaussian.cpp
+++ b/src/op_gaussian.cpp
@@ -135,9 +135,7 @@ void Gaussian::operator()(hipStream_t stream, const Tensor& input, Tensor& outpu
     }
 
     std::lock_guard<std::mutex> lock(m_bufferMutex);
-    if (device == eDeviceType::GPU) {
-        HIP_VALIDATE_NO_ERRORS(hipEventSynchronize(m_completionEvent));
-    }
+    HIP_VALIDATE_NO_ERRORS(hipEventSynchronize(m_completionEvent));
 
     // compute the kernel
     int halfW = kernelWidth / 2;


### PR DESCRIPTION
## Motivation
The current implementation of Gaussian has a concurrency edge case: if the operator is called on GPU, and then the same operator object is called on CPU, it is possible for the CPU-side call to start modifying the CPU memory held in `m_hostKernelMem` before the GPU-side call has finished copying it over, asynchronously, to GPU memory. 

Also added a note to the header file clarifying the enforced serialization of this operator.

## Technical Details
Call `hipEventSynchronize(m_completionEvent)` on both backends (rather than just GPU), so that a CPU call waits for any previous GPU-side operator call to complete its asynchronous GPU work (including the mem copy) before touching the CPU memory.

## Test Plan
rocCV CTests tests.

## Test Result
All CTests pass.
