### PR TITLE
[Bugfix]: Add validation on smem size for Gaussian

### DIFF
--- a/src/op_gaussian.cpp
+++ b/src/op_gaussian.cpp
@@ -134,6 +134,24 @@ void Gaussian::operator()(hipStream_t stream, const Tensor& input, Tensor& outpu
             eStatusType::INVALID_VALUE);
     }
 
+    // Validate will fit in shared mem
+    if (device == eDeviceType::GPU && !m_use2D) {
+        int deviceId;
+        HIP_VALIDATE_NO_ERRORS(hipGetDevice(&deviceId));
+        int maxSharedMem;
+        HIP_VALIDATE_NO_ERRORS(
+            hipDeviceGetAttribute(&maxSharedMem, hipDeviceAttributeMaxSharedMemoryPerBlock, deviceId));
+        constexpr int BLOCK_DIM = 128;
+        int smem = (BLOCK_DIM - 1 + std::max(kernelWidth, kernelHeight)) * input.dtype().size();
+        if (smem > maxSharedMem) {
+            throw roccv::Exception("Invalid kernel size = " + std::to_string(kernelWidth) + ", " +
+                                       std::to_string(kernelHeight) + " requires " + std::to_string(smem) +
+                                       " bytes for shared memory but device only supports " +
+                                       std::to_string(maxSharedMem) + " bytes per block.",
+                                   eStatusType::INVALID_VALUE);
+        }
+    }
+
     std::lock_guard<std::mutex> lock(m_bufferMutex);
     HIP_VALIDATE_NO_ERRORS(hipEventSynchronize(m_completionEvent));
 

--- a/tests/roccv/cpp/src/tests/operators/test_op_gaussian.cpp
+++ b/tests/roccv/cpp/src/tests/operators/test_op_gaussian.cpp
@@ -306,7 +306,8 @@ void TestNegativeGaussian() {
     }
 
     {
-        // Test bad kernel size (exceeding max) and sigma X
+        // Test bad kernel / sigma
+        // Kernel exceeds max
         EXPECT_EXCEPTION(
             op(nullptr, validGPUTensor, validGPUTensor, 3, 5, 1, 1, BORDER_TYPE_CONSTANT, eDeviceType::GPU),
             eStatusType::INVALID_VALUE);
@@ -327,6 +328,20 @@ void TestNegativeGaussian() {
         EXPECT_EXCEPTION(
             op(nullptr, validGPUTensor, validGPUTensor, 3, 3, -0.1, 1, BORDER_TYPE_CONSTANT, eDeviceType::GPU),
             eStatusType::INVALID_VALUE);
+        // Too large for LDS
+        hipError_t hipErr;
+        int deviceId;
+        hipErr = hipGetDevice(&deviceId);
+        if (hipErr != hipSuccess) return;  // not testing for hip err
+        int maxSharedMem;
+        hipErr = hipDeviceGetAttribute(&maxSharedMem, hipDeviceAttributeMaxSharedMemoryPerBlock, deviceId);
+        if (hipErr != hipSuccess) return;  // not testing for hip err
+        constexpr int BLOCK_DIM = 128;
+        int maxKernelDim = (maxSharedMem / validGPUTensor.dtype().size()) - BLOCK_DIM + 1;
+        Gaussian op(maxKernelDim + 2, 1);
+        EXPECT_EXCEPTION(op(nullptr, validGPUTensor, validGPUTensor, (maxKernelDim + 1 | 1), 1, 1, 1,
+                            BORDER_TYPE_CONSTANT, eDeviceType::GPU),
+                         eStatusType::INVALID_VALUE);
     }
 }
 


### PR DESCRIPTION
## Motivation
When using the separated filter2D kernels, Gaussian operator requests shared memory based on the kernel size parameters. Previously there was no validation that this requested size actually fit in the LDS, and so could silently fail. 

## Technical Details
Added a validation check in `Gaussian::operator()` when the device is GPU and using the separated kernels.

## Test Plan
Added a negative test to trigger this validation in the Gaussian ctest.

## Test Result
All ctests pass.