### PR TITLE
[Bugfix]: Added validation on size of Filter2D tensors to fit in int32 wrappers

### DIFF
--- a/src/op_average_blur.cpp
+++ b/src/op_average_blur.cpp
@@ -105,6 +105,9 @@ void AverageBlur::operator()(hipStream_t stream, const Tensor& input, Tensor& ou
     CHECK_TENSOR_COMPARISON(input.device() == output.device());
     CHECK_TENSOR_COMPARISON(input.shape() == output.shape());
 
+    CHECK_TENSOR_INT32_INDEXING(input);
+    CHECK_TENSOR_INT32_INDEXING(output);
+
     // Validate kernel size
     if (!(kernelWidth > 0 && kernelWidth % 2 == 1 && kernelWidth <= m_maxKernelWidth && kernelHeight > 0 &&
           kernelHeight % 2 == 1 && kernelHeight <= m_maxKernelHeight)) {

--- a/src/op_gaussian.cpp
+++ b/src/op_gaussian.cpp
@@ -104,6 +104,9 @@ void Gaussian::operator()(hipStream_t stream, const Tensor& input, Tensor& outpu
     CHECK_TENSOR_COMPARISON(input.device() == output.device());
     CHECK_TENSOR_COMPARISON(input.shape() == output.shape());
 
+    CHECK_TENSOR_INT32_INDEXING(input);
+    CHECK_TENSOR_INT32_INDEXING(output);
+
     // Validate sigma
     if (sigmaX <= 0) {
         throw roccv::Exception("Invalid sigmaX = " + std::to_string(sigmaX) + ": Ensure that sigmaX is positive.",

--- a/src/op_laplacian.cpp
+++ b/src/op_laplacian.cpp
@@ -80,6 +80,9 @@ void Laplacian::operator()(hipStream_t stream, const roccv::Tensor& input, const
     CHECK_TENSOR_COMPARISON(input.device() == output.device());
     CHECK_TENSOR_COMPARISON(input.shape() == output.shape());
 
+    CHECK_TENSOR_INT32_INDEXING(input);
+    CHECK_TENSOR_INT32_INDEXING(output);
+
     // Validate ksize
     if (!(ksize == 1 || ksize == 3)) {
         throw roccv::Exception("Invalid ksize = " + std::to_string(ksize) + ": Must be 1 or 3.",


### PR DESCRIPTION
## Motivation
The Filter2D operators (AverageBlur, Gaussian, and Laplacian) were missing the validation on the size of their input/output tensors, which is required because by default they use the ImageWrapper with int32_t indexing/stride calculations (following PR #167).

## Technical Details
Added `CHECK_TENSOR_INT32_INDEXING` on input and output tensors in all three operators.

## Test Plan
rocCV CTests.
Note these don't have negative tests yet, see #186.

## Test Result
All CTests pass.